### PR TITLE
Update sample app to use QDeferredPurchasesListener

### DIFF
--- a/sample/src/main/java/io/qonversion/sample/EntitlementsFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/EntitlementsFragment.kt
@@ -8,9 +8,10 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.qonversion.android.sdk.Qonversion
+import com.qonversion.android.sdk.dto.QPurchaseResult
 import com.qonversion.android.sdk.dto.QonversionError
 import com.qonversion.android.sdk.dto.entitlements.QEntitlement
-import com.qonversion.android.sdk.listeners.QEntitlementsUpdateListener
+import com.qonversion.android.sdk.listeners.QDeferredPurchasesListener
 import com.qonversion.android.sdk.listeners.QonversionEntitlementsCallback
 import io.qonversion.sample.databinding.FragmentEntitlementsBinding
 
@@ -47,7 +48,7 @@ class EntitlementsFragment : Fragment() {
         }
 
         binding.buttonSetListener.setOnClickListener {
-            setEntitlementsListener()
+            setDeferredPurchasesListener()
         }
 
         binding.buttonRestore.setOnClickListener {
@@ -83,19 +84,25 @@ class EntitlementsFragment : Fragment() {
         })
     }
 
-    private fun setEntitlementsListener() {
-        Qonversion.shared.setEntitlementsUpdateListener(object : QEntitlementsUpdateListener {
-            override fun onEntitlementsUpdated(entitlements: Map<String, QEntitlement>) {
+    private fun setDeferredPurchasesListener() {
+        Qonversion.shared.setDeferredPurchasesListener(object : QDeferredPurchasesListener {
+            override fun deferredPurchaseCompleted(purchaseResult: QPurchaseResult) {
                 _binding?.let {
-                    displayEntitlements(entitlements)
+                    displayEntitlements(purchaseResult.entitlements)
                 }
-                Toast.makeText(context, getString(R.string.entitlements_updated_via_listener), Toast.LENGTH_SHORT).show()
+                val messageRes = when {
+                    purchaseResult.isSuccessful -> R.string.deferred_purchase_completed
+                    purchaseResult.isPending -> R.string.purchase_pending
+                    purchaseResult.isCanceledByUser -> R.string.purchase_canceled
+                    else -> R.string.purchase_failed
+                }
+                Toast.makeText(context, getString(messageRes), Toast.LENGTH_SHORT).show()
             }
         })
         isListenerSet = true
         binding.buttonSetListener.text = getString(R.string.listener_set)
         binding.buttonSetListener.isEnabled = false
-        Toast.makeText(context, getString(R.string.entitlements_listener_set), Toast.LENGTH_SHORT).show()
+        Toast.makeText(context, getString(R.string.deferred_purchases_listener_set), Toast.LENGTH_SHORT).show()
     }
 
     private fun restore() {

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     
     <!-- Entitlements -->
     <string name="load_entitlements">Load Entitlements</string>
-    <string name="set_entitlements_listener">Set Entitlements Update Listener</string>
+    <string name="set_entitlements_listener">Set Deferred Purchases Listener</string>
     <string name="listener_set">Listener Set ✓</string>
     <string name="restore">Restore</string>
     <string name="sync_purchases">Sync Purchases</string>
@@ -68,8 +68,8 @@
     <string name="tap_button_to_load_entitlements">Tap the button above to load your entitlements</string>
     <string name="no_entitlements_found">No entitlements found</string>
     <string name="error_loading_entitlements">Error loading entitlements</string>
-    <string name="entitlements_listener_set">Entitlements update listener set</string>
-    <string name="entitlements_updated_via_listener">Entitlements updated via listener</string>
+    <string name="deferred_purchases_listener_set">Deferred purchases listener set</string>
+    <string name="deferred_purchase_completed">Deferred purchase completed</string>
     <string name="purchases_restored">Purchases restored successfully</string>
     <string name="purchases_synced">Purchases synced</string>
     <string name="active">Active</string>


### PR DESCRIPTION
## Summary
- Replace the deprecated `QEntitlementsUpdateListener` in `EntitlementsFragment` with the new `QDeferredPurchasesListener` introduced in SDK 9.3.0.
- Display entitlements from the `QPurchaseResult` and pick a toast message based on the result status (success, pending, canceled, error).
- Rename related strings (`set_entitlements_listener`, `entitlements_listener_set`, `entitlements_updated_via_listener`) to match the new listener.

## Test plan
- [ ] Build the sample app and open the Entitlements screen.
- [ ] Tap "Set Deferred Purchases Listener" and confirm the toast appears and the button switches to the "Listener Set" state.
- [ ] Trigger a deferred purchase (e.g., a pending Google Play transaction) and verify the entitlements list updates and the corresponding status toast is shown.

Generated with Claude Code