### PR TITLE
feat(web2app): DEV-847 Android SDK redemption surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,97 @@ Send user-level subscription data to your favorite platforms.
      </a>
 </p>
 
+## Web2App
+
+Web2App lets a user pay on your web checkout and unlock entitlements in the Android app. After payment, Qonversion emails the user a redemption link of the form:
+
+```
+https://screens.qonversion.io/r/{project_uid}/{token}
+```
+
+When the user taps it, Android opens your app via a verified [App Link](https://developer.android.com/training/app-links), and you forward the `Uri` to the SDK, which redeems the token and merges the purchase into the current user.
+
+### 1. Register the App Link
+
+Add an `<intent-filter>` to the activity that should receive the link. It **must** use `https` and `android:autoVerify="true"`, and the path **must** be scoped to your own `{project_uid}` (issued in Qonversion Connect Apps onboarding) so other merchants' apps can't intercept the token:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTask"
+    android:exported="true">
+
+    <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:scheme="https"
+            android:host="screens.qonversion.io"
+            android:pathPattern="/r/YOUR_PROJECT_UID/.*" />
+    </intent-filter>
+</activity>
+```
+
+> Only `https` App Links are supported as an email-link transport. The SDK rejects any other scheme or host before any network call, because any installed app can claim a custom (`qonversion://`) scheme and hijack the token. Use `singleTask` (or `singleTop`) so re-taps arrive in `onNewIntent` instead of relaunching the activity.
+
+### 2. Verify domain ownership (`assetlinks.json`)
+
+`autoVerify` requires Qonversion to host a Digital Asset Links file at `https://screens.qonversion.io/.well-known/assetlinks.json` that pins your app's package name and signing-certificate SHA-256 fingerprint. Provide these to Qonversion during onboarding. You can generate the fingerprint with:
+
+```bash
+keytool -list -v -keystore your-release.keystore -alias your-alias
+```
+
+Until the file lists your app, Android shows a chooser dialog instead of opening your app directly.
+
+### 3. Forward the link to the SDK
+
+In the activity that owns the intent-filter, forward the incoming `Uri` from both `onCreate` and `onNewIntent`:
+
+```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    handleRedemptionIntent(intent)
+}
+
+override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    handleRedemptionIntent(intent)
+}
+
+private fun handleRedemptionIntent(intent: Intent?) {
+    val uri = intent?.data ?: return
+    if (uri.scheme != "https" || uri.pathSegments.firstOrNull() != "r") return
+
+    Qonversion.shared.handleRedemptionLink(uri, object : QonversionRedemptionCallback {
+        override fun onResult(result: RedemptionResult) {
+            // Delivered once on the main thread.
+            when (result) {
+                RedemptionResult.Success -> { /* entitlements merged into current user */ }
+                RedemptionResult.AlreadyConsumed,
+                RedemptionResult.TokenExpired -> { /* offer the reissue dialog */ }
+                RedemptionResult.InvalidToken,
+                RedemptionResult.NetworkError -> { /* show an error / retry */ }
+            }
+        }
+    })
+}
+```
+
+On `RedemptionResult.Success` the SDK transparently calls `identify` with the user id returned by the backend, merging the current anonymous session with the purchasing account. Do **not** log or display the full redemption `Uri` — it carries a single-use token.
+
+### 4. Let users request a new link (`presentReissueUI`)
+
+If the original link is lost or expired, present the built-in dialog so the user can request a new redemption email. No host theme or layout resources are required:
+
+```kotlin
+Qonversion.shared.presentReissueUI(this) { success ->
+    // success == true once the reissue email is sent.
+}
+```
+
 ## Why Qonversion?
 
 * **No headaches with Apple's StoreKit & Google Billing.** Qonversion provides simple methods to handle Apple StoreKit & Google Billing purchase flow.

--- a/README.md
+++ b/README.md
@@ -150,18 +150,19 @@ private fun handleRedemptionIntent(intent: Intent?) {
         override fun onResult(result: RedemptionResult) {
             // Delivered once on the main thread.
             when (result) {
-                RedemptionResult.Success -> { /* entitlements merged into current user */ }
+                RedemptionResult.Success -> { /* entitlement granted — refresh the UI */ }
                 RedemptionResult.AlreadyConsumed,
                 RedemptionResult.TokenExpired -> { /* offer the reissue dialog */ }
-                RedemptionResult.InvalidToken,
-                RedemptionResult.NetworkError -> { /* show an error / retry */ }
+                RedemptionResult.InvalidToken -> { /* show an error */ }
+                RedemptionResult.NetworkError,
+                RedemptionResult.Retryable -> { /* offline / server asked to back off — retry later */ }
             }
         }
     })
 }
 ```
 
-On `RedemptionResult.Success` the SDK transparently calls `identify` with the user id returned by the backend, merging the current anonymous session with the purchasing account. Do **not** log or display the full redemption `Uri` — it carries a single-use token.
+On `RedemptionResult.Success` the entitlement has **already** been granted server-side (grant-first) and attached to the SDK user. The SDK does **not** call `identify`/merge — it only refreshes entitlements, so your next `checkEntitlements` reflects the new state. (You therefore do not need to add an `identify` call yourself.) Do **not** log or display the full redemption `Uri` — it carries a single-use token.
 
 ### 4. Let users request a new link (`presentReissueUI`)
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,10 +24,13 @@ android {
             if (propertiesFile.exists()) {
                 Properties properties = new Properties()
                 properties.load(propertiesFile.newDataInputStream())
-                storeFile file(properties.getProperty('storeFile'))
-                keyAlias properties.getProperty('keyAlias')
-                storePassword properties.getProperty('storePassword')
-                keyPassword properties.getProperty('keyPassword')
+                def storeFilePath = properties.getProperty('storeFile')
+                if (storeFilePath != null && !storeFilePath.isEmpty()) {
+                    storeFile file(storeFilePath)
+                    keyAlias properties.getProperty('keyAlias')
+                    storePassword properties.getProperty('storePassword')
+                    keyPassword properties.getProperty('keyPassword')
+                }
             }
         }
     }
@@ -40,7 +43,9 @@ android {
             signingConfig signingConfigs.release
         }
         debug {
-            signingConfig signingConfigs.release
+            // Use the default debug signing config (auto-generated debug
+            // keystore) when no release keystore is configured locally.
+            signingConfig signingConfigs.debug
             debuggable true
         }
     }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -37,6 +37,17 @@
               The custom scheme remains valid only for in-process host→SDK
               forwarding by the host itself.
             -->
+            <!--
+              MUST be path-scoped to THIS project's uid. Sharing
+              screens.qonversion.io across all merchants means an
+              unscoped `pathPattern="/r/.*"` triggers an Android
+              chooser dialog when another merchant's app is installed,
+              and worse — could redirect a token to the wrong app's
+              SDK. Production merchants set this to their project's uid
+              issued in Qonversion Connect Apps onboarding.
+
+              Local dev uses project `PcnB70vn` (Openchat).
+            -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -44,7 +55,7 @@
                 <data
                     android:scheme="https"
                     android:host="screens.qonversion.io"
-                    android:pathPattern="/r/.*" />
+                    android:pathPattern="/r/PcnB70vn/.*" />
             </intent-filter>
         </activity>
     </application>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -22,6 +22,30 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!--
+              Web2App (DEV-847) — redemption email App Link.
+
+              MUST use https + android:autoVerify="true". Pair this with a
+              hosted /.well-known/assetlinks.json that pins the host package
+              and signing fingerprint so other apps cannot intercept the
+              redemption Uri (plan §"RT2-W3" / §"RT-F11").
+
+              The companion custom-scheme intent-filter (qonversion://redeem)
+              is intentionally NOT registered as an email-link transport —
+              any installed app could claim that scheme and hijack the token.
+              The custom scheme remains valid only for in-process host→SDK
+              forwarding by the host itself.
+            -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="screens.qonversion.io"
+                    android:pathPattern="/r/.*" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/sample/src/main/java/io/qonversion/sample/MainActivity.kt
+++ b/sample/src/main/java/io/qonversion/sample/MainActivity.kt
@@ -85,8 +85,9 @@ class MainActivity : AppCompatActivity() {
         if (!ok) {
             return
         }
-        Log.i("Web2App", "handleRedemptionLink: $uri")
-        Toast.makeText(this, "Redemption link tapped: $uri", Toast.LENGTH_SHORT).show()
+        // Do NOT log/show the full Uri — the redemption token is in the path.
+        Log.i("Web2App", "handleRedemptionLink: host=${uri.host}")
+        Toast.makeText(this, "Redemption link tapped", Toast.LENGTH_SHORT).show()
         Qonversion.shared.handleRedemptionLink(uri, object : QonversionRedemptionCallback {
             override fun onResult(result: RedemptionResult) {
                 Log.i("Web2App", "Redemption result: $result")

--- a/sample/src/main/java/io/qonversion/sample/MainActivity.kt
+++ b/sample/src/main/java/io/qonversion/sample/MainActivity.kt
@@ -2,14 +2,20 @@ package io.qonversion.sample
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
+import com.qonversion.android.sdk.Qonversion
+import com.qonversion.android.sdk.dto.redemption.RedemptionResult
+import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
 import io.qonversion.sample.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
@@ -47,6 +53,52 @@ class MainActivity : AppCompatActivity() {
             // Show toolbar title
             binding.toolbar.title = destination.label
         }
+
+        // Web2App (DEV-847) — handle redemption deep links.
+        handleRedemptionIntent(intent)
+        handleReissueIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleRedemptionIntent(intent)
+        handleReissueIntent(intent)
+    }
+
+    private fun handleReissueIntent(intent: Intent?) {
+        // Triggered via `adb shell am start -a qontest.REISSUE` to exercise
+        // the reissue dialog without needing a UI button.
+        if (intent?.action != "qontest.REISSUE") return
+        Log.i("Web2App", "presentReissueUI triggered via intent")
+        Qonversion.shared.presentReissueUI(this) { success ->
+            Log.i("Web2App", "Reissue completed: success=$success")
+        }
+    }
+
+    private fun handleRedemptionIntent(intent: Intent?) {
+        val uri: Uri = intent?.data ?: return
+        // Accept the App Link host AND a few common local-testing aliases so
+        // adb-fired intents work the same as production email links.
+        val ok = uri.scheme in setOf("https", "http", "qonversion") &&
+                uri.pathSegments.firstOrNull() == "r"
+        if (!ok) {
+            return
+        }
+        Log.i("Web2App", "handleRedemptionLink: $uri")
+        Toast.makeText(this, "Redemption link tapped: $uri", Toast.LENGTH_SHORT).show()
+        Qonversion.shared.handleRedemptionLink(uri, object : QonversionRedemptionCallback {
+            override fun onResult(result: RedemptionResult) {
+                Log.i("Web2App", "Redemption result: $result")
+                runOnUiThread {
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Redemption: $result",
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+            }
+        })
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/sample/src/main/java/io/qonversion/sample/MainActivity.kt
+++ b/sample/src/main/java/io/qonversion/sample/MainActivity.kt
@@ -78,9 +78,13 @@ class MainActivity : AppCompatActivity() {
 
     private fun handleRedemptionIntent(intent: Intent?) {
         val uri: Uri = intent?.data ?: return
-        // Accept the App Link host AND a few common local-testing aliases so
-        // adb-fired intents work the same as production email links.
-        val ok = uri.scheme in setOf("https", "http", "qonversion") &&
+        // Accept ONLY the verified https App Link on the canonical host. Any
+        // installed app can claim a custom (`qonversion://`) scheme — or a plain
+        // `http`/foreign-host link — and hijack the single-use redemption token,
+        // so reference code must not whitelist those. (The SDK also re-checks
+        // scheme + host before any network call; this is defense-in-depth.)
+        val ok = uri.scheme.equals("https", ignoreCase = true) &&
+                uri.host.equals("screens.qonversion.io", ignoreCase = true) &&
                 uri.pathSegments.firstOrNull() == "r"
         if (!ok) {
             return

--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -411,9 +411,10 @@ interface Qonversion {
      * §RT-F11). Use https App Links only for email-borne links. Custom schemes
      * remain allowed for in-process host→SDK forwarding via [identify].
      *
-     * On [RedemptionResult.Success] the SDK transparently calls [identify] with
-     * the user id returned by the backend, merging the current anon session
-     * with the redeemed account.
+     * On [RedemptionResult.Success] the entitlement has already been granted
+     * server-side (grant-first) to the current SDK user; the SDK transparently
+     * refreshes its entitlement state so the grant is reflected on this device.
+     * No [identify]/merge is performed.
      *
      * @param uri      App Link Uri opened by the host activity.
      * @param callback delivered once on the main thread with the terminal

--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -1,7 +1,9 @@
 package com.qonversion.android.sdk
 
 import android.app.Activity
+import android.net.Uri
 import android.util.Log
+import androidx.fragment.app.FragmentActivity
 import com.qonversion.android.sdk.dto.QAttributionProvider
 import com.qonversion.android.sdk.dto.QPurchaseOptions
 import com.qonversion.android.sdk.dto.QPurchaseResult
@@ -17,6 +19,7 @@ import com.qonversion.android.sdk.listeners.QonversionEligibilityCallback
 import com.qonversion.android.sdk.listeners.QonversionEntitlementsCallback
 import com.qonversion.android.sdk.listeners.QonversionOfferingsCallback
 import com.qonversion.android.sdk.listeners.QonversionProductsCallback
+import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
 import com.qonversion.android.sdk.listeners.QonversionRemoteConfigCallback
 import com.qonversion.android.sdk.listeners.QonversionRemoteConfigListCallback
 import com.qonversion.android.sdk.listeners.QonversionRemoteConfigurationAttachCallback
@@ -393,4 +396,46 @@ interface Qonversion {
      * @param listener listener to be called when a deferred purchase completes.
      */
     fun setDeferredPurchasesListener(listener: QDeferredPurchasesListener)
+
+    /**
+     * Web2App (M1): redeem a token delivered to the user via an email App Link.
+     *
+     * The expected Uri shape is `https://screens.qonversion.io/r/{project_uid}/{token}`,
+     * registered in the host AndroidManifest as an `<intent-filter>` with
+     * `android:autoVerify="true"` so Android can route directly to the host
+     * activity without an app chooser. See plan §"What host app must do → Android".
+     *
+     * **Security note:** the custom `qonversion://` scheme is intentionally NOT
+     * supported as an email-link transport here — any installed app can claim
+     * a custom scheme intent-filter and hijack the redemption flow (plan §RT2-W3,
+     * §RT-F11). Use https App Links only for email-borne links. Custom schemes
+     * remain allowed for in-process host→SDK forwarding via [identify].
+     *
+     * On [RedemptionResult.Success] the SDK transparently calls [identify] with
+     * the user id returned by the backend, merging the current anon session
+     * with the redeemed account.
+     *
+     * @param uri      App Link Uri opened by the host activity.
+     * @param callback delivered once on the main thread with the terminal
+     *                 [com.qonversion.android.sdk.dto.redemption.RedemptionResult].
+     */
+    fun handleRedemptionLink(uri: Uri, callback: QonversionRedemptionCallback)
+
+    /**
+     * Web2App (M1): present a modal email-input dialog the user can use to
+     * request a new redemption email when their original link is lost or
+     * expired (`/v4/web/redeem/reissue`).
+     *
+     * The dialog is built programmatically — no host-app theme or layout
+     * resources are required. The dialog dismisses itself on a successful
+     * send and invokes [onCompletion] with `true`. If the user cancels (or
+     * the dialog is dismissed without sending), [onCompletion] is invoked
+     * with `false`.
+     *
+     * @param activity     a [FragmentActivity] used to host the dialog
+     *                     fragment. Pass an Activity that has a non-finished
+     *                     [androidx.fragment.app.FragmentManager].
+     * @param onCompletion main-thread callback invoked exactly once.
+     */
+    fun presentReissueUI(activity: FragmentActivity, onCompletion: (Boolean) -> Unit)
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/redemption/RedemptionResult.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/redemption/RedemptionResult.kt
@@ -3,7 +3,11 @@ package com.qonversion.android.sdk.dto.redemption
 /**
  * Result of attempting to redeem a Web2App token via [com.qonversion.android.sdk.Qonversion.handleRedemptionLink].
  *
- * The set of cases mirrors the iOS SDK to keep cross-platform parity.
+ * The set of cases (6) mirrors the iOS SDK `QONRedemptionResult` to keep
+ * cross-platform parity: Success, TokenExpired, AlreadyConsumed, InvalidToken,
+ * NetworkError, Retryable. Under the grant-first contract a [Success] means the
+ * server already attached the entitlement to `app_uid`; the SDK only refreshes
+ * entitlements (it does NOT identify/merge any client user id).
  */
 enum class RedemptionResult {
     /**
@@ -33,7 +37,21 @@ enum class RedemptionResult {
     InvalidToken,
 
     /**
-     * Could not reach the Qonversion backend. The host should retry later.
+     * Could not reach the Qonversion backend (DNS / TCP / TLS / timeout) — the
+     * device genuinely failed to talk to the server. This is NOT used for live
+     * server responses such as 429/5xx (see [Retryable]).
      */
     NetworkError,
+
+    /**
+     * The backend was reachable but returned a transient/server-side outcome
+     * that the host may safely retry later: rate limiting (429), server errors
+     * (5xx), or auth/config errors (other non-mapped 4xx such as 401/403). Also
+     * surfaced for SDK-side preconditions that can be retried (e.g. the SDK does
+     * not yet have a usable `app_uid`, or a redemption is already in flight).
+     * Distinguishing this from [NetworkError] avoids a misleading "no internet"
+     * UX when the network is live and the server simply asked the client to
+     * back off.
+     */
+    Retryable,
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/redemption/RedemptionResult.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/redemption/RedemptionResult.kt
@@ -1,0 +1,40 @@
+package com.qonversion.android.sdk.dto.redemption
+
+/**
+ * Result of attempting to redeem a Web2App token via [com.qonversion.android.sdk.Qonversion.handleRedemptionLink].
+ *
+ * The set of cases mirrors the iOS SDK to keep cross-platform parity.
+ */
+enum class RedemptionResult {
+    /**
+     * Token was consumed and the entitlement was granted to the current user.
+     * The SDK has already called `identify(userId)` for the merge flow, so a
+     * subsequent `checkEntitlements` will reflect the new state.
+     */
+    Success,
+
+    /**
+     * The redemption token has expired (its TTL elapsed before the user opened
+     * the email link). Hosts should prompt the user to request a new email via
+     * [com.qonversion.android.sdk.Qonversion.presentReissueUI].
+     */
+    TokenExpired,
+
+    /**
+     * The token has already been consumed on a previous device or session.
+     * Hosts should typically show a "this link was already used" message and
+     * suggest re-issue / contact support. The SDK still attempts identify-flow
+     * recovery server-side before returning this case (RT4-W2).
+     */
+    AlreadyConsumed,
+
+    /**
+     * The token is not recognized by the server (never existed or was revoked).
+     */
+    InvalidToken,
+
+    /**
+     * Could not reach the Qonversion backend. The host should retry later.
+     */
+    NetworkError,
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/redemption/RedemptionResult.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/redemption/RedemptionResult.kt
@@ -7,9 +7,9 @@ package com.qonversion.android.sdk.dto.redemption
  */
 enum class RedemptionResult {
     /**
-     * Token was consumed and the entitlement was granted to the current user.
-     * The SDK has already called `identify(userId)` for the merge flow, so a
-     * subsequent `checkEntitlements` will reflect the new state.
+     * Token was consumed and the entitlement was granted to the current user
+     * (server-side, grant-first). The SDK has already triggered an entitlements
+     * refresh, so a subsequent `checkEntitlements` will reflect the new state.
      */
     Success,
 
@@ -23,8 +23,7 @@ enum class RedemptionResult {
     /**
      * The token has already been consumed on a previous device or session.
      * Hosts should typically show a "this link was already used" message and
-     * suggest re-issue / contact support. The SDK still attempts identify-flow
-     * recovery server-side before returning this case (RT4-W2).
+     * suggest re-issue / contact support.
      */
     AlreadyConsumed,
 

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -2,8 +2,10 @@ package com.qonversion.android.sdk.internal
 
 import android.app.Activity
 import android.app.Application
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.qonversion.android.sdk.Qonversion
 import com.qonversion.android.sdk.dto.QAttributionProvider
@@ -23,12 +25,15 @@ import com.qonversion.android.sdk.internal.dto.purchase.PurchaseOptionsInternal
 import com.qonversion.android.sdk.internal.logger.ConsoleLogger
 import com.qonversion.android.sdk.internal.logger.ExceptionManager
 import com.qonversion.android.sdk.internal.provider.AppStateProvider
+import com.qonversion.android.sdk.internal.redemption.RedemptionManager
+import com.qonversion.android.sdk.internal.redemption.ReissueDialogFragment
 import com.qonversion.android.sdk.internal.services.QFallbacksService
 import com.qonversion.android.sdk.internal.storage.SharedPreferencesCache
 import com.qonversion.android.sdk.listeners.QonversionExperimentAttachCallback
 import com.qonversion.android.sdk.listeners.QonversionEntitlementsCallback
 import com.qonversion.android.sdk.listeners.QonversionOfferingsCallback
 import com.qonversion.android.sdk.listeners.QonversionProductsCallback
+import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
 import com.qonversion.android.sdk.listeners.QonversionRemoteConfigCallback
 import com.qonversion.android.sdk.listeners.QonversionEligibilityCallback
 import com.qonversion.android.sdk.listeners.QonversionUserCallback
@@ -56,6 +61,7 @@ internal class QonversionInternal(
     private var exceptionManager: ExceptionManager
     private var remoteConfigManager: QRemoteConfigManager
     private var fallbackService: QFallbacksService
+    private val redemptionManager: RedemptionManager
 
     override var appState = AppState.Background
 
@@ -113,6 +119,16 @@ internal class QonversionInternal(
 
         val lifecycleHandler = AppLifecycleHandler(this)
         postToMainThread { ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleHandler) }
+
+        // RedemptionManager has no DI dependencies of its own beyond Api +
+        // InternalConfig + Logger + the identify entrypoint, so we instantiate
+        // it here rather than adding another DI module just for one class.
+        redemptionManager = RedemptionManager(
+            api = QDependencyInjector.appComponent.api(),
+            internalConfig = internalConfig,
+            logger = logger,
+            identifyUser = { userId -> productCenterManager.identify(userId) },
+        )
 
         productCenterManager.launch(RequestTrigger.Init)
     }
@@ -386,6 +402,27 @@ internal class QonversionInternal(
         productCenterManager.setDeferredPurchasesListener(listener)
     }
 
+    override fun handleRedemptionLink(uri: Uri, callback: QonversionRedemptionCallback) {
+        redemptionManager.handleRedemptionLink(uri, callback)
+    }
+
+    override fun presentReissueUI(activity: FragmentActivity, onCompletion: (Boolean) -> Unit) {
+        // Re-use existing tagged instance if present so back-to-back calls
+        // don't stack multiple dialogs.
+        val manager = activity.supportFragmentManager
+        val existing = manager.findFragmentByTag(REISSUE_DIALOG_TAG)
+        if (existing is ReissueDialogFragment) {
+            existing.redemptionManager = redemptionManager
+            existing.onCompletion = onCompletion
+            return
+        }
+        val dialog = ReissueDialogFragment().also {
+            it.redemptionManager = redemptionManager
+            it.onCompletion = onCompletion
+        }
+        dialog.show(manager, REISSUE_DIALOG_TAG)
+    }
+
     // Private functions
     private fun mainEntitlementsCallback(callback: QonversionEntitlementsCallback): QonversionEntitlementsCallback =
         object : QonversionEntitlementsCallback {
@@ -435,5 +472,9 @@ internal class QonversionInternal(
         } else {
             handler.post(runnable)
         }
+    }
+
+    private companion object {
+        const val REISSUE_DIALOG_TAG = "qonversion.reissue_dialog"
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -127,7 +127,11 @@ internal class QonversionInternal(
             api = QDependencyInjector.appComponent.api(),
             internalConfig = internalConfig,
             logger = logger,
-            identifyUser = { userId -> productCenterManager.identify(userId) },
+            // Grant-first redeem: no identify/merge. After a successful redeem
+            // the server has already granted the entitlement to app_uid, so we
+            // re-launch with ActualizePermissions to pull the fresh entitlement
+            // state onto this device.
+            refreshEntitlements = { productCenterManager.launch(RequestTrigger.ActualizePermissions) },
         )
 
         productCenterManager.launch(RequestTrigger.Init)

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -121,12 +121,16 @@ internal class QonversionInternal(
         postToMainThread { ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleHandler) }
 
         // RedemptionManager has no DI dependencies of its own beyond Api +
-        // InternalConfig + Logger + the identify entrypoint, so we instantiate
-        // it here rather than adding another DI module just for one class.
+        // InternalConfig + Logger + a persistent cache + the refresh entrypoint,
+        // so we instantiate it here rather than adding another DI module just
+        // for one class.
         redemptionManager = RedemptionManager(
             api = QDependencyInjector.appComponent.api(),
             internalConfig = internalConfig,
             logger = logger,
+            // Persists per-token Idempotency-Keys so redeem dedup survives a
+            // cold-start (not just an in-process retry).
+            cache = sharedPreferencesCache,
             // Grant-first redeem: no identify/merge. After a successful redeem
             // the server has already granted the entitlement to app_uid, so we
             // re-launch with ActualizePermissions to pull the fresh entitlement

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/api/Api.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/api/Api.kt
@@ -17,6 +17,11 @@ import com.qonversion.android.sdk.internal.dto.request.EligibilityRequest
 import com.qonversion.android.sdk.internal.dto.request.IdentityRequest
 import com.qonversion.android.sdk.internal.dto.request.InitRequest
 import com.qonversion.android.sdk.internal.dto.request.PurchaseRequest
+import com.qonversion.android.sdk.internal.dto.request.RedeemReissueRequest
+import com.qonversion.android.sdk.internal.dto.request.RedeemRequest
+import com.qonversion.android.sdk.internal.dto.request.RedeemStatusRequest
+import com.qonversion.android.sdk.internal.dto.redemption.RedeemResponse
+import com.qonversion.android.sdk.internal.dto.redemption.RedeemStatusResponse
 import com.qonversion.android.sdk.internal.dto.request.RestoreRequest
 import com.qonversion.android.sdk.internal.dto.request.data.UserPropertyRequestData
 import retrofit2.Call
@@ -116,4 +121,31 @@ internal interface Api {
 
     @GET("v3/users/{user_id}/properties")
     fun getProperties(@Path("user_id") userId: String): Call<List<QUserProperty>>
+
+    // --- Web2App redemption (DEV-847) ---
+
+    /**
+     * Exchanges a redemption token (delivered to the user via App Link email)
+     * for an entitlement on the current SDK user. See plan §"Mobile SDK API
+     * surface → Android" and `RedemptionResult` for the response semantics.
+     */
+    @POST("v4/web/redeem")
+    fun redeem(@Body request: RedeemRequest): Call<RedeemResponse>
+
+    /**
+     * Disambiguates a 409 from [redeem]: tells the SDK whether the token was
+     * already consumed (→ `AlreadyConsumed`) versus some other transient
+     * server condition. Used to surface the identify-flow recovery hint to
+     * the host app (RT4-W2).
+     */
+    @POST("v4/web/redeem/status")
+    fun redeemStatus(@Body request: RedeemStatusRequest): Call<RedeemStatusResponse>
+
+    /**
+     * Requests a new redemption email when the original token is lost or
+     * expired. Backend always responds 200 on a well-formed email (no oracle
+     * leak); 429 / 503 are surfaced to the UI for retry messaging.
+     */
+    @POST("v4/web/redeem/reissue")
+    fun redeemReissue(@Body request: RedeemReissueRequest): Call<Void>
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/api/Api.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/api/Api.kt
@@ -128,24 +128,41 @@ internal interface Api {
      * Exchanges a redemption token (delivered to the user via App Link email)
      * for an entitlement on the current SDK user. See plan §"Mobile SDK API
      * surface → Android" and `RedemptionResult` for the response semantics.
+     *
+     * [idempotencyKey] is a UUID scoped to one *logical* redeem (parity with
+     * iOS): the same value is sent on the redeem POST and any 409→/status
+     * recovery call so the backend can dedup double-taps / retries — including
+     * across a cold-start (the key is persisted per token).
      */
     @POST("v4/web/redeem")
-    fun redeem(@Body request: RedeemRequest): Call<RedeemResponse>
+    fun redeem(
+        @Body request: RedeemRequest,
+        @Header("Idempotency-Key") idempotencyKey: String,
+    ): Call<RedeemResponse>
 
     /**
      * Disambiguates a 409 from [redeem]: tells the SDK whether the token was
      * already consumed (→ `AlreadyConsumed`) versus some other transient
      * server condition. Used to surface the identify-flow recovery hint to
-     * the host app (RT4-W2).
+     * the host app (RT4-W2). Carries the same [idempotencyKey] as the redeem
+     * POST it recovers from (same logical redeem).
      */
     @POST("v4/web/redeem/status")
-    fun redeemStatus(@Body request: RedeemStatusRequest): Call<RedeemStatusResponse>
+    fun redeemStatus(
+        @Body request: RedeemStatusRequest,
+        @Header("Idempotency-Key") idempotencyKey: String,
+    ): Call<RedeemStatusResponse>
 
     /**
      * Requests a new redemption email when the original token is lost or
      * expired. Backend always responds 200 on a well-formed email (no oracle
      * leak); 429 / 503 are surfaced to the UI for retry messaging.
+     *
+     * [idempotencyKey] is a fresh UUID per reissue (its own logical operation).
      */
     @POST("v4/web/redeem/reissue")
-    fun redeemReissue(@Body request: RedeemReissueRequest): Call<Void>
+    fun redeemReissue(
+        @Body request: RedeemReissueRequest,
+        @Header("Idempotency-Key") idempotencyKey: String,
+    ): Call<Void>
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/di/component/AppComponent.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/di/component/AppComponent.kt
@@ -6,6 +6,7 @@ import com.qonversion.android.sdk.internal.QHandledPurchasesCache
 import com.qonversion.android.sdk.internal.QIdentityManager
 import com.qonversion.android.sdk.internal.QRemoteConfigManager
 import com.qonversion.android.sdk.internal.QUserPropertiesManager
+import com.qonversion.android.sdk.internal.api.Api
 import com.qonversion.android.sdk.internal.di.module.AppModule
 import com.qonversion.android.sdk.internal.di.module.RepositoryModule
 import com.qonversion.android.sdk.internal.di.module.NetworkModule
@@ -45,4 +46,5 @@ internal interface AppComponent {
     fun sharedPreferencesCache(): SharedPreferencesCache
     fun exceptionManager(): QExceptionManager
     fun fallbacksService(): QFallbacksService
+    fun api(): Api
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/di/module/RepositoryModule.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/di/module/RepositoryModule.kt
@@ -69,6 +69,17 @@ internal class RepositoryModule {
         )
     }
 
+    /**
+     * Exposes the Retrofit-generated [Api] so additional managers
+     * (e.g. [com.qonversion.android.sdk.internal.redemption.RedemptionManager])
+     * can hit endpoints that aren't routed through [DefaultRepository].
+     */
+    @ApplicationScope
+    @Provides
+    fun provideApi(retrofit: Retrofit): Api {
+        return retrofit.create(Api::class.java)
+    }
+
     @ApplicationScope
     @Provides
     fun provideTokenStorage(preferences: SharedPreferences): TokenStorage {

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/dto/redemption/RedeemResponse.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/dto/redemption/RedeemResponse.kt
@@ -6,13 +6,16 @@ import com.squareup.moshi.JsonClass
 /**
  * Response body for `POST /v4/web/redeem` on success (HTTP 200).
  *
- * `user_id` is the Qonversion user id the entitlement was granted to. The SDK
- * calls `identify(user_id)` after a successful redemption to merge the current
- * anon session with that account (RT4-W2 / plan §"DEV-847").
+ * Web2App M1.5 canonical contract: `{ "redeemed": bool, "app_uid": string }`.
+ * Under grant-first entitlement the server has already attached the grant to
+ * `app_uid`, so the SDK does NOT identify/merge a client user id here — there
+ * is intentionally no `user_id` field. On success the SDK only refreshes the
+ * device's entitlement state so the server grant is reflected locally.
  */
 @JsonClass(generateAdapter = true)
 internal data class RedeemResponse(
-    @Json(name = "user_id") val userId: String?,
+    @Json(name = "redeemed") val redeemed: Boolean = false,
+    @Json(name = "app_uid") val appUid: String? = null,
 )
 
 /**

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/dto/redemption/RedeemResponse.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/dto/redemption/RedeemResponse.kt
@@ -1,0 +1,27 @@
+package com.qonversion.android.sdk.internal.dto.redemption
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Response body for `POST /v4/web/redeem` on success (HTTP 200).
+ *
+ * `user_id` is the Qonversion user id the entitlement was granted to. The SDK
+ * calls `identify(user_id)` after a successful redemption to merge the current
+ * anon session with that account (RT4-W2 / plan §"DEV-847").
+ */
+@JsonClass(generateAdapter = true)
+internal data class RedeemResponse(
+    @Json(name = "user_id") val userId: String?,
+)
+
+/**
+ * Response body for `POST /v4/web/redeem/status` — polled after a 409 from
+ * `/v4/web/redeem` to determine whether the token was already consumed (in
+ * which case the host shows recovery UI suggestion).
+ */
+@JsonClass(generateAdapter = true)
+internal data class RedeemStatusResponse(
+    @Json(name = "consumed") val consumed: Boolean = false,
+    @Json(name = "expired") val expired: Boolean = false,
+)

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/dto/request/RedeemRequest.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/dto/request/RedeemRequest.kt
@@ -1,0 +1,29 @@
+package com.qonversion.android.sdk.internal.dto.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * Request body for `POST /v4/web/redeem` — exchanges a Web2App token issued
+ * by `/v4/web/payment` for an entitlement grant attached to the current SDK user.
+ *
+ * The default restore behavior is `Transfer` (see plan §"DEV-845"), which is
+ * enforced server-side; the field is included here so the SDK can override it
+ * in future iterations without an API change.
+ */
+@JsonClass(generateAdapter = true)
+internal data class RedeemRequest(
+    @Json(name = "token") val token: String,
+    @Json(name = "anon_user_id") val anonUserId: String?,
+    @Json(name = "restore_behavior") val restoreBehavior: String = "transfer",
+)
+
+@JsonClass(generateAdapter = true)
+internal data class RedeemStatusRequest(
+    @Json(name = "token") val token: String,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class RedeemReissueRequest(
+    @Json(name = "email") val email: String,
+)

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/dto/request/RedeemRequest.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/dto/request/RedeemRequest.kt
@@ -14,7 +14,10 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 internal data class RedeemRequest(
     @Json(name = "token") val token: String,
-    @Json(name = "anon_user_id") val anonUserId: String?,
+    // Web2App M1.5 canonical contract: api-gateway and purchaseman read
+    // "app_uid". The value is unchanged (the SDK user id / internalConfig.uid);
+    // only the wire key was renamed from the legacy "anon_user_id".
+    @Json(name = "app_uid") val appUid: String?,
     @Json(name = "restore_behavior") val restoreBehavior: String = "transfer",
 )
 

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -74,16 +74,33 @@ internal class RedemptionManager(
             return
         }
 
-        // In-flight guard: if a redemption is already running, drop this call so
-        // we don't fire a second POST / second refresh. CAS null -> token.
+        // Fail-fast on a missing app_uid (parity with iOS). Redeem tokens are
+        // single-use: firing a redeem without app_uid would burn the token
+        // server-side with no user to attach the grant to. If the SDK has no
+        // usable app_uid yet (e.g. user-info bootstrap not finished), surface a
+        // retryable outcome and issue NO network request.
+        val appUid = internalConfig.uid.takeIf { it.isNotBlank() }
+        if (appUid == null) {
+            logger.error("RedemptionManager: no app_uid available yet — skipping redeem (retryable).")
+            deliver(callback, RedemptionResult.Retryable)
+            return
+        }
+
+        // In-flight guard: if a redemption is already running, reject this call
+        // so we don't fire a second POST / second refresh. CAS null -> token.
+        // The callback MUST still fire (Retryable) — a silent drop here strands
+        // the host UI on an eternal spinner. Note we do NOT route this through
+        // [deliver]: the guard belongs to the redemption already in flight and
+        // must not be released by this rejected call.
         if (!inFlightToken.compareAndSet(null, token)) {
-            logger.error("RedemptionManager: redemption already in flight — ignoring duplicate link.")
+            logger.error("RedemptionManager: redemption already in flight — rejecting duplicate link as retryable.")
+            postToMainThread { callback.onResult(RedemptionResult.Retryable) }
             return
         }
 
         val request = RedeemRequest(
             token = token,
-            appUid = internalConfig.uid.takeIf { it.isNotBlank() },
+            appUid = appUid,
         )
 
         api.redeem(request).enqueue {
@@ -115,11 +132,16 @@ internal class RedemptionManager(
                         deliver(callback, RedemptionResult.TokenExpired)
                     }
                     else -> {
+                        // 429 (rate limit), 5xx (server error) and any other
+                        // non-mapped 4xx (401/403/etc.): the server was reachable
+                        // and responded, so this is NOT a "no network" condition.
+                        // Surface Retryable (parity with iOS) so the host shows a
+                        // back-off/retry affordance, not a misleading offline error.
                         logger.error(
-                            "RedemptionManager: redeem unexpected ${response.code()} — " +
-                                "treating as NetworkError."
+                            "RedemptionManager: redeem reachable but non-success ${response.code()} — " +
+                                "treating as Retryable."
                         )
-                        deliver(callback, RedemptionResult.NetworkError)
+                        deliver(callback, RedemptionResult.Retryable)
                     }
                 }
             }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -12,6 +12,7 @@ import com.qonversion.android.sdk.internal.dto.request.RedeemStatusRequest
 import com.qonversion.android.sdk.internal.enqueue
 import com.qonversion.android.sdk.internal.logger.Logger
 import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Coordinates Web2App redemption: parses the email App Link, calls
@@ -37,6 +38,14 @@ internal class RedemptionManager(
     private val handler = Handler(Looper.getMainLooper())
 
     /**
+     * Token of the redemption currently in flight, or `null` when idle. Guards
+     * against a double/race redemption (e.g. `onCreate` + `onNewIntent`, or a
+     * fast double tap) firing two parallel `POST /v4/web/redeem` calls and two
+     * `identify` calls. Reset to `null` on every terminal [deliver].
+     */
+    private val inFlightToken = AtomicReference<String?>(null)
+
+    /**
      * Parses [uri] (expected: `https://screens.qonversion.io/r/{project_uid}/{token}`),
      * POSTs `/v4/web/redeem`, and invokes [callback] on the main thread with the
      * terminal [RedemptionResult]. See [RedemptionResult] for case semantics.
@@ -51,10 +60,17 @@ internal class RedemptionManager(
             // Never log the full Uri — the redemption token lives in the path and
             // would leak into LogCat / crash reporters. Log only scheme+host.
             logger.error(
-                "RedemptionManager: malformed redemption Uri " +
-                    "(scheme=${uri.scheme}, host=${uri.host}) — no token segment found."
+                "RedemptionManager: malformed or untrusted redemption Uri " +
+                    "(scheme=${uri.scheme}, host=${uri.host}) — no valid token segment found."
             )
             deliver(callback, RedemptionResult.InvalidToken)
+            return
+        }
+
+        // In-flight guard: if a redemption is already running, drop this call so
+        // we don't fire a second POST / second identify. CAS null -> token.
+        if (!inFlightToken.compareAndSet(null, token)) {
+            logger.error("RedemptionManager: redemption already in flight — ignoring duplicate link.")
             return
         }
 
@@ -170,6 +186,13 @@ internal class RedemptionManager(
         // host→SDK forwarding and is not exercised by this entry point.
         if (!uri.scheme.equals(REDEEM_SCHEME_HTTPS, ignoreCase = true)) return null
 
+        // Host pinning: even over https, only the canonical App Link host is a
+        // trusted email-link transport. A link like
+        // `https://attacker.com/r/{proj}/{token}` would otherwise leak the
+        // redemption token to a third-party backend. Reject any other host
+        // up-front — before any token extraction or network call.
+        if (!uri.host.equals(REDEEM_HOST, ignoreCase = true)) return null
+
         val segments = uri.pathSegments ?: return null
         // Expected: /r/{project_uid}/{token}
         if (segments.size < REDEEM_PATH_MIN_SEGMENTS) return null
@@ -180,6 +203,10 @@ internal class RedemptionManager(
     }
 
     private fun deliver(callback: QonversionRedemptionCallback, result: RedemptionResult) {
+        // Terminal point of a redemption — release the in-flight guard so a
+        // later, legitimate redemption can proceed. Safe no-op when the guard
+        // was never taken (e.g. malformed/untrusted Uri short-circuit).
+        inFlightToken.set(null)
         postToMainThread { callback.onResult(result) }
     }
 
@@ -216,5 +243,8 @@ internal class RedemptionManager(
         const val REDEEM_PATH_MIN_SEGMENTS = 3
         // RT2-W3: only https App Links are accepted as email-link transport.
         const val REDEEM_SCHEME_HTTPS = "https"
+        // Canonical App Link host. Token transport is pinned to this host so a
+        // foreign https host can't exfiltrate the redemption token.
+        const val REDEEM_HOST = "screens.qonversion.io"
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -41,6 +41,10 @@ internal class RedemptionManager(
      * POSTs `/v4/web/redeem`, and invokes [callback] on the main thread with the
      * terminal [RedemptionResult]. See [RedemptionResult] for case semantics.
      */
+    // The post-redeem identify is best-effort: any failure there must not
+    // fail the already-successful redeem, so we intentionally catch broadly
+    // and only log.
+    @Suppress("TooGenericExceptionCaught")
     fun handleRedemptionLink(uri: Uri, callback: QonversionRedemptionCallback) {
         val token = extractToken(uri)
         if (token == null) {
@@ -147,6 +151,10 @@ internal class RedemptionManager(
         }
     }
 
+    // Sequential guard clauses (scheme, segment count, prefix, token) read
+    // clearer as early returns than nested conditionals; exceeds detekt's
+    // default ReturnCount of 2 by design.
+    @Suppress("ReturnCount")
     private fun extractToken(uri: Uri): String? {
         // Spec rule RT2-W3: only the verified https App Link form
         // (`android:autoVerify="true"`) is allowed as an email-link

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -11,7 +11,10 @@ import com.qonversion.android.sdk.internal.dto.request.RedeemRequest
 import com.qonversion.android.sdk.internal.dto.request.RedeemStatusRequest
 import com.qonversion.android.sdk.internal.enqueue
 import com.qonversion.android.sdk.internal.logger.Logger
+import com.qonversion.android.sdk.internal.storage.Cache
 import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
+import java.security.MessageDigest
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -39,6 +42,9 @@ internal class RedemptionManager(
     private val api: Api,
     private val internalConfig: InternalConfig,
     private val logger: Logger,
+    // Persistent store for per-token Idempotency-Keys so dedup survives a
+    // cold-start, not just an in-process retry (see [idempotencyKeyForToken]).
+    private val cache: Cache,
     private val refreshEntitlements: () -> Unit,
 ) {
 
@@ -103,7 +109,14 @@ internal class RedemptionManager(
             appUid = appUid,
         )
 
-        api.redeem(request).enqueue {
+        // One Idempotency-Key (UUIDv4) per *logical* redeem — not per HTTP
+        // attempt (parity with iOS). The same key is sent on the redeem POST and
+        // any 409→/status recovery call. Persisted per token so a redeem retried
+        // after the app was killed/relaunched reuses the same key and the backend
+        // can still dedup — i.e. dedup survives cold-start, not just in-process.
+        val idempotencyKey = idempotencyKeyForToken(token)
+
+        api.redeem(request, idempotencyKey).enqueue {
             onResponse = { response ->
                 when {
                     response.isSuccessful -> {
@@ -123,7 +136,8 @@ internal class RedemptionManager(
                     }
                     response.code() == HTTP_CONFLICT -> {
                         // Disambiguate consumed vs other 409 via /redeem/status.
-                        resolveConflict(token, callback)
+                        // Same logical redeem → reuse the same Idempotency-Key.
+                        resolveConflict(token, idempotencyKey, callback)
                     }
                     response.code() == HTTP_NOT_FOUND -> {
                         deliver(callback, RedemptionResult.InvalidToken)
@@ -157,7 +171,8 @@ internal class RedemptionManager(
      * the [ReissueResult] cases used by the dialog UI to render the right hint.
      */
     fun requestReissue(email: String, callback: (ReissueResult) -> Unit) {
-        api.redeemReissue(RedeemReissueRequest(email)).enqueue {
+        // Reissue is its own logical operation → its own fresh Idempotency-Key.
+        api.redeemReissue(RedeemReissueRequest(email), UUID.randomUUID().toString()).enqueue {
             onResponse = { response ->
                 val mapped = when {
                     response.isSuccessful -> ReissueResult.Sent
@@ -174,8 +189,12 @@ internal class RedemptionManager(
         }
     }
 
-    private fun resolveConflict(token: String, callback: QonversionRedemptionCallback) {
-        api.redeemStatus(RedeemStatusRequest(token)).enqueue {
+    private fun resolveConflict(
+        token: String,
+        idempotencyKey: String,
+        callback: QonversionRedemptionCallback,
+    ) {
+        api.redeemStatus(RedeemStatusRequest(token), idempotencyKey).enqueue {
             onResponse = { response ->
                 val body = response.body()
                 val result = when {
@@ -226,6 +245,29 @@ internal class RedemptionManager(
         return token?.takeIf { it.isNotBlank() }
     }
 
+    /**
+     * Returns a stable Idempotency-Key for the logical redeem of [token],
+     * generating and persisting a fresh UUID the first time and reusing it on
+     * any later attempt for the same token — so dedup survives a cold-start, not
+     * just an in-process retry.
+     *
+     * The token itself is a secret carried in the email link; we never persist
+     * it in clear. The cache entry is keyed by a SHA-256 of the token so the
+     * raw token never lands on disk while still keying by token identity.
+     */
+    private fun idempotencyKeyForToken(token: String): String {
+        val cacheKey = IDEMPOTENCY_KEY_PREFIX + sha256(token)
+        cache.getString(cacheKey, null)?.takeIf { it.isNotBlank() }?.let { return it }
+        val key = UUID.randomUUID().toString()
+        cache.putString(cacheKey, key)
+        return key
+    }
+
+    private fun sha256(value: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
     private fun deliver(callback: QonversionRedemptionCallback, result: RedemptionResult) {
         // Terminal point of a redemption — release the in-flight guard so a
         // later, legitimate redemption can proceed. Safe no-op when the guard
@@ -270,5 +312,7 @@ internal class RedemptionManager(
         // Canonical App Link host. Token transport is pinned to this host so a
         // foreign https host can't exfiltrate the redemption token.
         const val REDEEM_HOST = "screens.qonversion.io"
+        // Prefix for the persisted per-token Idempotency-Key entries.
+        const val IDEMPOTENCY_KEY_PREFIX = "com.qonversion.web2app.redeem.idempotency."
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -148,7 +148,14 @@ internal class RedemptionManager(
     }
 
     private fun extractToken(uri: Uri): String? {
-        if (uri.scheme.isNullOrBlank()) return null
+        // Spec rule RT2-W3: only the verified https App Link form
+        // (`android:autoVerify="true"`) is allowed as an email-link
+        // transport. Any installed app can claim a `qonversion://`
+        // intent-filter and hijack the redemption token, so we reject any
+        // non-https scheme up-front — before any token extraction or
+        // network call. The custom scheme is reserved for in-process
+        // host→SDK forwarding and is not exercised by this entry point.
+        if (!uri.scheme.equals(REDEEM_SCHEME_HTTPS, ignoreCase = true)) return null
 
         val segments = uri.pathSegments ?: return null
         // Expected: /r/{project_uid}/{token}
@@ -194,5 +201,7 @@ internal class RedemptionManager(
         // → segments = ["r", "{project}", "{token}"], token is at index 2.
         const val REDEEM_TOKEN_SEGMENT_INDEX = 2
         const val REDEEM_PATH_MIN_SEGMENTS = 3
+        // RT2-W3: only https App Links are accepted as email-link transport.
+        const val REDEEM_SCHEME_HTTPS = "https"
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -48,7 +48,12 @@ internal class RedemptionManager(
     fun handleRedemptionLink(uri: Uri, callback: QonversionRedemptionCallback) {
         val token = extractToken(uri)
         if (token == null) {
-            logger.error("RedemptionManager: malformed Uri '$uri' — no token segment found.")
+            // Never log the full Uri — the redemption token lives in the path and
+            // would leak into LogCat / crash reporters. Log only scheme+host.
+            logger.error(
+                "RedemptionManager: malformed redemption Uri " +
+                    "(scheme=${uri.scheme}, host=${uri.host}) — no token segment found."
+            )
             deliver(callback, RedemptionResult.InvalidToken)
             return
         }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -1,0 +1,198 @@
+package com.qonversion.android.sdk.internal.redemption
+
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import com.qonversion.android.sdk.dto.redemption.RedemptionResult
+import com.qonversion.android.sdk.internal.InternalConfig
+import com.qonversion.android.sdk.internal.api.Api
+import com.qonversion.android.sdk.internal.dto.request.RedeemReissueRequest
+import com.qonversion.android.sdk.internal.dto.request.RedeemRequest
+import com.qonversion.android.sdk.internal.dto.request.RedeemStatusRequest
+import com.qonversion.android.sdk.internal.enqueue
+import com.qonversion.android.sdk.internal.logger.Logger
+import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
+
+/**
+ * Coordinates Web2App redemption: parses the email App Link, calls
+ * `POST /v4/web/redeem`, disambiguates 409 via `/v4/web/redeem/status`, and
+ * triggers the SDK identify-flow for the merge (RT4-W2).
+ *
+ * The reissue endpoint is also exposed here so the reissue dialog UI doesn't
+ * need its own networking — it forwards through this manager.
+ *
+ * All public callbacks are dispatched on the main thread.
+ *
+ * Note: the SDK identify call is invoked through the supplied [identifyUser]
+ * lambda rather than a direct reference to the product center manager so this
+ * class stays unit-testable without spinning up the full DI graph.
+ */
+internal class RedemptionManager(
+    private val api: Api,
+    private val internalConfig: InternalConfig,
+    private val logger: Logger,
+    private val identifyUser: (userId: String) -> Unit,
+) {
+
+    private val handler = Handler(Looper.getMainLooper())
+
+    /**
+     * Parses [uri] (expected: `https://screens.qonversion.io/r/{project_uid}/{token}`),
+     * POSTs `/v4/web/redeem`, and invokes [callback] on the main thread with the
+     * terminal [RedemptionResult]. See [RedemptionResult] for case semantics.
+     */
+    fun handleRedemptionLink(uri: Uri, callback: QonversionRedemptionCallback) {
+        val token = extractToken(uri)
+        if (token == null) {
+            logger.error("RedemptionManager: malformed Uri '$uri' — no token segment found.")
+            deliver(callback, RedemptionResult.InvalidToken)
+            return
+        }
+
+        val request = RedeemRequest(
+            token = token,
+            anonUserId = internalConfig.uid.takeIf { it.isNotBlank() },
+        )
+
+        api.redeem(request).enqueue {
+            onResponse = { response ->
+                when {
+                    response.isSuccessful -> {
+                        val userId = response.body()?.userId
+                        if (!userId.isNullOrBlank()) {
+                            // Trigger merge: identify the (now anon) device user
+                            // with the Qonversion user id returned by redeem.
+                            try {
+                                identifyUser(userId)
+                            } catch (t: Throwable) {
+                                logger.error(
+                                    "RedemptionManager: identify after redeem threw: $t"
+                                )
+                            }
+                        } else {
+                            logger.error(
+                                "RedemptionManager: redeem 200 with empty user_id — " +
+                                    "skipping identify, host should call checkEntitlements."
+                            )
+                        }
+                        deliver(callback, RedemptionResult.Success)
+                    }
+                    response.code() == HTTP_CONFLICT -> {
+                        // Disambiguate consumed vs other 409 via /redeem/status.
+                        resolveConflict(token, callback)
+                    }
+                    response.code() == HTTP_NOT_FOUND -> {
+                        deliver(callback, RedemptionResult.InvalidToken)
+                    }
+                    response.code() == HTTP_GONE -> {
+                        deliver(callback, RedemptionResult.TokenExpired)
+                    }
+                    else -> {
+                        logger.error(
+                            "RedemptionManager: redeem unexpected ${response.code()} — " +
+                                "treating as NetworkError."
+                        )
+                        deliver(callback, RedemptionResult.NetworkError)
+                    }
+                }
+            }
+            onFailure = { t ->
+                logger.error("RedemptionManager: redeem network failure: $t")
+                deliver(callback, RedemptionResult.NetworkError)
+            }
+        }
+    }
+
+    /**
+     * POSTs `/v4/web/redeem/reissue` for [email]. Maps HTTP status to one of
+     * the [ReissueResult] cases used by the dialog UI to render the right hint.
+     */
+    fun requestReissue(email: String, callback: (ReissueResult) -> Unit) {
+        api.redeemReissue(RedeemReissueRequest(email)).enqueue {
+            onResponse = { response ->
+                val mapped = when {
+                    response.isSuccessful -> ReissueResult.Sent
+                    response.code() == HTTP_TOO_MANY_REQUESTS -> ReissueResult.RateLimited
+                    response.code() in HTTP_SERVER_ERROR_RANGE -> ReissueResult.ServerError
+                    else -> ReissueResult.ServerError
+                }
+                deliverReissue(callback, mapped)
+            }
+            onFailure = { t ->
+                logger.error("RedemptionManager: reissue network failure: $t")
+                deliverReissue(callback, ReissueResult.ServerError)
+            }
+        }
+    }
+
+    private fun resolveConflict(token: String, callback: QonversionRedemptionCallback) {
+        api.redeemStatus(RedeemStatusRequest(token)).enqueue {
+            onResponse = { response ->
+                val body = response.body()
+                val result = when {
+                    !response.isSuccessful -> RedemptionResult.AlreadyConsumed
+                    body?.consumed == true -> RedemptionResult.AlreadyConsumed
+                    body?.expired == true -> RedemptionResult.TokenExpired
+                    else -> RedemptionResult.AlreadyConsumed
+                }
+                deliver(callback, result)
+            }
+            onFailure = { t ->
+                // If status check itself fails, surface the original 409 as
+                // AlreadyConsumed — the host UI guidance for both states is
+                // "request a new email", which matches AlreadyConsumed.
+                logger.error("RedemptionManager: redeem/status failure: $t")
+                deliver(callback, RedemptionResult.AlreadyConsumed)
+            }
+        }
+    }
+
+    private fun extractToken(uri: Uri): String? {
+        if (uri.scheme.isNullOrBlank()) return null
+
+        val segments = uri.pathSegments ?: return null
+        // Expected: /r/{project_uid}/{token}
+        if (segments.size < REDEEM_PATH_MIN_SEGMENTS) return null
+        if (segments[0] != REDEEM_PATH_PREFIX) return null
+
+        val token = segments.getOrNull(REDEEM_TOKEN_SEGMENT_INDEX)?.trim()
+        return token?.takeIf { it.isNotBlank() }
+    }
+
+    private fun deliver(callback: QonversionRedemptionCallback, result: RedemptionResult) {
+        postToMainThread { callback.onResult(result) }
+    }
+
+    private fun deliverReissue(callback: (ReissueResult) -> Unit, result: ReissueResult) {
+        postToMainThread { callback(result) }
+    }
+
+    private fun postToMainThread(runnable: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            runnable()
+        } else {
+            handler.post(runnable)
+        }
+    }
+
+    /** Internal-only reissue outcome surfaced to the dialog. */
+    internal enum class ReissueResult {
+        Sent,
+        RateLimited,
+        ServerError,
+    }
+
+    private companion object {
+        const val HTTP_CONFLICT = 409
+        const val HTTP_NOT_FOUND = 404
+        const val HTTP_GONE = 410
+        const val HTTP_TOO_MANY_REQUESTS = 429
+        val HTTP_SERVER_ERROR_RANGE = 500..599
+
+        const val REDEEM_PATH_PREFIX = "r"
+        // Path segments are 0-indexed after the leading "/", so /r/{project}/{token}
+        // → segments = ["r", "{project}", "{token}"], token is at index 2.
+        const val REDEEM_TOKEN_SEGMENT_INDEX = 2
+        const val REDEEM_PATH_MIN_SEGMENTS = 3
+    }
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -6,6 +6,7 @@ import android.os.Looper
 import com.qonversion.android.sdk.dto.redemption.RedemptionResult
 import com.qonversion.android.sdk.internal.InternalConfig
 import com.qonversion.android.sdk.internal.api.Api
+import com.qonversion.android.sdk.internal.dto.redemption.RedeemResponse
 import com.qonversion.android.sdk.internal.dto.request.RedeemReissueRequest
 import com.qonversion.android.sdk.internal.dto.request.RedeemRequest
 import com.qonversion.android.sdk.internal.dto.request.RedeemStatusRequest
@@ -16,6 +17,7 @@ import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
 import java.security.MessageDigest
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
+import retrofit2.Response
 
 /**
  * Coordinates Web2App redemption: parses the email App Link, calls
@@ -63,10 +65,10 @@ internal class RedemptionManager(
      * POSTs `/v4/web/redeem`, and invokes [callback] on the main thread with the
      * terminal [RedemptionResult]. See [RedemptionResult] for case semantics.
      */
-    // The post-redeem entitlements refresh is best-effort: any failure there
-    // must not fail the already-successful redeem, so we intentionally catch
-    // broadly and only log.
-    @Suppress("TooGenericExceptionCaught")
+    // Sequential precondition guard clauses (token, app_uid, in-flight) read
+    // clearer as early returns than nested conditionals; exceeds detekt's
+    // default ReturnCount of 2 by design.
+    @Suppress("ReturnCount")
     fun handleRedemptionLink(uri: Uri, callback: QonversionRedemptionCallback) {
         val token = extractToken(uri)
         if (token == null) {
@@ -118,50 +120,61 @@ internal class RedemptionManager(
 
         api.redeem(request, idempotencyKey).enqueue {
             onResponse = { response ->
-                when {
-                    response.isSuccessful -> {
-                        // Grant-first: the server already attached the entitlement
-                        // to app_uid. We do NOT identify/merge a client user id;
-                        // we only refresh entitlements so the grant shows up on
-                        // this device. Best-effort — refresh failure must not fail
-                        // the already-successful redeem.
-                        try {
-                            refreshEntitlements()
-                        } catch (t: Throwable) {
-                            logger.error(
-                                "RedemptionManager: entitlements refresh after redeem threw: $t"
-                            )
-                        }
-                        deliver(callback, RedemptionResult.Success)
-                    }
-                    response.code() == HTTP_CONFLICT -> {
-                        // Disambiguate consumed vs other 409 via /redeem/status.
-                        // Same logical redeem → reuse the same Idempotency-Key.
-                        resolveConflict(token, idempotencyKey, callback)
-                    }
-                    response.code() == HTTP_NOT_FOUND -> {
-                        deliver(callback, RedemptionResult.InvalidToken)
-                    }
-                    response.code() == HTTP_GONE -> {
-                        deliver(callback, RedemptionResult.TokenExpired)
-                    }
-                    else -> {
-                        // 429 (rate limit), 5xx (server error) and any other
-                        // non-mapped 4xx (401/403/etc.): the server was reachable
-                        // and responded, so this is NOT a "no network" condition.
-                        // Surface Retryable (parity with iOS) so the host shows a
-                        // back-off/retry affordance, not a misleading offline error.
-                        logger.error(
-                            "RedemptionManager: redeem reachable but non-success ${response.code()} — " +
-                                "treating as Retryable."
-                        )
-                        deliver(callback, RedemptionResult.Retryable)
-                    }
-                }
+                onRedeemResponse(response, token, idempotencyKey, callback)
             }
             onFailure = { t ->
                 logger.error("RedemptionManager: redeem network failure: $t")
                 deliver(callback, RedemptionResult.NetworkError)
+            }
+        }
+    }
+
+    // The post-redeem entitlements refresh is best-effort: any failure there
+    // must not fail the already-successful redeem, so we intentionally catch
+    // broadly and only log.
+    @Suppress("TooGenericExceptionCaught")
+    private fun onRedeemResponse(
+        response: Response<RedeemResponse>,
+        token: String,
+        idempotencyKey: String,
+        callback: QonversionRedemptionCallback,
+    ) {
+        when {
+            response.isSuccessful -> {
+                // Grant-first: the server already attached the entitlement to
+                // app_uid. We do NOT identify/merge a client user id; we only
+                // refresh entitlements so the grant shows up on this device.
+                // Best-effort — refresh failure must not fail the already-
+                // successful redeem.
+                try {
+                    refreshEntitlements()
+                } catch (t: Throwable) {
+                    logger.error("RedemptionManager: entitlements refresh after redeem threw: $t")
+                }
+                deliver(callback, RedemptionResult.Success)
+            }
+            response.code() == HTTP_CONFLICT -> {
+                // Disambiguate consumed vs other 409 via /redeem/status. Same
+                // logical redeem → reuse the same Idempotency-Key.
+                resolveConflict(token, idempotencyKey, callback)
+            }
+            response.code() == HTTP_NOT_FOUND -> {
+                deliver(callback, RedemptionResult.InvalidToken)
+            }
+            response.code() == HTTP_GONE -> {
+                deliver(callback, RedemptionResult.TokenExpired)
+            }
+            else -> {
+                // 429 (rate limit), 5xx (server error) and any other non-mapped
+                // 4xx (401/403/etc.): the server was reachable and responded, so
+                // this is NOT a "no network" condition. Surface Retryable
+                // (parity with iOS) so the host shows a back-off/retry
+                // affordance, not a misleading offline error.
+                logger.error(
+                    "RedemptionManager: redeem reachable but non-success ${response.code()} — " +
+                        "treating as Retryable."
+                )
+                deliver(callback, RedemptionResult.Retryable)
             }
         }
     }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -16,23 +16,30 @@ import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Coordinates Web2App redemption: parses the email App Link, calls
- * `POST /v4/web/redeem`, disambiguates 409 via `/v4/web/redeem/status`, and
- * triggers the SDK identify-flow for the merge (RT4-W2).
+ * `POST /v4/web/redeem`, disambiguates 409 via `/v4/web/redeem/status`, and on
+ * success triggers an entitlements refresh so the server-side grant is
+ * reflected on the device.
+ *
+ * Web2App M1.5 is grant-first: the backend attaches the entitlement to the
+ * `app_uid` the SDK sends, and the redeem response is `{redeemed, app_uid}`
+ * with no user id. The SDK therefore does NOT identify/merge any client user
+ * id after redeem — it only refreshes entitlements.
  *
  * The reissue endpoint is also exposed here so the reissue dialog UI doesn't
  * need its own networking — it forwards through this manager.
  *
  * All public callbacks are dispatched on the main thread.
  *
- * Note: the SDK identify call is invoked through the supplied [identifyUser]
- * lambda rather than a direct reference to the product center manager so this
- * class stays unit-testable without spinning up the full DI graph.
+ * Note: the entitlements refresh is invoked through the supplied
+ * [refreshEntitlements] lambda rather than a direct reference to the product
+ * center manager so this class stays unit-testable without spinning up the
+ * full DI graph.
  */
 internal class RedemptionManager(
     private val api: Api,
     private val internalConfig: InternalConfig,
     private val logger: Logger,
-    private val identifyUser: (userId: String) -> Unit,
+    private val refreshEntitlements: () -> Unit,
 ) {
 
     private val handler = Handler(Looper.getMainLooper())
@@ -41,7 +48,7 @@ internal class RedemptionManager(
      * Token of the redemption currently in flight, or `null` when idle. Guards
      * against a double/race redemption (e.g. `onCreate` + `onNewIntent`, or a
      * fast double tap) firing two parallel `POST /v4/web/redeem` calls and two
-     * `identify` calls. Reset to `null` on every terminal [deliver].
+     * entitlement refreshes. Reset to `null` on every terminal [deliver].
      */
     private val inFlightToken = AtomicReference<String?>(null)
 
@@ -50,9 +57,9 @@ internal class RedemptionManager(
      * POSTs `/v4/web/redeem`, and invokes [callback] on the main thread with the
      * terminal [RedemptionResult]. See [RedemptionResult] for case semantics.
      */
-    // The post-redeem identify is best-effort: any failure there must not
-    // fail the already-successful redeem, so we intentionally catch broadly
-    // and only log.
+    // The post-redeem entitlements refresh is best-effort: any failure there
+    // must not fail the already-successful redeem, so we intentionally catch
+    // broadly and only log.
     @Suppress("TooGenericExceptionCaught")
     fun handleRedemptionLink(uri: Uri, callback: QonversionRedemptionCallback) {
         val token = extractToken(uri)
@@ -68,7 +75,7 @@ internal class RedemptionManager(
         }
 
         // In-flight guard: if a redemption is already running, drop this call so
-        // we don't fire a second POST / second identify. CAS null -> token.
+        // we don't fire a second POST / second refresh. CAS null -> token.
         if (!inFlightToken.compareAndSet(null, token)) {
             logger.error("RedemptionManager: redemption already in flight — ignoring duplicate link.")
             return
@@ -76,28 +83,23 @@ internal class RedemptionManager(
 
         val request = RedeemRequest(
             token = token,
-            anonUserId = internalConfig.uid.takeIf { it.isNotBlank() },
+            appUid = internalConfig.uid.takeIf { it.isNotBlank() },
         )
 
         api.redeem(request).enqueue {
             onResponse = { response ->
                 when {
                     response.isSuccessful -> {
-                        val userId = response.body()?.userId
-                        if (!userId.isNullOrBlank()) {
-                            // Trigger merge: identify the (now anon) device user
-                            // with the Qonversion user id returned by redeem.
-                            try {
-                                identifyUser(userId)
-                            } catch (t: Throwable) {
-                                logger.error(
-                                    "RedemptionManager: identify after redeem threw: $t"
-                                )
-                            }
-                        } else {
+                        // Grant-first: the server already attached the entitlement
+                        // to app_uid. We do NOT identify/merge a client user id;
+                        // we only refresh entitlements so the grant shows up on
+                        // this device. Best-effort — refresh failure must not fail
+                        // the already-successful redeem.
+                        try {
+                            refreshEntitlements()
+                        } catch (t: Throwable) {
                             logger.error(
-                                "RedemptionManager: redeem 200 with empty user_id — " +
-                                    "skipping identify, host should call checkEntitlements."
+                                "RedemptionManager: entitlements refresh after redeem threw: $t"
                             )
                         }
                         deliver(callback, RedemptionResult.Success)

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/RedemptionManager.kt
@@ -78,7 +78,7 @@ internal class RedemptionManager(
                 "RedemptionManager: malformed or untrusted redemption Uri " +
                     "(scheme=${uri.scheme}, host=${uri.host}) — no valid token segment found."
             )
-            deliver(callback, RedemptionResult.InvalidToken)
+            rejectWithoutGuard(callback, RedemptionResult.InvalidToken)
             return
         }
 
@@ -90,19 +90,19 @@ internal class RedemptionManager(
         val appUid = internalConfig.uid.takeIf { it.isNotBlank() }
         if (appUid == null) {
             logger.error("RedemptionManager: no app_uid available yet — skipping redeem (retryable).")
-            deliver(callback, RedemptionResult.Retryable)
+            rejectWithoutGuard(callback, RedemptionResult.Retryable)
             return
         }
 
         // In-flight guard: if a redemption is already running, reject this call
         // so we don't fire a second POST / second refresh. CAS null -> token.
         // The callback MUST still fire (Retryable) — a silent drop here strands
-        // the host UI on an eternal spinner. Note we do NOT route this through
+        // the host UI on an eternal spinner — but via [rejectWithoutGuard], NOT
         // [deliver]: the guard belongs to the redemption already in flight and
         // must not be released by this rejected call.
         if (!inFlightToken.compareAndSet(null, token)) {
             logger.error("RedemptionManager: redemption already in flight — rejecting duplicate link as retryable.")
-            postToMainThread { callback.onResult(RedemptionResult.Retryable) }
+            rejectWithoutGuard(callback, RedemptionResult.Retryable)
             return
         }
 
@@ -282,10 +282,21 @@ internal class RedemptionManager(
     }
 
     private fun deliver(callback: QonversionRedemptionCallback, result: RedemptionResult) {
-        // Terminal point of a redemption — release the in-flight guard so a
-        // later, legitimate redemption can proceed. Safe no-op when the guard
-        // was never taken (e.g. malformed/untrusted Uri short-circuit).
+        // Terminal point of a redemption that HELD the in-flight guard — release
+        // it so a later, legitimate redemption can proceed. Only call this once
+        // the CAS in [handleRedemptionLink] succeeded; for calls that were
+        // rejected before acquiring the guard use [rejectWithoutGuard], otherwise
+        // this unconditional reset would free a *concurrent* redemption's guard.
         inFlightToken.set(null)
+        postToMainThread { callback.onResult(result) }
+    }
+
+    private fun rejectWithoutGuard(callback: QonversionRedemptionCallback, result: RedemptionResult) {
+        // Reject a call that never acquired the in-flight guard (malformed Uri,
+        // missing app_uid, or a duplicate link while another redeem is running).
+        // The callback MUST still fire so the host UI never strands on a spinner,
+        // but we must NOT touch [inFlightToken]: it belongs to whichever
+        // redemption currently holds it.
         postToMainThread { callback.onResult(result) }
     }
 

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/ReissueDialogFragment.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/redemption/ReissueDialogFragment.kt
@@ -1,0 +1,159 @@
+package com.qonversion.android.sdk.internal.redemption
+
+import android.app.Dialog
+import android.os.Bundle
+import android.text.InputType
+import android.util.Patterns
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.fragment.app.DialogFragment
+
+/**
+ * Modal email-input dialog used by [com.qonversion.android.sdk.Qonversion.presentReissueUI]
+ * as the fallback when a user cannot complete redemption via the email App Link.
+ *
+ * Built programmatically (no XML resource) to keep the SDK module's resource
+ * surface minimal and avoid host-app theme conflicts. Hosts can wrap this in a
+ * standard fragment transaction.
+ *
+ * The fragment exposes its outcome via [onCompletion]: `true` on a 200 send,
+ * `false` if the user cancels.
+ *
+ * The dialog is not retained across configuration changes — the host is
+ * expected to re-present on rotation if needed. This matches the iOS modal's
+ * single-shot semantics.
+ */
+internal class ReissueDialogFragment : DialogFragment() {
+
+    /**
+     * Wiring set by [com.qonversion.android.sdk.internal.QonversionInternal] before
+     * showing the fragment. Not `Parcelable`, so the dialog cannot survive a
+     * process death — by design (see class docs).
+     */
+    var redemptionManager: RedemptionManager? = null
+    var onCompletion: ((Boolean) -> Unit)? = null
+
+    private lateinit var emailInput: EditText
+    private lateinit var sendButton: Button
+    private lateinit var progress: ProgressBar
+    private lateinit var hintText: TextView
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = Dialog(requireContext())
+        dialog.setTitle("Restore your purchase")
+        dialog.setContentView(buildContent())
+        dialog.setCanceledOnTouchOutside(false)
+        dialog.setOnCancelListener {
+            onCompletion?.invoke(false)
+        }
+        return dialog
+    }
+
+    private fun buildContent(): View {
+        val ctx = requireContext()
+        val padding = (PADDING_DP * resources.displayMetrics.density).toInt()
+
+        val root = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(padding, padding, padding, padding)
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+        }
+
+        val title = TextView(ctx).apply {
+            text = "Enter the email used at checkout to receive a new restore link."
+            textSize = TITLE_TEXT_SIZE_SP
+        }
+        root.addView(title)
+
+        emailInput = EditText(ctx).apply {
+            hint = "you@example.com"
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+            setSingleLine(true)
+        }
+        root.addView(emailInput)
+
+        progress = ProgressBar(ctx).apply {
+            visibility = View.GONE
+        }
+        root.addView(progress)
+
+        hintText = TextView(ctx).apply {
+            visibility = View.GONE
+            gravity = Gravity.START
+        }
+        root.addView(hintText)
+
+        sendButton = Button(ctx).apply {
+            text = "Send"
+            setOnClickListener { onSendClicked() }
+        }
+        root.addView(sendButton)
+
+        return root
+    }
+
+    private fun onSendClicked() {
+        val email = emailInput.text?.toString()?.trim().orEmpty()
+        if (!isValidEmail(email)) {
+            hintText.text = "Please enter a valid email."
+            hintText.visibility = View.VISIBLE
+            return
+        }
+
+        val manager = redemptionManager
+        if (manager == null) {
+            // Defensive — should never happen because Qonversion wires this
+            // up before show(). Surface as a generic error so the user can
+            // close the dialog and retry.
+            hintText.text = "Something went wrong, please try again."
+            hintText.visibility = View.VISIBLE
+            return
+        }
+
+        setBusy(true)
+        manager.requestReissue(email) { result ->
+            // requestReissue already dispatches to the main thread, so it's
+            // safe to touch views here.
+            setBusy(false)
+            when (result) {
+                RedemptionManager.ReissueResult.Sent -> {
+                    onCompletion?.invoke(true)
+                    dismissAllowingStateLoss()
+                }
+                RedemptionManager.ReissueResult.RateLimited -> {
+                    hintText.text = "Too many attempts, try again later."
+                    hintText.visibility = View.VISIBLE
+                }
+                RedemptionManager.ReissueResult.ServerError -> {
+                    hintText.text = "Something went wrong, please try again."
+                    hintText.visibility = View.VISIBLE
+                }
+            }
+        }
+    }
+
+    private fun setBusy(busy: Boolean) {
+        progress.visibility = if (busy) View.VISIBLE else View.GONE
+        sendButton.isEnabled = !busy
+        emailInput.isEnabled = !busy
+    }
+
+    private fun isValidEmail(value: String): Boolean {
+        if (value.isBlank()) return false
+        return Patterns.EMAIL_ADDRESS.matcher(value).matches()
+    }
+
+    private companion object {
+        const val PADDING_DP = 16
+        const val TITLE_TEXT_SIZE_SP = 14f
+    }
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/listeners/QonversionRedemptionCallback.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/listeners/QonversionRedemptionCallback.kt
@@ -1,0 +1,13 @@
+package com.qonversion.android.sdk.listeners
+
+import com.qonversion.android.sdk.dto.redemption.RedemptionResult
+
+/**
+ * Callback used by [com.qonversion.android.sdk.Qonversion.handleRedemptionLink].
+ *
+ * Called once with the terminal [RedemptionResult] for the redemption attempt.
+ * All invocations are delivered on the main thread.
+ */
+interface QonversionRedemptionCallback {
+    fun onResult(result: RedemptionResult)
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerIdentifyContractTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerIdentifyContractTest.kt
@@ -1,0 +1,199 @@
+package com.qonversion.android.sdk.internal
+
+import android.app.Application
+import com.android.billingclient.api.Purchase
+import android.os.Build
+import com.qonversion.android.sdk.dto.QonversionError
+import com.qonversion.android.sdk.dto.QonversionErrorCode
+import com.qonversion.android.sdk.internal.api.RequestTrigger
+import com.qonversion.android.sdk.internal.billing.QonversionBillingService
+import com.qonversion.android.sdk.internal.dto.QLaunchResult
+import com.qonversion.android.sdk.internal.logger.Logger
+import com.qonversion.android.sdk.internal.provider.AppStateProvider
+import com.qonversion.android.sdk.internal.repository.QRepository
+import com.qonversion.android.sdk.internal.services.QUserInfoService
+import com.qonversion.android.sdk.internal.storage.LaunchResultCacheWrapper
+import com.qonversion.android.sdk.internal.storage.PurchasesCache
+import io.mockk.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Date
+
+/**
+ * Web 2 App M1 [RT5-N2] — contract tests for [QProductCenterManager.identify].
+ *
+ * The /v4/web/redeem/status recovery UX (DEV-845, plan §"POST
+ * /v4/web/redeem/status") relies on `Qonversion.identify(userID:)`
+ * triggering a fresh entitlement fetch via the merged identity. The
+ * SDK currently honours this implicitly: when the new identity differs
+ * from the current user id, [QProductCenterManager.processIdentity]
+ * calls `launchResultCache.clearPermissionsCache()` followed by
+ * `launch(RequestTrigger.Identify)`.
+ *
+ * If a future SDK change defers or skips the launch step (e.g.,
+ * lazy-fetch on next checkEntitlements call), the web→app recovery
+ * flow silently breaks — the user signs in but the server-side
+ * entitlement never reaches the host app. These tests pin the
+ * contract so any regression fails CI.
+ *
+ * Source of truth — Android: QProductCenterManager.kt:221-257.
+ * Symmetric iOS contract test lives in:
+ *   qonversion-ios-sdk/Tests/.../QNProductCenterManagerIdentifyContractTests.swift
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+internal class QProductCenterManagerIdentifyContractTest {
+
+    private val mockLogger: Logger = mockk(relaxed = true)
+    private val mockDeviceStorage = mockk<PurchasesCache>(relaxed = true)
+    private val mockHandledPurchasesCache = mockk<QHandledPurchasesCache>(relaxed = true)
+    private val mockLaunchResultCacheWrapper = mockk<LaunchResultCacheWrapper>(relaxed = true)
+    private val mockContext = mockk<Application>(relaxed = true)
+    private val mockRepository = mockk<QRepository>(relaxed = true)
+    private val mockUserInfoService = mockk<QUserInfoService>(relaxed = true)
+    private val mockIdentityManager = mockk<QIdentityManager>(relaxed = true)
+    private val mockBillingService = mockk<QonversionBillingService>(relaxed = true)
+    private val mockConfig = mockk<InternalConfig>(relaxed = true)
+    private val mockAppStateProvider = mockk<AppStateProvider>(relaxed = true)
+    private val mockRemoteConfigManager = mockk<QRemoteConfigManager>(relaxed = true)
+
+    private lateinit var pcm: QProductCenterManager
+
+    @Before
+    fun setUp() {
+        clearAllMocks()
+
+        // isLaunchingFinished := sessionLaunchResult != null. Set it so
+        // identify() takes the synchronous fast path (no init → identify).
+        val launchResult = QLaunchResult("uid_initial", Date(), offerings = null)
+        every { mockLaunchResultCacheWrapper.sessionLaunchResult } returns launchResult
+
+        // Force kids-mode so launch() skips AdvertisingProvider, which
+        // would otherwise spin up a background Thread and break the
+        // synchronous verifyOrder window.
+        every { mockConfig.primaryConfig.isKidsMode } returns true
+
+        // billingService.queryPurchases is the synchronous entry point
+        // into continueLaunchWithPurchasesInfo → processInit →
+        // repository.init. With the relaxed mock it's a no-op and
+        // repository.init never runs. Invoke the success lambda with an
+        // empty list so processInitDefault() fires on the same thread.
+        every {
+            mockBillingService.queryPurchases(any(), captureLambda())
+        } answers {
+            lambda<(List<Purchase>) -> Unit>().captured.invoke(emptyList())
+        }
+
+        pcm = QProductCenterManager(
+            mockContext,
+            mockRepository,
+            mockLogger,
+            mockDeviceStorage,
+            mockHandledPurchasesCache,
+            mockLaunchResultCacheWrapper,
+            mockUserInfoService,
+            mockIdentityManager,
+            mockConfig,
+            mockAppStateProvider,
+            mockRemoteConfigManager
+        )
+        pcm.billingService = mockBillingService
+    }
+
+    /**
+     * RT5-N2 happy path — different identity successfully linked: the
+     * SDK MUST clear the cached permissions AND issue a fresh launch
+     * with `RequestTrigger.Identify`. This is the wire that the web→app
+     * recovery UX depends on.
+     *
+     * If this test starts failing because someone moved the
+     * clear+launch to a lazy code path, see the [RT5-N2] note in
+     * plan §"SDK contract dependency" — the host app integration
+     * docs MUST then add an explicit `Qonversion.checkEntitlements()`
+     * call after `identify()` returns success.
+     */
+    @Test
+    fun `identify with different uid clears cache and re-launches with Identify trigger`() {
+        val newIdentity = "user@example.com"
+        val mergedUid = "uid_merged_999"
+
+        every { mockUserInfoService.obtainUserId() } returns "uid_initial"
+        // Identity manager succeeds with a DIFFERENT qonversion uid (the
+        // cross-user-success branch in processIdentity).
+        every {
+            mockIdentityManager.identify(eq(newIdentity), any())
+        } answers {
+            val cb = secondArg<IdentityManagerCallback>()
+            cb.onSuccess(mergedUid)
+        }
+
+        pcm.identify(newIdentity)
+
+        // Order matters — clear THEN re-launch. If launch reads the
+        // cache and finds stale permissions before clear, the UX is
+        // broken.
+        verifyOrder {
+            mockConfig.uid = mergedUid
+            mockRemoteConfigManager.onUserUpdate()
+            mockLaunchResultCacheWrapper.clearPermissionsCache()
+            mockRepository.init(match { it.requestTrigger == RequestTrigger.Identify })
+        }
+    }
+
+    /**
+     * Same-uid case is the "user re-identifies themselves" branch.
+     * The contract here is the OPPOSITE: the SDK MUST NOT clear cache
+     * or re-launch (would waste a request and could flash UI). Test
+     * pins the negative branch so a future patch can't accidentally
+     * always-launch.
+     */
+    @Test
+    fun `identify with same uid does NOT clear cache or re-launch`() {
+        val newIdentity = "user@example.com"
+        val sameUid = "uid_initial"
+
+        every { mockUserInfoService.obtainUserId() } returns sameUid
+        every {
+            mockIdentityManager.identify(eq(newIdentity), any())
+        } answers {
+            secondArg<IdentityManagerCallback>().onSuccess(sameUid)
+        }
+
+        pcm.identify(newIdentity)
+
+        verify(exactly = 0) { mockLaunchResultCacheWrapper.clearPermissionsCache() }
+        verify(exactly = 0) {
+            mockRepository.init(match { it.requestTrigger == RequestTrigger.Identify })
+        }
+    }
+
+    /**
+     * Identity error must NOT clear cache or re-launch — silently
+     * keeping prior entitlements is the correct fallback. Pins the
+     * error branch so future error handlers can't accidentally taint
+     * the cache.
+     */
+    @Test
+    fun `identify with identityManager error does NOT touch cache`() {
+        val newIdentity = "user@example.com"
+
+        every { mockUserInfoService.obtainUserId() } returns "uid_initial"
+        every {
+            mockIdentityManager.identify(eq(newIdentity), any())
+        } answers {
+            secondArg<IdentityManagerCallback>().onError(
+                QonversionError(QonversionErrorCode.BackendError)
+            )
+        }
+
+        pcm.identify(newIdentity)
+
+        verify(exactly = 0) { mockLaunchResultCacheWrapper.clearPermissionsCache() }
+        verify(exactly = 0) {
+            mockRepository.init(match { it.requestTrigger == RequestTrigger.Identify })
+        }
+    }
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerIdentifyContractTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerIdentifyContractTest.kt
@@ -23,21 +23,23 @@ import org.robolectric.annotation.Config
 import java.util.Date
 
 /**
- * Web 2 App M1 [RT5-N2] — contract tests for [QProductCenterManager.identify].
+ * Contract tests for [QProductCenterManager.identify].
  *
- * The /v4/web/redeem/status recovery UX (DEV-845, plan §"POST
- * /v4/web/redeem/status") relies on `Qonversion.identify(userID:)`
- * triggering a fresh entitlement fetch via the merged identity. The
- * SDK currently honours this implicitly: when the new identity differs
- * from the current user id, [QProductCenterManager.processIdentity]
- * calls `launchResultCache.clearPermissionsCache()` followed by
- * `launch(RequestTrigger.Identify)`.
+ * NOTE — these are NOT Web2App redemption tests. Web2App redemption is
+ * grant-first: the entitlement is granted server-side to `app_uid` and the SDK
+ * only refreshes entitlements (`launch(ActualizePermissions)`); it does NOT
+ * call `identify`/merge. That path is covered by `RedemptionManagerTest`
+ * (`RT5-N2 contract — success path triggers entitlements refresh ... and never
+ * identifies`). These tests instead pin the behaviour of the general public
+ * `identify(userID:)` API, which is unrelated to redemption.
  *
- * If a future SDK change defers or skips the launch step (e.g.,
- * lazy-fetch on next checkEntitlements call), the web→app recovery
- * flow silently breaks — the user signs in but the server-side
- * entitlement never reaches the host app. These tests pin the
- * contract so any regression fails CI.
+ * The contract: when the new identity differs from the current user id,
+ * [QProductCenterManager.processIdentity] calls
+ * `launchResultCache.clearPermissionsCache()` followed by
+ * `launch(RequestTrigger.Identify)`. If a future SDK change defers or skips the
+ * launch step (e.g. lazy-fetch on next checkEntitlements call), a user who
+ * identifies signs in but the server-side entitlement never reaches the host
+ * app. These tests pin the contract so any regression fails CI.
  *
  * Source of truth — Android: QProductCenterManager.kt:221-257.
  * Symmetric iOS contract test lives in:
@@ -104,16 +106,15 @@ internal class QProductCenterManagerIdentifyContractTest {
     }
 
     /**
-     * RT5-N2 happy path — different identity successfully linked: the
-     * SDK MUST clear the cached permissions AND issue a fresh launch
-     * with `RequestTrigger.Identify`. This is the wire that the web→app
-     * recovery UX depends on.
+     * Happy path — different identity successfully linked: the SDK MUST clear
+     * the cached permissions AND issue a fresh launch with
+     * `RequestTrigger.Identify`, so the newly identified user's entitlements are
+     * fetched rather than served stale from the previous user's cache.
      *
-     * If this test starts failing because someone moved the
-     * clear+launch to a lazy code path, see the [RT5-N2] note in
-     * plan §"SDK contract dependency" — the host app integration
-     * docs MUST then add an explicit `Qonversion.checkEntitlements()`
-     * call after `identify()` returns success.
+     * If this test starts failing because someone moved the clear+launch to a
+     * lazy code path, host apps that rely on `identify()` refreshing
+     * entitlements would need to add an explicit `Qonversion.checkEntitlements()`
+     * after `identify()` returns success.
      */
     @Test
     fun `identify with different uid clears cache and re-launches with Identify trigger`() {

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
@@ -304,6 +304,90 @@ internal class RedemptionManagerTest {
     }
 
     @Test
+    fun `handleRedemptionLink maps 429 rate limit to Retryable (not NetworkError)`() {
+        // #1 parity with iOS: a live 429 means the server is reachable and asked
+        // the client to back off — surfacing NetworkError would show a wrong
+        // "no internet" UX. Must be Retryable.
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_429")
+        every { api.redeem(any()) } returns alwaysErrorCall(429)
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.Retryable, callback.received)
+    }
+
+    @Test
+    fun `handleRedemptionLink maps 503 server error to Retryable (not NetworkError)`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_503")
+        every { api.redeem(any()) } returns alwaysErrorCall(503)
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.Retryable, callback.received)
+    }
+
+    @Test
+    fun `handleRedemptionLink maps 401 auth error to Retryable (not NetworkError)`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_401")
+        every { api.redeem(any()) } returns alwaysErrorCall(401)
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.Retryable, callback.received)
+    }
+
+    @Test
+    fun `handleRedemptionLink with blank app_uid returns Retryable WITHOUT any network call`() {
+        // #2 fail-fast (parity with iOS): redeem tokens are single-use. Firing a
+        // redeem with no app_uid would burn the token server-side with no user
+        // to attach the grant to. When the SDK has no usable app_uid yet, surface
+        // Retryable and issue NO network request.
+        every { internalConfig.uid } returns ""
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_nouid")
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.Retryable, callback.received)
+        verify(exactly = 0) { api.redeem(any()) }
+        assertEquals(0, refreshCount)
+    }
+
+    @Test
+    fun `handleRedemptionLink delivers Retryable to a second link while one is in flight`() {
+        // #6 no eternal spinner: the in-flight guard must not swallow the second
+        // legitimate link — its callback MUST fire (Retryable) instead of never
+        // being invoked, while the first redemption keeps running unaffected.
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_busy")
+        val pending = pendingCall<RedeemResponse>()
+        every { api.redeem(any()) } returns pending
+
+        val first = RecordingCallback()
+        val second = RecordingCallback()
+        manager.handleRedemptionLink(uri, first)
+        manager.handleRedemptionLink(uri, second)
+
+        flushMainLooper()
+
+        // First is still in flight (never completed); second must NOT hang.
+        assertNull(first.received)
+        assertEquals(RedemptionResult.Retryable, second.received)
+        // Still only one network request — the guard held.
+        verify(exactly = 1) { api.redeem(any()) }
+    }
+
+    @Test
     fun `handleRedemptionLink maps network failure to NetworkError`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_neterr")
         every { api.redeem(any()) } returns alwaysNetworkFailureCall()

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
@@ -11,6 +11,7 @@ import com.qonversion.android.sdk.internal.dto.request.RedeemRequest
 import com.qonversion.android.sdk.internal.dto.request.RedeemStatusRequest
 import com.qonversion.android.sdk.internal.logger.Logger
 import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
+import com.squareup.moshi.Moshi
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -19,7 +20,9 @@ import io.mockk.verify
 import okhttp3.MediaType
 import okhttp3.ResponseBody
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,7 +46,14 @@ internal class RedemptionManagerTest {
     private lateinit var api: Api
     private lateinit var internalConfig: InternalConfig
     private lateinit var logger: Logger
-    private lateinit var identifiedUserIds: MutableList<String>
+
+    /**
+     * Counts how many times the SDK triggered an entitlements refresh after a
+     * redeem. Under the grant-first contract the server has already granted the
+     * entitlement, so the SDK must NOT identify/merge — it only refreshes the
+     * device's entitlement state so the grant is reflected locally.
+     */
+    private var refreshCount: Int = 0
 
     private lateinit var manager: RedemptionManager
 
@@ -53,13 +63,13 @@ internal class RedemptionManagerTest {
         api = mockk(relaxed = true)
         internalConfig = mockk(relaxed = true)
         logger = mockk(relaxed = true)
-        identifiedUserIds = mutableListOf()
+        refreshCount = 0
         every { internalConfig.uid } returns "QON_anon_123"
         manager = RedemptionManager(
             api = api,
             internalConfig = internalConfig,
             logger = logger,
-            identifyUser = { identifiedUserIds.add(it) },
+            refreshEntitlements = { refreshCount++ },
         )
     }
 
@@ -67,7 +77,8 @@ internal class RedemptionManagerTest {
     fun `handleRedemptionLink parses token from valid Uri and posts request`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj_abc/tok_xyz")
         val captured = slot<RedeemRequest>()
-        every { api.redeem(capture(captured)) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_42"))
+        every { api.redeem(capture(captured)) } returns
+            alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -75,10 +86,42 @@ internal class RedemptionManagerTest {
         flushMainLooper()
 
         assertEquals("tok_xyz", captured.captured.token)
-        assertEquals("QON_anon_123", captured.captured.anonUserId)
+        assertEquals("QON_anon_123", captured.captured.appUid)
         assertEquals("transfer", captured.captured.restoreBehavior)
         assertEquals(RedemptionResult.Success, callback.received)
-        assertEquals(listOf("QON_user_42"), identifiedUserIds)
+        assertEquals(1, refreshCount)
+    }
+
+    @Test
+    fun `redeem request body serializes to canonical contract (token, app_uid, restore_behavior)`() {
+        // Golden contract test: pins the OUTGOING JSON keys so a regression to
+        // the old "anon_user_id" name (api-gateway/purchaseman read "app_uid")
+        // turns this red. Uses the real Moshi adapter the SDK ships with.
+        val moshi = Moshi.Builder().build()
+        val json = moshi.adapter(RedeemRequest::class.java).toJson(
+            RedeemRequest(token = "tok_xyz", appUid = "QON_anon_123"),
+        )
+
+        assertTrue("must send token", json.contains("\"token\":\"tok_xyz\""))
+        assertTrue("must send app_uid", json.contains("\"app_uid\":\"QON_anon_123\""))
+        assertTrue(
+            "must send restore_behavior",
+            json.contains("\"restore_behavior\":\"transfer\""),
+        )
+        // Regression guard: the old field name must be gone.
+        assertFalse("anon_user_id must NOT be sent", json.contains("anon_user_id"))
+    }
+
+    @Test
+    fun `redeem response parses canonical contract (redeemed, app_uid) and has no user_id`() {
+        // Golden contract test: pins the INCOMING JSON shape {redeemed, app_uid}.
+        // A regression that re-adds user_id parsing would not satisfy this.
+        val moshi = Moshi.Builder().build()
+        val parsed = moshi.adapter(RedeemResponse::class.java)
+            .fromJson("{\"redeemed\":true,\"app_uid\":\"QON_anon_123\"}")
+
+        assertEquals(true, parsed?.redeemed)
+        assertEquals("QON_anon_123", parsed?.appUid)
     }
 
     @Test
@@ -101,7 +144,7 @@ internal class RedemptionManagerTest {
         // Load-bearing security assertion: the token must NEVER leak over the
         // wire when the scheme is rejected.
         verify(exactly = 0) { api.redeem(any()) }
-        assertEquals(emptyList<String>(), identifiedUserIds)
+        assertEquals(0, refreshCount)
     }
 
     @Test
@@ -121,13 +164,13 @@ internal class RedemptionManagerTest {
         // Load-bearing security assertion: the token must NEVER leak over the
         // wire when the host is not the canonical App Link host.
         verify(exactly = 0) { api.redeem(any()) }
-        assertEquals(emptyList<String>(), identifiedUserIds)
+        assertEquals(0, refreshCount)
     }
 
     @Test
     fun `handleRedemptionLink accepts canonical host case-insensitively`() {
         val uri = Uri.parse("https://SCREENS.QONVERSION.IO/r/proj/tok_case")
-        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_case"))
+        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -160,7 +203,7 @@ internal class RedemptionManagerTest {
     @Test
     fun `handleRedemptionLink allows a fresh redemption after the previous one terminates`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_again")
-        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_again"))
+        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         manager.handleRedemptionLink(uri, RecordingCallback())
         flushMainLooper()
@@ -184,7 +227,7 @@ internal class RedemptionManagerTest {
         // Should never have hit the network for a malformed Uri.
         verify(exactly = 0) { api.redeem(any()) }
         // No identify should have been triggered either.
-        assertEquals(emptyList<String>(), identifiedUserIds)
+        assertEquals(0, refreshCount)
     }
 
     @Test
@@ -201,9 +244,9 @@ internal class RedemptionManagerTest {
     }
 
     @Test
-    fun `handleRedemptionLink maps 200 to Success and triggers identify`() {
+    fun `handleRedemptionLink maps 200 to Success and triggers entitlements refresh`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_ok")
-        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_99"))
+        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -211,7 +254,7 @@ internal class RedemptionManagerTest {
         flushMainLooper()
 
         assertEquals(RedemptionResult.Success, callback.received)
-        assertEquals(listOf("QON_user_99"), identifiedUserIds)
+        assertEquals(1, refreshCount)
     }
 
     @Test
@@ -229,9 +272,9 @@ internal class RedemptionManagerTest {
 
         assertEquals("tok_used", statusCaptured.captured.token)
         assertEquals(RedemptionResult.AlreadyConsumed, callback.received)
-        // identify must NOT be called on AlreadyConsumed — the host is in
-        // recovery flow, not merge flow.
-        assertEquals(emptyList<String>(), identifiedUserIds)
+        // No entitlements refresh on AlreadyConsumed — nothing was granted on
+        // this device, the host is in recovery flow.
+        assertEquals(0, refreshCount)
     }
 
     @Test
@@ -274,29 +317,30 @@ internal class RedemptionManagerTest {
     }
 
     /**
-     * RT5-N2 contract test: a successful redemption MUST cause `identify` to
-     * be invoked on the product center manager so the SDK runs a new launch
-     * and pulls the freshly-granted entitlements.
+     * RT5-N2 contract test (grant-first): a successful redemption MUST NOT
+     * identify/merge a client-supplied user id — under grant-first the server
+     * has already attached the entitlement to `app_uid`. Instead the SDK must
+     * trigger exactly one entitlements refresh so the server grant is reflected
+     * on the device.
      *
      * We assert the contract at the [RedemptionManager] boundary (its
-     * `identifyUser` lambda is the seam where it hands off to
-     * `QProductCenterManager.identify`). A full end-to-end contract test that
-     * asserts `identify(newUserId)` triggers a network launch / permissions
-     * fetch should live next to the product center manager and exercise the
-     * real `QProductCenterManager`. See [com.qonversion.android.sdk.internal
-     * .QProductCenterManager.identify] — adding that integration-style test
-     * requires staging the full launch state machine and is tracked
-     * separately (DEV-847 follow-up).
+     * `refreshEntitlements` lambda is the seam where it hands off to
+     * `QProductCenterManager.launch(ActualizePermissions)`). A full end-to-end
+     * test asserting that the refresh triggers a real network launch / permissions
+     * fetch should live next to the product center manager and exercise the real
+     * `QProductCenterManager`; adding that integration-style test requires staging
+     * the full launch state machine and is tracked separately (DEV-847 follow-up).
      */
     @Test
-    fun `RT5-N2 contract — success path forwards Qonversion user id to identify exactly once`() {
+    fun `RT5-N2 contract — success path triggers entitlements refresh exactly once and never identifies`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_contract")
-        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_contract"))
+        every { api.redeem(any()) } returns
+            alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         manager.handleRedemptionLink(uri, RecordingCallback())
         flushMainLooper()
 
-        assertEquals(listOf("QON_user_contract"), identifiedUserIds)
+        assertEquals(1, refreshCount)
     }
 
     // --- Helpers ---------------------------------------------------------

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
@@ -105,6 +105,73 @@ internal class RedemptionManagerTest {
     }
 
     @Test
+    fun `handleRedemptionLink rejects foreign https host without network call (RT2-W3 host)`() {
+        // Security: scheme==https alone is not enough. An attacker-controlled
+        // host (`https://attacker.com/r/proj/tok`) would otherwise leak the
+        // redemption token to a third-party backend. The SDK MUST reject any
+        // host other than the canonical App Link host before any network call.
+        val uri = Uri.parse("https://attacker.com/r/proj_abc/tok_xyz")
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.InvalidToken, callback.received)
+        // Load-bearing security assertion: the token must NEVER leak over the
+        // wire when the host is not the canonical App Link host.
+        verify(exactly = 0) { api.redeem(any()) }
+        assertEquals(emptyList<String>(), identifiedUserIds)
+    }
+
+    @Test
+    fun `handleRedemptionLink accepts canonical host case-insensitively`() {
+        val uri = Uri.parse("https://SCREENS.QONVERSION.IO/r/proj/tok_case")
+        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_case"))
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.Success, callback.received)
+        verify(exactly = 1) { api.redeem(any()) }
+    }
+
+    @Test
+    fun `handleRedemptionLink guards against in-flight double redemption (no second request)`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_race")
+        // A call that never invokes its callback — keeps the redemption
+        // in-flight so the second tap collides with the first.
+        val pending = pendingCall<RedeemResponse>()
+        every { api.redeem(any()) } returns pending
+
+        manager.handleRedemptionLink(uri, RecordingCallback())
+        // Second tap (e.g. onCreate + onNewIntent, or a fast double tap) for the
+        // same token while the first POST is still in flight.
+        manager.handleRedemptionLink(uri, RecordingCallback())
+
+        flushMainLooper()
+
+        // Only ONE network request must have been issued for the same token.
+        verify(exactly = 1) { api.redeem(any()) }
+    }
+
+    @Test
+    fun `handleRedemptionLink allows a fresh redemption after the previous one terminates`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_again")
+        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_again"))
+
+        manager.handleRedemptionLink(uri, RecordingCallback())
+        flushMainLooper()
+        // First redemption terminated (Success delivered) — guard must be reset.
+        manager.handleRedemptionLink(uri, RecordingCallback())
+        flushMainLooper()
+
+        verify(exactly = 2) { api.redeem(any()) }
+    }
+
+    @Test
     fun `handleRedemptionLink returns InvalidToken when Uri is malformed`() {
         val uri = Uri.parse("https://screens.qonversion.io/some/other/path")
 
@@ -259,6 +326,13 @@ internal class RedemptionManagerTest {
             val resp: Response<T> = Response.error(code, errBody)
             cb.onResponse(call, resp)
         }
+        return call
+    }
+
+    /** A call whose [Call.enqueue] never invokes the callback — stays in-flight. */
+    private fun <T> pendingCall(): Call<T> {
+        val call = mockk<Call<T>>(relaxed = true)
+        every { call.enqueue(any()) } answers { /* never completes */ }
         return call
     }
 

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
@@ -400,6 +400,37 @@ internal class RedemptionManagerTest {
     }
 
     @Test
+    fun `a rejected link arriving mid-flight must not release the in-flight redemption's guard`() {
+        // Regression (#2/#6 interaction): a call rejected BEFORE acquiring the
+        // guard (here: a malformed/untrusted Uri) must reject without touching
+        // inFlightToken. If it incorrectly routed through deliver() it would
+        // reset the guard of the redemption already running, letting a later
+        // valid link fire a SECOND POST / second refresh on the same device.
+        val valid = Uri.parse("https://screens.qonversion.io/r/proj/tok_busy")
+        every { api.redeem(any(), any()) } returns pendingCall<RedeemResponse>()
+
+        val first = RecordingCallback()
+        manager.handleRedemptionLink(valid, first) // acquires the guard, stays in flight
+
+        // A junk deep link arrives while the redeem is pending → rejected.
+        val malformed = Uri.parse("https://evil.example.com/not/a/redeem")
+        val intruder = RecordingCallback()
+        manager.handleRedemptionLink(malformed, intruder)
+        flushMainLooper()
+        assertEquals(RedemptionResult.InvalidToken, intruder.received)
+
+        // The guard must still be held: a subsequent VALID link is rejected
+        // Retryable and fires NO new network call.
+        val second = RecordingCallback()
+        manager.handleRedemptionLink(valid, second)
+        flushMainLooper()
+
+        assertNull(first.received)
+        assertEquals(RedemptionResult.Retryable, second.received)
+        verify(exactly = 1) { api.redeem(any(), any()) }
+    }
+
+    @Test
     fun `handleRedemptionLink maps network failure to NetworkError`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_neterr")
         every { api.redeem(any(), any()) } returns alwaysNetworkFailureCall()

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
@@ -10,7 +10,9 @@ import com.qonversion.android.sdk.internal.dto.redemption.RedeemStatusResponse
 import com.qonversion.android.sdk.internal.dto.request.RedeemRequest
 import com.qonversion.android.sdk.internal.dto.request.RedeemStatusRequest
 import com.qonversion.android.sdk.internal.logger.Logger
+import com.qonversion.android.sdk.internal.storage.Cache
 import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
+import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -57,18 +59,28 @@ internal class RedemptionManagerTest {
 
     private lateinit var manager: RedemptionManager
 
+    /**
+     * In-memory [Cache] standing in for the SDK's SharedPreferences-backed
+     * cache. Persists across [RedemptionManager] instances within a test so we
+     * can simulate a cold-start (new manager, same backing store) for the
+     * Idempotency-Key dedup contract.
+     */
+    private lateinit var fakeCache: FakeCache
+
     @Before
     fun setUp() {
         clearAllMocks()
         api = mockk(relaxed = true)
         internalConfig = mockk(relaxed = true)
         logger = mockk(relaxed = true)
+        fakeCache = FakeCache()
         refreshCount = 0
         every { internalConfig.uid } returns "QON_anon_123"
         manager = RedemptionManager(
             api = api,
             internalConfig = internalConfig,
             logger = logger,
+            cache = fakeCache,
             refreshEntitlements = { refreshCount++ },
         )
     }
@@ -77,7 +89,7 @@ internal class RedemptionManagerTest {
     fun `handleRedemptionLink parses token from valid Uri and posts request`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj_abc/tok_xyz")
         val captured = slot<RedeemRequest>()
-        every { api.redeem(capture(captured)) } returns
+        every { api.redeem(capture(captured), any()) } returns
             alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         val callback = RecordingCallback()
@@ -143,7 +155,7 @@ internal class RedemptionManagerTest {
         assertEquals(RedemptionResult.InvalidToken, callback.received)
         // Load-bearing security assertion: the token must NEVER leak over the
         // wire when the scheme is rejected.
-        verify(exactly = 0) { api.redeem(any()) }
+        verify(exactly = 0) { api.redeem(any(), any()) }
         assertEquals(0, refreshCount)
     }
 
@@ -163,14 +175,14 @@ internal class RedemptionManagerTest {
         assertEquals(RedemptionResult.InvalidToken, callback.received)
         // Load-bearing security assertion: the token must NEVER leak over the
         // wire when the host is not the canonical App Link host.
-        verify(exactly = 0) { api.redeem(any()) }
+        verify(exactly = 0) { api.redeem(any(), any()) }
         assertEquals(0, refreshCount)
     }
 
     @Test
     fun `handleRedemptionLink accepts canonical host case-insensitively`() {
         val uri = Uri.parse("https://SCREENS.QONVERSION.IO/r/proj/tok_case")
-        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
+        every { api.redeem(any(), any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -178,7 +190,7 @@ internal class RedemptionManagerTest {
         flushMainLooper()
 
         assertEquals(RedemptionResult.Success, callback.received)
-        verify(exactly = 1) { api.redeem(any()) }
+        verify(exactly = 1) { api.redeem(any(), any()) }
     }
 
     @Test
@@ -187,7 +199,7 @@ internal class RedemptionManagerTest {
         // A call that never invokes its callback — keeps the redemption
         // in-flight so the second tap collides with the first.
         val pending = pendingCall<RedeemResponse>()
-        every { api.redeem(any()) } returns pending
+        every { api.redeem(any(), any()) } returns pending
 
         manager.handleRedemptionLink(uri, RecordingCallback())
         // Second tap (e.g. onCreate + onNewIntent, or a fast double tap) for the
@@ -197,13 +209,13 @@ internal class RedemptionManagerTest {
         flushMainLooper()
 
         // Only ONE network request must have been issued for the same token.
-        verify(exactly = 1) { api.redeem(any()) }
+        verify(exactly = 1) { api.redeem(any(), any()) }
     }
 
     @Test
     fun `handleRedemptionLink allows a fresh redemption after the previous one terminates`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_again")
-        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
+        every { api.redeem(any(), any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         manager.handleRedemptionLink(uri, RecordingCallback())
         flushMainLooper()
@@ -211,7 +223,7 @@ internal class RedemptionManagerTest {
         manager.handleRedemptionLink(uri, RecordingCallback())
         flushMainLooper()
 
-        verify(exactly = 2) { api.redeem(any()) }
+        verify(exactly = 2) { api.redeem(any(), any()) }
     }
 
     @Test
@@ -225,7 +237,7 @@ internal class RedemptionManagerTest {
 
         assertEquals(RedemptionResult.InvalidToken, callback.received)
         // Should never have hit the network for a malformed Uri.
-        verify(exactly = 0) { api.redeem(any()) }
+        verify(exactly = 0) { api.redeem(any(), any()) }
         // No identify should have been triggered either.
         assertEquals(0, refreshCount)
     }
@@ -240,13 +252,13 @@ internal class RedemptionManagerTest {
         flushMainLooper()
 
         assertEquals(RedemptionResult.InvalidToken, callback.received)
-        verify(exactly = 0) { api.redeem(any()) }
+        verify(exactly = 0) { api.redeem(any(), any()) }
     }
 
     @Test
     fun `handleRedemptionLink maps 200 to Success and triggers entitlements refresh`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_ok")
-        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
+        every { api.redeem(any(), any()) } returns alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -260,9 +272,9 @@ internal class RedemptionManagerTest {
     @Test
     fun `handleRedemptionLink maps 409 with consumed=true to AlreadyConsumed`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_used")
-        every { api.redeem(any()) } returns alwaysErrorCall(409)
+        every { api.redeem(any(), any()) } returns alwaysErrorCall(409)
         val statusCaptured = slot<RedeemStatusRequest>()
-        every { api.redeemStatus(capture(statusCaptured)) } returns
+        every { api.redeemStatus(capture(statusCaptured), any()) } returns
             alwaysSuccessCall(RedeemStatusResponse(consumed = true, expired = false))
 
         val callback = RecordingCallback()
@@ -280,7 +292,7 @@ internal class RedemptionManagerTest {
     @Test
     fun `handleRedemptionLink maps 404 to InvalidToken`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_404")
-        every { api.redeem(any()) } returns alwaysErrorCall(404)
+        every { api.redeem(any(), any()) } returns alwaysErrorCall(404)
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -293,7 +305,7 @@ internal class RedemptionManagerTest {
     @Test
     fun `handleRedemptionLink maps 410 to TokenExpired`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_expired")
-        every { api.redeem(any()) } returns alwaysErrorCall(410)
+        every { api.redeem(any(), any()) } returns alwaysErrorCall(410)
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -309,7 +321,7 @@ internal class RedemptionManagerTest {
         // the client to back off — surfacing NetworkError would show a wrong
         // "no internet" UX. Must be Retryable.
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_429")
-        every { api.redeem(any()) } returns alwaysErrorCall(429)
+        every { api.redeem(any(), any()) } returns alwaysErrorCall(429)
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -322,7 +334,7 @@ internal class RedemptionManagerTest {
     @Test
     fun `handleRedemptionLink maps 503 server error to Retryable (not NetworkError)`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_503")
-        every { api.redeem(any()) } returns alwaysErrorCall(503)
+        every { api.redeem(any(), any()) } returns alwaysErrorCall(503)
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -335,7 +347,7 @@ internal class RedemptionManagerTest {
     @Test
     fun `handleRedemptionLink maps 401 auth error to Retryable (not NetworkError)`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_401")
-        every { api.redeem(any()) } returns alwaysErrorCall(401)
+        every { api.redeem(any(), any()) } returns alwaysErrorCall(401)
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -360,7 +372,7 @@ internal class RedemptionManagerTest {
         flushMainLooper()
 
         assertEquals(RedemptionResult.Retryable, callback.received)
-        verify(exactly = 0) { api.redeem(any()) }
+        verify(exactly = 0) { api.redeem(any(), any()) }
         assertEquals(0, refreshCount)
     }
 
@@ -371,7 +383,7 @@ internal class RedemptionManagerTest {
         // being invoked, while the first redemption keeps running unaffected.
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_busy")
         val pending = pendingCall<RedeemResponse>()
-        every { api.redeem(any()) } returns pending
+        every { api.redeem(any(), any()) } returns pending
 
         val first = RecordingCallback()
         val second = RecordingCallback()
@@ -384,13 +396,13 @@ internal class RedemptionManagerTest {
         assertNull(first.received)
         assertEquals(RedemptionResult.Retryable, second.received)
         // Still only one network request — the guard held.
-        verify(exactly = 1) { api.redeem(any()) }
+        verify(exactly = 1) { api.redeem(any(), any()) }
     }
 
     @Test
     fun `handleRedemptionLink maps network failure to NetworkError`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_neterr")
-        every { api.redeem(any()) } returns alwaysNetworkFailureCall()
+        every { api.redeem(any(), any()) } returns alwaysNetworkFailureCall()
 
         val callback = RecordingCallback()
         manager.handleRedemptionLink(uri, callback)
@@ -418,7 +430,7 @@ internal class RedemptionManagerTest {
     @Test
     fun `RT5-N2 contract — success path triggers entitlements refresh exactly once and never identifies`() {
         val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_contract")
-        every { api.redeem(any()) } returns
+        every { api.redeem(any(), any()) } returns
             alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
 
         manager.handleRedemptionLink(uri, RecordingCallback())
@@ -427,7 +439,97 @@ internal class RedemptionManagerTest {
         assertEquals(1, refreshCount)
     }
 
+    @Test
+    fun `redeem sends an Idempotency-Key header and reuses the same key across cold-start (per token)`() {
+        // #7 parity with iOS + cold-start hardening: each logical redeem carries
+        // an Idempotency-Key. On Android the key is PERSISTED per token so a
+        // redeem retried after the app was killed/relaunched reuses the same key
+        // and the backend can still dedup — i.e. dedup survives cold-start.
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_idem")
+        val firstKey = slot<String>()
+        every { api.redeem(any(), capture(firstKey)) } returns
+            alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
+
+        manager.handleRedemptionLink(uri, RecordingCallback())
+        flushMainLooper()
+
+        assertTrue("Idempotency-Key must be sent", firstKey.isCaptured && firstKey.captured.isNotBlank())
+        val keyFromFirstRun = firstKey.captured
+
+        // Simulate a cold-start: brand new manager, SAME backing cache.
+        val coldStartManager = RedemptionManager(
+            api = api,
+            internalConfig = internalConfig,
+            logger = logger,
+            cache = fakeCache,
+            refreshEntitlements = { refreshCount++ },
+        )
+        val secondKey = slot<String>()
+        every { api.redeem(any(), capture(secondKey)) } returns
+            alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
+
+        coldStartManager.handleRedemptionLink(uri, RecordingCallback())
+        flushMainLooper()
+
+        assertEquals(
+            "same token must reuse the persisted Idempotency-Key across cold-start",
+            keyFromFirstRun,
+            secondKey.captured,
+        )
+    }
+
+    @Test
+    fun `redeem uses a distinct Idempotency-Key per distinct token`() {
+        val keyA = slot<String>()
+        every { api.redeem(any(), capture(keyA)) } returns
+            alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
+        manager.handleRedemptionLink(Uri.parse("https://screens.qonversion.io/r/proj/tok_A"), RecordingCallback())
+        flushMainLooper()
+
+        val keyB = slot<String>()
+        every { api.redeem(any(), capture(keyB)) } returns
+            alwaysSuccessCall(RedeemResponse(redeemed = true, appUid = "QON_anon_123"))
+        manager.handleRedemptionLink(Uri.parse("https://screens.qonversion.io/r/proj/tok_B"), RecordingCallback())
+        flushMainLooper()
+
+        assertTrue("distinct tokens must get distinct keys", keyA.captured != keyB.captured)
+    }
+
+    @Test
+    fun `409 recovery reuses the same Idempotency-Key as the redeem POST`() {
+        // Same logical redeem → the /status recovery call must carry the same key.
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_409idem")
+        val redeemKey = slot<String>()
+        every { api.redeem(any(), capture(redeemKey)) } returns alwaysErrorCall(409)
+        val statusKey = slot<String>()
+        every { api.redeemStatus(any(), capture(statusKey)) } returns
+            alwaysSuccessCall(RedeemStatusResponse(consumed = true, expired = false))
+
+        manager.handleRedemptionLink(uri, RecordingCallback())
+        flushMainLooper()
+
+        assertEquals(redeemKey.captured, statusKey.captured)
+    }
+
     // --- Helpers ---------------------------------------------------------
+
+    /** In-memory [Cache]; only the string ops are exercised by the manager. */
+    private class FakeCache : Cache {
+        private val strings = mutableMapOf<String, String?>()
+        override fun putString(key: String, value: String?) { strings[key] = value }
+        override fun getString(key: String, defValue: String?): String? = strings.getOrDefault(key, defValue)
+        override fun remove(key: String) { strings.remove(key) }
+        override fun putInt(key: String, value: Int) = error("unused")
+        override fun getInt(key: String, defValue: Int): Int = error("unused")
+        override fun getBool(key: String, defValue: Boolean): Boolean = error("unused")
+        override fun putBool(key: String, value: Boolean) = error("unused")
+        override fun putFloat(key: String, value: Float) = error("unused")
+        override fun getFloat(key: String, defValue: Float): Float = error("unused")
+        override fun putLong(key: String, value: Long) = error("unused")
+        override fun getLong(key: String, defValue: Long): Long = error("unused")
+        override fun <T> putObject(key: String, value: T, adapter: JsonAdapter<T>) = error("unused")
+        override fun <T> getObject(key: String, adapter: JsonAdapter<T>): T? = error("unused")
+    }
 
     private class RecordingCallback : QonversionRedemptionCallback {
         var received: RedemptionResult? = null

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
@@ -1,0 +1,254 @@
+package com.qonversion.android.sdk.internal.redemption
+
+import android.net.Uri
+import android.os.Looper
+import com.qonversion.android.sdk.dto.redemption.RedemptionResult
+import com.qonversion.android.sdk.internal.InternalConfig
+import com.qonversion.android.sdk.internal.api.Api
+import com.qonversion.android.sdk.internal.dto.redemption.RedeemResponse
+import com.qonversion.android.sdk.internal.dto.redemption.RedeemStatusResponse
+import com.qonversion.android.sdk.internal.dto.request.RedeemRequest
+import com.qonversion.android.sdk.internal.dto.request.RedeemStatusRequest
+import com.qonversion.android.sdk.internal.logger.Logger
+import com.qonversion.android.sdk.listeners.QonversionRedemptionCallback
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+/**
+ * Unit tests for [RedemptionManager].
+ *
+ * Uses Robolectric to get a real [Uri] parser and a controllable main looper.
+ * Retrofit [Call]s are hand-mocked because the SDK doesn't ship a
+ * `MockWebServer` test fixture and the surface area is small enough that
+ * inline mocks are clearer than spinning one up.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class RedemptionManagerTest {
+
+    private lateinit var api: Api
+    private lateinit var internalConfig: InternalConfig
+    private lateinit var logger: Logger
+    private lateinit var identifiedUserIds: MutableList<String>
+
+    private lateinit var manager: RedemptionManager
+
+    @Before
+    fun setUp() {
+        clearAllMocks()
+        api = mockk(relaxed = true)
+        internalConfig = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
+        identifiedUserIds = mutableListOf()
+        every { internalConfig.uid } returns "QON_anon_123"
+        manager = RedemptionManager(
+            api = api,
+            internalConfig = internalConfig,
+            logger = logger,
+            identifyUser = { identifiedUserIds.add(it) },
+        )
+    }
+
+    @Test
+    fun `handleRedemptionLink parses token from valid Uri and posts request`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj_abc/tok_xyz")
+        val captured = slot<RedeemRequest>()
+        every { api.redeem(capture(captured)) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_42"))
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals("tok_xyz", captured.captured.token)
+        assertEquals("QON_anon_123", captured.captured.anonUserId)
+        assertEquals("transfer", captured.captured.restoreBehavior)
+        assertEquals(RedemptionResult.Success, callback.received)
+        assertEquals(listOf("QON_user_42"), identifiedUserIds)
+    }
+
+    @Test
+    fun `handleRedemptionLink returns InvalidToken when Uri is malformed`() {
+        val uri = Uri.parse("https://screens.qonversion.io/some/other/path")
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.InvalidToken, callback.received)
+        // Should never have hit the network for a malformed Uri.
+        verify(exactly = 0) { api.redeem(any()) }
+        // No identify should have been triggered either.
+        assertEquals(emptyList<String>(), identifiedUserIds)
+    }
+
+    @Test
+    fun `handleRedemptionLink returns InvalidToken when path is just the prefix`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj_abc")
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.InvalidToken, callback.received)
+        verify(exactly = 0) { api.redeem(any()) }
+    }
+
+    @Test
+    fun `handleRedemptionLink maps 200 to Success and triggers identify`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_ok")
+        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_99"))
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.Success, callback.received)
+        assertEquals(listOf("QON_user_99"), identifiedUserIds)
+    }
+
+    @Test
+    fun `handleRedemptionLink maps 409 with consumed=true to AlreadyConsumed`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_used")
+        every { api.redeem(any()) } returns alwaysErrorCall(409)
+        val statusCaptured = slot<RedeemStatusRequest>()
+        every { api.redeemStatus(capture(statusCaptured)) } returns
+            alwaysSuccessCall(RedeemStatusResponse(consumed = true, expired = false))
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals("tok_used", statusCaptured.captured.token)
+        assertEquals(RedemptionResult.AlreadyConsumed, callback.received)
+        // identify must NOT be called on AlreadyConsumed — the host is in
+        // recovery flow, not merge flow.
+        assertEquals(emptyList<String>(), identifiedUserIds)
+    }
+
+    @Test
+    fun `handleRedemptionLink maps 404 to InvalidToken`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_404")
+        every { api.redeem(any()) } returns alwaysErrorCall(404)
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.InvalidToken, callback.received)
+    }
+
+    @Test
+    fun `handleRedemptionLink maps 410 to TokenExpired`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_expired")
+        every { api.redeem(any()) } returns alwaysErrorCall(410)
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.TokenExpired, callback.received)
+    }
+
+    @Test
+    fun `handleRedemptionLink maps network failure to NetworkError`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_neterr")
+        every { api.redeem(any()) } returns alwaysNetworkFailureCall()
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.NetworkError, callback.received)
+    }
+
+    /**
+     * RT5-N2 contract test: a successful redemption MUST cause `identify` to
+     * be invoked on the product center manager so the SDK runs a new launch
+     * and pulls the freshly-granted entitlements.
+     *
+     * We assert the contract at the [RedemptionManager] boundary (its
+     * `identifyUser` lambda is the seam where it hands off to
+     * `QProductCenterManager.identify`). A full end-to-end contract test that
+     * asserts `identify(newUserId)` triggers a network launch / permissions
+     * fetch should live next to the product center manager and exercise the
+     * real `QProductCenterManager`. See [com.qonversion.android.sdk.internal
+     * .QProductCenterManager.identify] — adding that integration-style test
+     * requires staging the full launch state machine and is tracked
+     * separately (DEV-847 follow-up).
+     */
+    @Test
+    fun `RT5-N2 contract — success path forwards Qonversion user id to identify exactly once`() {
+        val uri = Uri.parse("https://screens.qonversion.io/r/proj/tok_contract")
+        every { api.redeem(any()) } returns alwaysSuccessCall(RedeemResponse(userId = "QON_user_contract"))
+
+        manager.handleRedemptionLink(uri, RecordingCallback())
+        flushMainLooper()
+
+        assertEquals(listOf("QON_user_contract"), identifiedUserIds)
+    }
+
+    // --- Helpers ---------------------------------------------------------
+
+    private class RecordingCallback : QonversionRedemptionCallback {
+        var received: RedemptionResult? = null
+        override fun onResult(result: RedemptionResult) {
+            assertNull("callback invoked more than once", received)
+            received = result
+        }
+    }
+
+    private fun <T> alwaysSuccessCall(body: T): Call<T> {
+        val call = mockk<Call<T>>(relaxed = true)
+        every { call.enqueue(any()) } answers {
+            val cb = arg<Callback<T>>(0)
+            cb.onResponse(call, Response.success(body))
+        }
+        return call
+    }
+
+    private fun <T> alwaysErrorCall(code: Int): Call<T> {
+        val call = mockk<Call<T>>(relaxed = true)
+        every { call.enqueue(any()) } answers {
+            val cb = arg<Callback<T>>(0)
+            val errBody = ResponseBody.create(MediaType.parse("application/json"), "{}")
+            val resp: Response<T> = Response.error(code, errBody)
+            cb.onResponse(call, resp)
+        }
+        return call
+    }
+
+    private fun <T> alwaysNetworkFailureCall(): Call<T> {
+        val call = mockk<Call<T>>(relaxed = true)
+        every { call.enqueue(any()) } answers {
+            val cb = arg<Callback<T>>(0)
+            cb.onFailure(call, RuntimeException("simulated network failure"))
+        }
+        return call
+    }
+
+    private fun flushMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/redemption/RedemptionManagerTest.kt
@@ -82,6 +82,29 @@ internal class RedemptionManagerTest {
     }
 
     @Test
+    fun `handleRedemptionLink rejects qonversion custom-scheme Uri without network call (RT2-W3)`() {
+        // Spec rule RT2-W3: only the verified https App Link is allowed as an
+        // email-link transport on Android. Any installed app can claim a
+        // `qonversion://` intent-filter and hijack the token, so the SDK MUST
+        // reject the custom scheme before any network call. The custom scheme
+        // is reserved for in-process host→SDK forwarding (see Qonversion.kt
+        // docstring on handleRedemptionLink) and is not exercised by this
+        // public entry point.
+        val uri = Uri.parse("qonversion://screens.qonversion.io/r/proj_abc/tok_xyz")
+
+        val callback = RecordingCallback()
+        manager.handleRedemptionLink(uri, callback)
+
+        flushMainLooper()
+
+        assertEquals(RedemptionResult.InvalidToken, callback.received)
+        // Load-bearing security assertion: the token must NEVER leak over the
+        // wire when the scheme is rejected.
+        verify(exactly = 0) { api.redeem(any()) }
+        assertEquals(emptyList<String>(), identifiedUserIds)
+    }
+
+    @Test
     fun `handleRedemptionLink returns InvalidToken when Uri is malformed`() {
         val uri = Uri.parse("https://screens.qonversion.io/some/other/path")
 


### PR DESCRIPTION
**DEV-847** (Web 2 App M1 — Mobile SDK).

## Public API added

- \`Qonversion.shared.handleRedemptionLink(uri, callback)\` — App Link email→app entry; POSTs \`/v4/web/redeem\`
- \`Qonversion.shared.presentReissueUI(activity, onCompletion)\` — fallback email-input \`DialogFragment\`; POSTs \`/v4/web/redeem/reissue\`
- \`RedemptionResult\` enum — 5 cases (Success, TokenExpired, AlreadyConsumed, InvalidToken, NetworkError); mirrors iOS

## Behavior

- Parses \`https://screens.qonversion.io/r/{project_uid}/{token}\` Uri → POST \`/v4/web/redeem\`
- On 200 → existing \`Qonversion.shared.identify(userID:)\` for merge → \`Success\`
- On 409 → POST \`/v4/web/redeem/status\` → \`consumed=true\` → \`AlreadyConsumed\`
- 429/503 messaging per plan §SDK reissue UI

## Security (RT2-W3 + RT-F11)

- Email transport = **App Links only** (https + \`autoVerify=true\` + assetlinks.json on host)
- \`qonversion://\` **NOT** registered for email links in sample (hijack vector)
- Sample \`AndroidManifest.xml\` updated with App Link intent-filter

## Build + tests

- \`./gradlew :sdk:compileDebugKotlin\` — BUILD SUCCESSFUL
- \`./gradlew :sdk:assembleDebug\` — BUILD SUCCESSFUL
- \`./gradlew :sdk:testDebugUnitTest\` — 9/9 PASSED

Test coverage: Uri parsing (valid/malformed/prefix-only), 200/404/410/409/network → result mapping, RT5-N2 identify contract.

## Test plan
- [x] Uri parsing handles edge cases
- [x] Status code → RedemptionResult mapping
- [x] Identify-flow recovery on 409
- [x] App Link intent-filter in sample
- [x] qonversion:// NOT for email links
- [ ] E2E with real backend (after staging deploy)

Refs: plan §Mobile SDK API surface → Android, §DEV-847 (M1.5), RT2-W3, RT5-N2