### PR TITLE
UserIdGenerator implementation.

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/user/UserServiceImpl.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/user/UserServiceImpl.kt
@@ -108,6 +108,7 @@ internal class UserServiceImpl(
         return mapper.fromMap(response.mapData) ?: throw QonversionException(ErrorCode.Mapping)
     }
 
+    // todo replace with UserIdGenerator
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun generateRandomUserID(): String {
         val uuid = UUID.randomUUID().toString().replace(Regex("-"), "")

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/user/generator/UserIdGenerator.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/user/generator/UserIdGenerator.kt
@@ -1,0 +1,6 @@
+package com.qonversion.android.sdk.internal.user.generator
+
+interface UserIdGenerator {
+
+    fun generateUserId(): String
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/user/generator/UserIdGeneratorImpl.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/user/generator/UserIdGeneratorImpl.kt
@@ -1,0 +1,15 @@
+package com.qonversion.android.sdk.internal.user.generator
+
+import java.util.UUID
+
+private const val USER_ID_PREFIX = "QON"
+private const val USER_ID_SEPARATOR = "_"
+
+class UserIdGeneratorImpl : UserIdGenerator {
+
+    override fun generateUserId(): String {
+        val uuid = UUID.randomUUID().toString().replace(Regex("-"), "")
+
+        return "${USER_ID_PREFIX}${USER_ID_SEPARATOR}$uuid"
+    }
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/user/UserServiceTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/user/UserServiceTest.kt
@@ -437,25 +437,4 @@ internal class UserServiceTest {
             verify { mockMapper.fromMap(responseData) }
         }
     }
-
-    @Nested
-    inner class GenerateRandomUserIdTest {
-
-        @Test
-        fun `format check`() {
-            val ids = (1..10).map {
-                // given
-                val regex = Regex("""^QON_[a-zA-Z\d]{32}$""")
-
-                // when
-                val id = userService.generateRandomUserID()
-
-                // then
-                assertThat(regex.matches(id)).isTrue
-                id
-            }
-            // check for duplicates
-            assertThat(ids.size).isEqualTo(ids.toSet().size)
-        }
-    }
 }

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/user/generator/UserIdGeneratorTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/user/generator/UserIdGeneratorTest.kt
@@ -1,0 +1,26 @@
+package com.qonversion.android.sdk.internal.user.generator
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class UserIdGeneratorTest {
+
+    private val generator: UserIdGenerator = UserIdGeneratorImpl()
+
+    @Test
+    fun `format check`() {
+        val ids = (1..10).map {
+            // given
+            val regex = Regex("""^QON_[a-zA-Z\d]{32}$""")
+
+            // when
+            val id = generator.generateUserId()
+
+            // then
+            assertThat(regex.matches(id)).isTrue
+            id
+        }
+        // check for duplicates
+        assertThat(ids.size).isEqualTo(ids.toSet().size)
+    }
+}


### PR DESCRIPTION
I'm not replacing the current `generateRandomUserID` method with the new generator as we will also remove the method which uses that, so it would be double work for now.