### PR TITLE
fix: SUP3-118 defer consumePurchases when product types unknown

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QProductCenterManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QProductCenterManager.kt
@@ -416,7 +416,10 @@ internal class QProductCenterManager internal constructor(
                 return@queryPurchases
             }
 
-            billingService.consumePurchases(purchases, getNonConsumableStoreIds())
+            val nonConsumableIds = getNonConsumableStoreIds()
+            if (nonConsumableIds != null) {
+                billingService.consumePurchases(purchases, nonConsumableIds)
+            }
 
             val purchaseRecords = purchases.map { PurchaseRecord(it) }
             repository.restore(
@@ -427,6 +430,14 @@ internal class QProductCenterManager internal constructor(
                     override fun onSuccess(launchResult: QLaunchResult) {
                         handleUserSwitchingOnRestore(launchResult)
                         updateLaunchResult(launchResult)
+
+                        if (nonConsumableIds == null) {
+                            billingService.consumePurchases(
+                                purchases,
+                                getNonConsumableStoreIds() ?: emptySet()
+                            )
+                        }
+
                         executeRestoreBlocksOnSuccess(launchResult.permissions.toEntitlementsMap())
                     }
 
@@ -793,7 +804,7 @@ internal class QProductCenterManager internal constructor(
                 if (processingPurchases.isNotEmpty()) {
                     handledPurchasesCache.saveHandledPurchases(processingPurchases)
 
-                    billingService.consumePurchases(processingPurchases.toList(), getNonConsumableStoreIds())
+                    billingService.consumePurchases(processingPurchases.toList(), getNonConsumableStoreIds() ?: emptySet())
                     processingPurchases = emptyList()
                 }
 
@@ -1029,7 +1040,10 @@ internal class QProductCenterManager internal constructor(
     }
 
     private fun handlePurchases(purchases: List<Purchase>, requestTrigger: RequestTrigger) {
-        billingService.consumePurchases(purchases, getNonConsumableStoreIds())
+        val nonConsumableIds = getNonConsumableStoreIds()
+        if (nonConsumableIds != null) {
+            billingService.consumePurchases(purchases, nonConsumableIds)
+        }
 
         purchases.forEach { purchase ->
             val purchaseCallback = purchasingCallbacks[purchase.productId]
@@ -1062,6 +1076,13 @@ internal class QProductCenterManager internal constructor(
                 object : QonversionLaunchCallback {
                     override fun onSuccess(launchResult: QLaunchResult) {
                         updateLaunchResult(launchResult)
+
+                        if (nonConsumableIds == null) {
+                            billingService.consumePurchases(
+                                listOf(purchase),
+                                getNonConsumableStoreIds() ?: emptySet()
+                            )
+                        }
 
                         val entitlements = launchResult.permissions.toEntitlementsMap()
 
@@ -1126,11 +1147,11 @@ internal class QProductCenterManager internal constructor(
                 )
     }
 
-    private fun getNonConsumableStoreIds(): Set<String> {
+    private fun getNonConsumableStoreIds(): Set<String>? {
         return launchResultCache.getActualProducts()?.values
             ?.filter { it.isNonConsumable }
             ?.mapNotNull { it.storeId }
-            ?.toSet() ?: emptySet()
+            ?.toSet()
     }
 
     private inline fun forEachPurchaseCallback(purchases: List<Purchase>, action: (QonversionPurchaseCallback) -> Unit) {

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerTest.kt
@@ -225,6 +225,121 @@ internal class QProductCenterManagerTest {
         verify { callback.onError(any()) }
     }
 
+    // SUP3-118: Lifetime purchases consumed when restore() races with launch()
+
+    @Test
+    fun `restore should not call consumePurchases before API when products not loaded`() {
+        // When products are not loaded (fresh install, launch not complete),
+        // consumePurchases should NOT be called before the restore API call.
+        // It should only be called in onSuccess after products arrive from the response.
+        every { mockLaunchResultCacheWrapper.getActualProducts() } returns null
+
+        val purchase = mockPurchase(Purchase.PurchaseState.PURCHASED, false)
+        every { mockBillingService.queryPurchases(any(), captureLambda()) } answers {
+            lambda<(List<Purchase>) -> Unit>().captured.invoke(listOf(purchase))
+        }
+        every { mockBillingService.consumePurchases(any(), any()) } just Runs
+
+        val callbackSlot = slot<QonversionLaunchCallback>()
+        every {
+            mockRepository.restore(any(), any(), any(), capture(callbackSlot))
+        } just Runs
+
+        val callback = mockk<QonversionEntitlementsCallback>(relaxed = true)
+        productCenterManager.restore(RequestTrigger.Restore, callback)
+
+        // consumePurchases should NOT have been called yet (before API response)
+        verify(exactly = 0) { mockBillingService.consumePurchases(any(), any()) }
+
+        // Now simulate API success - products become available
+        val launchResult = QLaunchResult("uid", Date(), offerings = null)
+        every { mockLaunchResultCacheWrapper.getActualProducts() } returns emptyMap()
+        callbackSlot.captured.onSuccess(launchResult)
+
+        // NOW consumePurchases should be called with the fresh data
+        verify(exactly = 1) { mockBillingService.consumePurchases(any(), any()) }
+    }
+
+    @Test
+    fun `restore should call consumePurchases immediately when products are loaded`() {
+        // When products are already loaded (launch completed), current behavior is preserved:
+        // consumePurchases is called immediately before the API call.
+        every { mockLaunchResultCacheWrapper.getActualProducts() } returns emptyMap()
+
+        val purchase = mockPurchase(Purchase.PurchaseState.PURCHASED, false)
+        every { mockBillingService.queryPurchases(any(), captureLambda()) } answers {
+            lambda<(List<Purchase>) -> Unit>().captured.invoke(listOf(purchase))
+        }
+        every { mockBillingService.consumePurchases(any(), any()) } just Runs
+
+        every {
+            mockRepository.restore(any(), any(), any(), any())
+        } just Runs
+
+        val callback = mockk<QonversionEntitlementsCallback>(relaxed = true)
+        productCenterManager.restore(RequestTrigger.Restore, callback)
+
+        // consumePurchases should be called immediately (before API response)
+        verify(exactly = 1) { mockBillingService.consumePurchases(any(), any()) }
+    }
+
+    @Test
+    fun `restore should not call consumePurchases on API error when products not loaded`() {
+        every { mockLaunchResultCacheWrapper.getActualProducts() } returns null
+
+        val purchase = mockPurchase(Purchase.PurchaseState.PURCHASED, false)
+        every { mockBillingService.queryPurchases(any(), captureLambda()) } answers {
+            lambda<(List<Purchase>) -> Unit>().captured.invoke(listOf(purchase))
+        }
+        every { mockBillingService.consumePurchases(any(), any()) } just Runs
+
+        val callbackSlot = slot<QonversionLaunchCallback>()
+        every {
+            mockRepository.restore(any(), any(), any(), capture(callbackSlot))
+        } just Runs
+
+        val callback = mockk<QonversionEntitlementsCallback>(relaxed = true)
+        productCenterManager.restore(RequestTrigger.Restore, callback)
+
+        // Simulate API error
+        callbackSlot.captured.onError(QonversionError(QonversionErrorCode.BackendError))
+
+        // consumePurchases should NEVER be called - purchase stays safe in Google
+        verify(exactly = 0) { mockBillingService.consumePurchases(any(), any()) }
+    }
+
+    @Test
+    fun `handlePurchases should not call consumePurchases before API when products not loaded`() {
+        val spykProductCenterManager = spyk(productCenterManager, recordPrivateCalls = true)
+        spykProductCenterManager.mockPrivateField("processingPurchaseOptions", emptyMap<String, QPurchaseOptions>())
+
+        every { mockLaunchResultCacheWrapper.getActualProducts() } returns null
+
+        val purchase = mockPurchase(Purchase.PurchaseState.PURCHASED, false)
+        every { mockBillingService.queryPurchases(any(), captureLambda()) } answers {
+            lambda<(List<Purchase>) -> Unit>().captured.invoke(listOf(purchase))
+        }
+        every { mockBillingService.consumePurchases(any(), any()) } just Runs
+
+        val callbackSlot = slot<QonversionLaunchCallback>()
+        every {
+            mockRepository.purchase(any(), any(), any(), any(), capture(callbackSlot))
+        } just Runs
+
+        spykProductCenterManager.onAppForeground()
+
+        // consumePurchases should NOT be called before API response
+        verify(exactly = 0) { mockBillingService.consumePurchases(any(), any()) }
+
+        // Simulate purchase API success - products become available
+        val launchResult = QLaunchResult("uid", Date(), offerings = null)
+        every { mockLaunchResultCacheWrapper.getActualProducts() } returns emptyMap()
+        callbackSlot.captured.onSuccess(launchResult)
+
+        // NOW consumePurchases should be called
+        verify(exactly = 1) { mockBillingService.consumePurchases(any(), any()) }
+    }
+
     @Test
     fun `restore with empty uid in response should not trigger user switch`() {
         val currentUid = "user_current"


### PR DESCRIPTION
## Summary

- Fix race condition where `restore()` and `handlePurchases()` consume Lifetime purchases when called before `launch()` completes
- `getNonConsumableStoreIds()` now returns `null` (not `emptySet()`) when products aren't loaded
- Hybrid approach: consume immediately if products known (current behavior preserved), defer to API response `onSuccess` if not
- No consume on API error when products unknown - purchase stays safe in Google Play

## Root Cause

`getNonConsumableStoreIds()` returned `emptySet()` when `launchResultCache.getActualProducts()` was null (fresh install, session cleared by `resetSessionCache()`). This caused `consumePurchases` to treat ALL in-app purchases as consumable, permanently destroying Lifetime purchases via Google's `consume()`.

Two unguarded call sites: `restore()` (line 419) and `handlePurchases()` (line 1032). Compare with `handlePendingPurchases()` which correctly guards with `isLaunchingFinished`, and launch `onSuccess` which correctly runs `updateLaunchResult` before `consumePurchases`.

Introduced by commit 1d4fd73a (DEV-589).

## Evidence

ES logs show restore request arriving 686ms before init for the same client - confirming restore ran before launch completed.

## Linear

SUP3-118

## Test plan

- [ ] New tests: restore with products not loaded defers consumePurchases to onSuccess
- [ ] New tests: restore with products loaded calls consumePurchases immediately (current behavior)
- [ ] New tests: restore with API error and products not loaded never calls consumePurchases
- [ ] New tests: handlePurchases with products not loaded defers consumePurchases to onSuccess
- [ ] Existing restore tests continue to pass
- [ ] Existing handlePendingPurchases tests continue to pass

Generated with [Claude Code](https://claude.com/claude-code)