### PR TITLE
Replace InternalConfig implicit dependencies with explicit interfaces.

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -4,6 +4,7 @@ import com.qonversion.android.sdk.dto.CacheLifetime
 import com.qonversion.android.sdk.dto.Environment
 import com.qonversion.android.sdk.dto.LogLevel
 import com.qonversion.android.sdk.dto.UserProperty
+import com.qonversion.android.sdk.internal.InternalConfig
 import com.qonversion.android.sdk.internal.QonversionInternal
 import com.qonversion.android.sdk.internal.exception.ErrorCode
 import com.qonversion.android.sdk.internal.exception.QonversionException
@@ -35,7 +36,7 @@ interface Qonversion {
          */
         @JvmStatic
         fun initialize(config: QonversionConfig): Qonversion {
-            return QonversionInternal(config).also {
+            return QonversionInternal(config, InternalConfig).also {
                 backingInstance = it
             }
         }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/InternalConfig.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/InternalConfig.kt
@@ -8,24 +8,27 @@ import com.qonversion.android.sdk.dto.Environment
 import com.qonversion.android.sdk.dto.LogLevel
 import com.qonversion.android.sdk.internal.cache.CacheLifetimeConfig
 
-import com.qonversion.android.sdk.internal.networkLayer.NetworkConfigHolder
+import com.qonversion.android.sdk.internal.provider.NetworkConfigHolder
 import com.qonversion.android.sdk.internal.provider.CacheLifetimeConfigProvider
 import com.qonversion.android.sdk.internal.provider.EnvironmentProvider
 import com.qonversion.android.sdk.internal.provider.LoggerConfigProvider
+import com.qonversion.android.sdk.internal.provider.PrimaryConfigProvider
+import com.qonversion.android.sdk.internal.provider.UidProvider
 
 internal object InternalConfig :
     EnvironmentProvider,
     LoggerConfigProvider,
     CacheLifetimeConfigProvider,
-    NetworkConfigHolder {
-    var uid: String = ""
+    NetworkConfigHolder,
+    PrimaryConfigProvider,
+    UidProvider {
+    override var uid: String = ""
 
-    lateinit var primaryConfig: PrimaryConfig
+    override lateinit var primaryConfig: PrimaryConfig
     lateinit var storeConfig: StoreConfig
     lateinit var networkConfig: NetworkConfig
     lateinit var loggerConfig: LoggerConfig
-
-    override var cacheLifetimeConfig = CacheLifetimeConfig()
+    override lateinit var cacheLifetimeConfig: CacheLifetimeConfig
 
     override val environment
         get() = primaryConfig.environment

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -1,6 +1,5 @@
 package com.qonversion.android.sdk.internal
 
-import androidx.annotation.VisibleForTesting
 import com.qonversion.android.sdk.Qonversion
 import com.qonversion.android.sdk.QonversionConfig
 import com.qonversion.android.sdk.dto.CacheLifetime

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -1,5 +1,6 @@
 package com.qonversion.android.sdk.internal
 
+import androidx.annotation.VisibleForTesting
 import com.qonversion.android.sdk.Qonversion
 import com.qonversion.android.sdk.QonversionConfig
 import com.qonversion.android.sdk.dto.CacheLifetime
@@ -9,35 +10,38 @@ import com.qonversion.android.sdk.dto.UserProperty
 import com.qonversion.android.sdk.internal.cache.CacheLifetimeConfig
 import com.qonversion.android.sdk.internal.cache.InternalCacheLifetime
 
-internal class QonversionInternal(config: QonversionConfig) : Qonversion {
+internal class QonversionInternal(
+    config: QonversionConfig,
+    private val internalConfig: InternalConfig
+) : Qonversion {
 
     init {
-        InternalConfig.primaryConfig = config.primaryConfig
-        InternalConfig.storeConfig = config.storeConfig
-        InternalConfig.networkConfig = config.networkConfig
+        internalConfig.primaryConfig = config.primaryConfig
+        internalConfig.storeConfig = config.storeConfig
+        internalConfig.networkConfig = config.networkConfig
 
         val internalBackgroundCacheLifetime = InternalCacheLifetime.from(config.cacheLifetime)
-        InternalConfig.cacheLifetimeConfig = CacheLifetimeConfig(internalBackgroundCacheLifetime)
+        internalConfig.cacheLifetimeConfig = CacheLifetimeConfig(internalBackgroundCacheLifetime)
 
-        InternalConfig.loggerConfig = config.loggerConfig
+        internalConfig.loggerConfig = config.loggerConfig
     }
 
     override fun setEnvironment(environment: Environment) {
-        InternalConfig.primaryConfig = InternalConfig.primaryConfig.copy(environment = environment)
+        internalConfig.primaryConfig = internalConfig.primaryConfig.copy(environment = environment)
     }
 
     override fun setLogLevel(logLevel: LogLevel) {
-        InternalConfig.loggerConfig = InternalConfig.loggerConfig.copy(logLevel = logLevel)
+        internalConfig.loggerConfig = internalConfig.loggerConfig.copy(logLevel = logLevel)
     }
 
     override fun setLogTag(logTag: String) {
-        InternalConfig.loggerConfig = InternalConfig.loggerConfig.copy(logTag = logTag)
+        internalConfig.loggerConfig = internalConfig.loggerConfig.copy(logTag = logTag)
     }
 
     override fun setCacheLifetime(cacheLifetime: CacheLifetime) {
         val internalCacheLifetime = InternalCacheLifetime.from(cacheLifetime)
-        InternalConfig.cacheLifetimeConfig =
-            InternalConfig.cacheLifetimeConfig.copy(backgroundCacheLifetime = internalCacheLifetime)
+        internalConfig.cacheLifetimeConfig =
+            internalConfig.cacheLifetimeConfig.copy(backgroundCacheLifetime = internalCacheLifetime)
     }
 
     override fun finish() {

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/networkLayer/apiInteractor/ApiInteractorImpl.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/networkLayer/apiInteractor/ApiInteractorImpl.kt
@@ -1,9 +1,9 @@
 package com.qonversion.android.sdk.internal.networkLayer.apiInteractor
 
-import com.qonversion.android.sdk.internal.InternalConfig
 import com.qonversion.android.sdk.internal.exception.ErrorCode
 import com.qonversion.android.sdk.internal.exception.QonversionException
 import com.qonversion.android.sdk.internal.common.mappers.error.ErrorResponseMapper
+import com.qonversion.android.sdk.internal.provider.NetworkConfigHolder
 import com.qonversion.android.sdk.internal.networkLayer.RetryPolicy
 import com.qonversion.android.sdk.internal.networkLayer.dto.RawResponse
 import com.qonversion.android.sdk.internal.networkLayer.dto.Request
@@ -31,7 +31,7 @@ internal data class RetryConfig(
 internal class ApiInteractorImpl(
     private val networkClient: NetworkClient,
     private val delayCalculator: RetryDelayCalculator,
-    private val config: InternalConfig,
+    private val configHolder: NetworkConfigHolder,
     private val errorMapper: ErrorResponseMapper,
     private val defaultRetryPolicy: RetryPolicy = RetryPolicy.Exponential()
 ) : ApiInteractor {
@@ -49,7 +49,7 @@ internal class ApiInteractorImpl(
         attemptIndex: Int
     ): Response {
         return withContext(Dispatchers.IO) {
-            if (!config.canSendRequests) {
+            if (!configHolder.canSendRequests) {
                 throw QonversionException(ErrorCode.RequestDenied)
             }
 
@@ -73,7 +73,7 @@ internal class ApiInteractorImpl(
                 Response.Success(response.code, data)
             } else {
                 if (response != null && ERROR_CODES_BLOCKING_FURTHER_EXECUTIONS.contains(response.code)) {
-                    config.canSendRequests = false
+                    configHolder.canSendRequests = false
                     return@withContext getErrorResponse(response, executionException)
                 }
 

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/networkLayer/headerBuilder/HeaderBuilderImpl.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/networkLayer/headerBuilder/HeaderBuilderImpl.kt
@@ -1,32 +1,39 @@
 package com.qonversion.android.sdk.internal.networkLayer.headerBuilder
 
 import android.os.Build
-import com.qonversion.android.sdk.internal.InternalConfig
 import com.qonversion.android.sdk.internal.common.DEBUG_MODE_PREFIX
 import com.qonversion.android.sdk.internal.common.PLATFORM
 import com.qonversion.android.sdk.internal.common.StorageConstants
 import com.qonversion.android.sdk.internal.common.localStorage.LocalStorage
 import com.qonversion.android.sdk.internal.networkLayer.ApiHeader
+import com.qonversion.android.sdk.internal.provider.EnvironmentProvider
+import com.qonversion.android.sdk.internal.provider.PrimaryConfigProvider
+import com.qonversion.android.sdk.internal.provider.UidProvider
 import java.util.Locale
 
 internal class HeaderBuilderImpl(
     private val localStorage: LocalStorage,
     private val locale: Locale,
-    private val config: InternalConfig
+    private val primaryConfigProvider: PrimaryConfigProvider,
+    private val environmentProvider: EnvironmentProvider,
+    private val uidProvider: UidProvider
 ) : HeaderBuilder {
     private val source by lazy {
         localStorage.getString(StorageConstants.SourceKey.key, PLATFORM) ?: PLATFORM
     }
     private val sourceVersion by lazy {
-        localStorage.getString(StorageConstants.VersionKey.key, config.primaryConfig.sdkVersion)
-            ?: config.primaryConfig.sdkVersion
+        localStorage.getString(
+            StorageConstants.VersionKey.key,
+            primaryConfigProvider.primaryConfig.sdkVersion
+        )
+            ?: primaryConfigProvider.primaryConfig.sdkVersion
     }
 
     override fun buildCommonHeaders(): Map<String, String> {
         val locale = locale.language
         val projectKey =
-            if (config.isSandbox) "$DEBUG_MODE_PREFIX${config.primaryConfig.projectKey}"
-            else config.primaryConfig.projectKey
+            if (environmentProvider.isSandbox) "$DEBUG_MODE_PREFIX${primaryConfigProvider.primaryConfig.projectKey}"
+            else primaryConfigProvider.primaryConfig.projectKey
         val bearer = "Bearer $projectKey"
 
         return mapOf(
@@ -36,7 +43,7 @@ internal class HeaderBuilderImpl(
             ApiHeader.SourceVersion.key to sourceVersion,
             ApiHeader.Platform.key to PLATFORM,
             ApiHeader.PlatformVersion.key to Build.VERSION.RELEASE,
-            ApiHeader.UserID.key to config.uid
+            ApiHeader.UserID.key to uidProvider.uid
         )
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/networkLayer/requestConfigurator/RequestConfiguratorImpl.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/networkLayer/requestConfigurator/RequestConfiguratorImpl.kt
@@ -1,12 +1,15 @@
 package com.qonversion.android.sdk.internal.networkLayer.requestConfigurator
 
-import com.qonversion.android.sdk.internal.InternalConfig
 import com.qonversion.android.sdk.internal.networkLayer.dto.Request
 import com.qonversion.android.sdk.internal.networkLayer.headerBuilder.HeaderBuilder
+import com.qonversion.android.sdk.internal.provider.PrimaryConfigProvider
+import com.qonversion.android.sdk.internal.provider.UidProvider
 
 internal class RequestConfiguratorImpl(
     private val headerBuilder: HeaderBuilder,
-    private val baseUrl: String
+    private val baseUrl: String,
+    private val primaryConfigProvider: PrimaryConfigProvider,
+    private val uidProvider: UidProvider
 ) : RequestConfigurator {
 
     override fun configureUserRequest(id: String): Request {
@@ -26,8 +29,8 @@ internal class RequestConfiguratorImpl(
         val headers = headerBuilder.buildCommonHeaders()
         // TODO delete access_token and q_uid from the body after migrating API to v2
         val body = mapOf(
-            "access_token" to InternalConfig.primaryConfig.projectKey,
-            "q_uid" to InternalConfig.uid,
+            "access_token" to primaryConfigProvider.primaryConfig.projectKey,
+            "q_uid" to uidProvider.uid,
             "properties" to properties
         )
 

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/provider/NetworkConfigHolder.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/provider/NetworkConfigHolder.kt
@@ -1,4 +1,4 @@
-package com.qonversion.android.sdk.internal.networkLayer
+package com.qonversion.android.sdk.internal.provider
 
 internal interface NetworkConfigHolder {
 

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/provider/PrimaryConfigProvider.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/provider/PrimaryConfigProvider.kt
@@ -1,0 +1,8 @@
+package com.qonversion.android.sdk.internal.provider
+
+import com.qonversion.android.sdk.config.PrimaryConfig
+
+internal interface PrimaryConfigProvider {
+
+    val primaryConfig: PrimaryConfig
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/provider/UidProvider.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/provider/UidProvider.kt
@@ -1,0 +1,7 @@
+package com.qonversion.android.sdk.internal.provider
+
+// todo should be removed when UserInfoProvider will be implemented
+internal interface UidProvider {
+
+    val uid: String
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/InternalConfigTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/InternalConfigTest.kt
@@ -7,8 +7,7 @@ import com.qonversion.android.sdk.dto.Environment
 import com.qonversion.android.sdk.dto.LaunchMode
 import com.qonversion.android.sdk.dto.LogLevel
 import com.qonversion.android.sdk.internal.cache.CacheLifetimeConfig
-import com.qonversion.android.sdk.internal.cache.InternalCacheLifetime
-import com.qonversion.android.sdk.internal.networkLayer.NetworkConfigHolder
+import com.qonversion.android.sdk.internal.provider.NetworkConfigHolder
 import com.qonversion.android.sdk.internal.provider.CacheLifetimeConfigProvider
 import com.qonversion.android.sdk.internal.provider.EnvironmentProvider
 import com.qonversion.android.sdk.internal.provider.LoggerConfigProvider
@@ -105,22 +104,6 @@ internal class InternalConfigTest {
     @Nested
     inner class CacheLifetimeConfigProviderTest {
         private val mockCacheLifetimeLoggerConfig = mockk<CacheLifetimeConfig>()
-
-        @Test
-        fun `get default cache lifetime config`() {
-            // given
-            val cacheLifetimeConfigProvider: CacheLifetimeConfigProvider = InternalConfig
-            val expectedInternalCacheLifetimeConfig =
-                CacheLifetimeConfig(InternalCacheLifetime.ThreeDays, InternalCacheLifetime.FiveMin)
-
-            // when
-            val cacheLifetimeConfig = cacheLifetimeConfigProvider.cacheLifetimeConfig
-
-            // then
-            assertThat(cacheLifetimeConfig).isEqualToComparingFieldByField(
-                expectedInternalCacheLifetimeConfig
-            )
-        }
 
         @Test
         fun `get cache lifetime config`() {

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/networkLayer/apiInteractor/ApiInteractorTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/networkLayer/apiInteractor/ApiInteractorTest.kt
@@ -1,10 +1,10 @@
 package com.qonversion.android.sdk.internal.networkLayer.apiInteractor
 
 import com.qonversion.android.sdk.coAssertThatQonversionExceptionThrown
-import com.qonversion.android.sdk.internal.InternalConfig
 import com.qonversion.android.sdk.internal.exception.ErrorCode
 import com.qonversion.android.sdk.internal.exception.QonversionException
 import com.qonversion.android.sdk.internal.common.mappers.error.ErrorResponseMapper
+import com.qonversion.android.sdk.internal.provider.NetworkConfigHolder
 import com.qonversion.android.sdk.internal.networkLayer.RetryPolicy
 import com.qonversion.android.sdk.internal.networkLayer.dto.RawResponse
 import com.qonversion.android.sdk.internal.networkLayer.dto.Request
@@ -32,7 +32,7 @@ internal class ApiInteractorTest {
     private lateinit var interactor: ApiInteractorImpl
     private val networkClient = mockk<NetworkClient>()
     private val delayCalculator = mockk<RetryDelayCalculator>()
-    private val config = mockk<InternalConfig>()
+    private val configHolder = mockk<NetworkConfigHolder>()
     private val errorMapper = mockk<ErrorResponseMapper>()
     private val request = Request.get("smth", emptyMap())
 
@@ -50,14 +50,14 @@ internal class ApiInteractorTest {
 
     @BeforeEach
     fun setUp() {
-        interactor = ApiInteractorImpl(networkClient, delayCalculator, config, errorMapper)
+        interactor = ApiInteractorImpl(networkClient, delayCalculator, configHolder, errorMapper)
 
         val minDelaySlot = slot<Long>()
         every {
             delayCalculator.countDelay(capture(minDelaySlot), any())
         } answers { minDelaySlot.captured + 1 }
         every {
-            config.canSendRequests
+            configHolder.canSendRequests
         } returns true
         coEvery {
             networkClient.execute(request)
@@ -282,7 +282,7 @@ internal class ApiInteractorTest {
     fun `execute request with deny option on`() {
         // given
         every {
-            config.canSendRequests
+            configHolder.canSendRequests
         } returns false
 
         // when and then
@@ -482,7 +482,7 @@ internal class ApiInteractorTest {
         } returns parsedErrorResponse
         val setValue = slot<Boolean>()
         every {
-            config.canSendRequests = capture(setValue)
+            configHolder.canSendRequests = capture(setValue)
         } just runs
 
         // when

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/networkLayer/headerBuilder/HeaderBuilderImplTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/networkLayer/headerBuilder/HeaderBuilderImplTest.kt
@@ -1,12 +1,14 @@
 package com.qonversion.android.sdk.internal.networkLayer.headerBuilder
 
 import android.os.Build
-import com.qonversion.android.sdk.internal.InternalConfig
 import com.qonversion.android.sdk.internal.common.DEBUG_MODE_PREFIX
 import com.qonversion.android.sdk.internal.common.PLATFORM
 import com.qonversion.android.sdk.internal.common.StorageConstants
 import com.qonversion.android.sdk.internal.common.localStorage.LocalStorage
 import com.qonversion.android.sdk.internal.networkLayer.ApiHeader
+import com.qonversion.android.sdk.internal.provider.EnvironmentProvider
+import com.qonversion.android.sdk.internal.provider.PrimaryConfigProvider
+import com.qonversion.android.sdk.internal.provider.UidProvider
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -19,7 +21,9 @@ internal class HeaderBuilderTest {
     private lateinit var headerBuilder: HeaderBuilderImpl
     private val localStorage = mockk<LocalStorage>()
     private val locale = mockk<Locale>()
-    private val config = mockk<InternalConfig>()
+    private val primaryConfigProvider = mockk<PrimaryConfigProvider>()
+    private val environmentProvider = mockk<EnvironmentProvider>()
+    private val uidProvider = mockk<UidProvider>()
 
     private val testSourceKey = "test source key"
     private val testVersionKey = "test version key"
@@ -41,7 +45,14 @@ internal class HeaderBuilderTest {
 
     @BeforeEach
     fun setUp() {
-        headerBuilder = HeaderBuilderImpl(localStorage, locale, config)
+        headerBuilder = HeaderBuilderImpl(
+            localStorage,
+            locale,
+            primaryConfigProvider,
+            environmentProvider,
+            uidProvider
+        )
+
         every {
             localStorage.getString(StorageConstants.SourceKey.key, any())
         } returns testSourceKey
@@ -49,10 +60,10 @@ internal class HeaderBuilderTest {
             localStorage.getString(StorageConstants.VersionKey.key, any())
         } returns testVersionKey
         every { locale.language } returns testLanguage
-        every { config.isSandbox } returns false
-        every { config.uid } returns testUid
-        every { config.primaryConfig.sdkVersion } returns testSdkVersion
-        every { config.primaryConfig.projectKey } returns testProjectKey
+        every { environmentProvider.isSandbox } returns false
+        every { uidProvider.uid } returns testUid
+        every { primaryConfigProvider.primaryConfig.sdkVersion } returns testSdkVersion
+        every { primaryConfigProvider.primaryConfig.projectKey } returns testProjectKey
     }
 
     @Test
@@ -91,7 +102,7 @@ internal class HeaderBuilderTest {
     fun `debug mode`() {
         // given
         every {
-            config.isSandbox
+            environmentProvider.isSandbox
         } returns true
 
         val expectedResult = defaultExpectedHeaders +


### PR DESCRIPTION
There is a new UidProvider interface in this pull request which will be used till the normal UserDataProvider implementation. Marked with //todo to remove after that.