### PR TITLE
fix: improve screen events reliability - flush on close, handle 2xx/4xx, add event_uid

### DIFF
--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/networkLayer/networkClient/NetworkClientImpl.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/networkLayer/networkClient/NetworkClientImpl.kt
@@ -124,7 +124,17 @@ internal class NetworkClientImpl(
             emptyMap<Any, Any>()
         } else {
             val responsePayload = read(stream)
-            serializer.deserialize(responsePayload)
+            if (responsePayload.isEmpty()) {
+                emptyMap<Any, Any>()
+            } else if (code.isSuccessHttpCode) {
+                try {
+                    serializer.deserialize(responsePayload)
+                } catch (_: Exception) {
+                    emptyMap<Any, Any>()
+                }
+            } else {
+                serializer.deserialize(responsePayload)
+            }
         }
         return RawResponse(code, response)
     }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/service/ScreenEventsServiceImpl.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/service/ScreenEventsServiceImpl.kt
@@ -11,6 +11,7 @@ import io.qonversion.nocodes.internal.logger.Logger
 import io.qonversion.nocodes.internal.networkLayer.apiInteractor.ApiInteractor
 import io.qonversion.nocodes.internal.networkLayer.requestConfigurator.RequestConfigurator
 import io.qonversion.nocodes.internal.networkLayer.dto.Response
+import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -33,12 +34,20 @@ internal class ScreenEventsServiceImpl(
     private var cachedUserId: String? = null
 
     override fun track(event: ScreenEvent) {
+        val enrichedEvent = if (event.data.containsKey("event_uid")) {
+            event
+        } else {
+            ScreenEvent(data = event.data.toMutableMap().apply {
+                put("event_uid", UUID.randomUUID().toString())
+            })
+        }
+
         var shouldFlush = false
         synchronized(lock) {
-            buffer.add(event)
+            buffer.add(enrichedEvent)
             shouldFlush = buffer.size >= BATCH_SIZE
         }
-        logger.verbose("ScreenEventsService -> tracked event: ${event.data["type"] ?: "unknown"}")
+        logger.verbose("ScreenEventsService -> tracked event: ${enrichedEvent.data["type"] ?: "unknown"}")
         if (shouldFlush) {
             flush()
         }
@@ -118,11 +127,12 @@ internal class ScreenEventsServiceImpl(
             val eventMaps = eventsToSend.map { it.toMap() }
             val body = mapOf<String, Any?>("events" to eventMaps)
             val request = requestConfigurator.configureScreenEventsRequest(uid, body)
+            logger.verbose("ScreenEventsService -> sending ${eventsToSend.size} events to ${request.url}")
             val response = apiInteractor.execute(request)
 
             if (response is Response.Error) {
-                logger.error("ScreenEventsService -> failed to send events: ${response.message}")
-                if (reBufferOnFailure) {
+                logger.error("ScreenEventsService -> failed to send events (code=${response.code}): ${response.message}")
+                if (reBufferOnFailure && response.code >= 500) {
                     reBuffer(eventsToSend)
                 }
             } else {

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/service/ScreenEventsServiceImpl.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/service/ScreenEventsServiceImpl.kt
@@ -11,6 +11,7 @@ import io.qonversion.nocodes.internal.logger.Logger
 import io.qonversion.nocodes.internal.networkLayer.apiInteractor.ApiInteractor
 import io.qonversion.nocodes.internal.networkLayer.requestConfigurator.RequestConfigurator
 import io.qonversion.nocodes.internal.networkLayer.dto.Response
+import io.qonversion.nocodes.internal.networkLayer.utils.isInternalServerErrorHttpCode
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -132,7 +133,7 @@ internal class ScreenEventsServiceImpl(
 
             if (response is Response.Error) {
                 logger.error("ScreenEventsService -> failed to send events (code=${response.code}): ${response.message}")
-                if (reBufferOnFailure && response.code >= 500) {
+                if (reBufferOnFailure && response.code.isInternalServerErrorHttpCode) {
                     reBuffer(eventsToSend)
                 }
             } else {

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -209,6 +209,7 @@ internal class ScreenPresenter(
             "happened_at" to currentUnixTimestamp()
         ))
         screenEventsService.track(event)
+        screenEventsService.flush()
     }
 
     private fun currentUnixTimestamp(): Long =


### PR DESCRIPTION
## Summary
- **Fix 2a**: Handle non-JSON 2xx responses gracefully (try-catch around deserialization for success codes)
- **Fix 2b**: Only rebuffer events on 5xx server errors, not 4xx client errors (prevents infinite retry on permanent failures)
- **Fix 1**: Flush remaining events on screen close (`onScreenClosed()` now calls `flush()` after tracking screen_closed)
- **Fix 3**: Generate UUID v4 `event_uid` per event in `track()` for deduplication

## Context
Part of Screen Events Reliability initiative (5 repos). Ships with next SDK release (Phase B).

## Files changed
- `NetworkClientImpl.kt` — wrap deserialize in try-catch for 2xx
- `ScreenEventsServiceImpl.kt` — 4xx no-rebuffer, event_uid generation
- `ScreenPresenter.kt` — flush on screen close

## Test plan
- [ ] TC-1.1: Events flushed on screen close (short session < 10 events)
- [ ] TC-1.3: Flush after batch already sent (12+ events then close)
- [ ] TC-2.2: No retry loop on 202
- [ ] TC-2.5: 4xx errors not rebuffered
- [ ] TC-2.6: 5xx errors still rebuffered
- [ ] TC-3.2: event_uid present in POST body (UUID v4 format)