### PR TITLE
fix(remote-config): confine QRemoteConfigManager state to the main thread (fixes ConcurrentModificationException)

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -44,7 +44,7 @@ internal class QRemoteConfigManager @Inject constructor(
     lateinit var userPropertiesManager: QUserPropertiesManager
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    fun handlePendingRequests() = runOnMainThread {
+    fun handlePendingRequests() = postToMainThread {
         loadingStates.filter { it.value.callbacks.isNotEmpty() }
             .keys.forEach { contextKey -> loadRemoteConfig(contextKey, null) }
 
@@ -62,23 +62,23 @@ internal class QRemoteConfigManager @Inject constructor(
         }
     }
 
-    fun userChangingRequestFailedWithError(error: QonversionError) = runOnMainThread {
+    fun userChangingRequestFailedWithError(error: QonversionError) = postToMainThread {
         loadingStates.keys.forEach {
             fireToCallbacks(it) { onError(error) }
         }
     }
 
-    fun onUserUpdate() = runOnMainThread {
+    fun onUserUpdate() = postToMainThread {
         loadingStates = mutableMapOf()
     }
 
-    fun loadRemoteConfig(contextKey: String?, callback: QonversionRemoteConfigCallback?) = runOnMainThread {
+    fun loadRemoteConfig(contextKey: String?, callback: QonversionRemoteConfigCallback?) = postToMainThread {
         loadingStates[contextKey]
             ?.loadedConfig
             ?.takeIf { userStateProvider.isUserStable }
             ?.let {
                 callback?.onSuccess(it)
-                return@runOnMainThread
+                return@postToMainThread
             }
 
         val loadingState = loadingStates[contextKey] ?: LoadingState()
@@ -89,7 +89,7 @@ internal class QRemoteConfigManager @Inject constructor(
         }
 
         if (!userStateProvider.isUserStable || loadingState.isInProgress) {
-            return@runOnMainThread
+            return@postToMainThread
         }
 
         loadingState.isInProgress = true
@@ -133,17 +133,17 @@ internal class QRemoteConfigManager @Inject constructor(
         contextKeys: List<String>,
         includeEmptyContextKey: Boolean,
         callback: QonversionRemoteConfigListCallback
-    ) = runOnMainThread {
+    ) = postToMainThread {
         val allKeys = if (includeEmptyContextKey) contextKeys + EmptyContextKey else contextKeys
         if (allKeys.all { loadingStates[it]?.loadedConfig != null }) {
             val configs = allKeys.mapNotNull { loadingStates[it]?.loadedConfig }
             callback.onSuccess(QRemoteConfigList(configs))
-            return@runOnMainThread
+            return@postToMainThread
         }
 
         if (!userStateProvider.isUserStable) {
             listRequests.add(ListRequestData(callback, contextKeys, includeEmptyContextKey))
-            return@runOnMainThread
+            return@postToMainThread
         }
 
         userPropertiesManager.forceSendProperties(object : QonversionEmptyCallback {
@@ -157,10 +157,10 @@ internal class QRemoteConfigManager @Inject constructor(
         })
     }
 
-    fun loadRemoteConfigList(callback: QonversionRemoteConfigListCallback) = runOnMainThread {
+    fun loadRemoteConfigList(callback: QonversionRemoteConfigListCallback) = postToMainThread {
         if (!userStateProvider.isUserStable) {
             listRequests.add(ListRequestData(callback))
-            return@runOnMainThread
+            return@postToMainThread
         }
 
         userPropertiesManager.forceSendProperties(object : QonversionEmptyCallback {
@@ -170,12 +170,12 @@ internal class QRemoteConfigManager @Inject constructor(
         })
     }
 
-    fun attachUserToExperiment(experimentId: String, groupId: String, callback: QonversionExperimentAttachCallback) = runOnMainThread {
+    fun attachUserToExperiment(experimentId: String, groupId: String, callback: QonversionExperimentAttachCallback) = postToMainThread {
         loadingStates[EmptyContextKey]?.loadedConfig = null
         remoteConfigService.attachUserToExperiment(experimentId, groupId, callback)
     }
 
-    fun detachUserFromExperiment(experimentId: String, callback: QonversionExperimentAttachCallback) = runOnMainThread {
+    fun detachUserFromExperiment(experimentId: String, callback: QonversionExperimentAttachCallback) = postToMainThread {
         loadingStates[EmptyContextKey]?.loadedConfig = null
         remoteConfigService.detachUserFromExperiment(experimentId, callback)
     }
@@ -183,7 +183,7 @@ internal class QRemoteConfigManager @Inject constructor(
     fun attachUserToRemoteConfiguration(
         remoteConfigurationId: String,
         callback: QonversionRemoteConfigurationAttachCallback
-    ) = runOnMainThread {
+    ) = postToMainThread {
         loadingStates[EmptyContextKey]?.loadedConfig = null
         remoteConfigService.attachUserToRemoteConfiguration(remoteConfigurationId, callback)
     }
@@ -191,7 +191,7 @@ internal class QRemoteConfigManager @Inject constructor(
     fun detachUserFromRemoteConfiguration(
         remoteConfigurationId: String,
         callback: QonversionRemoteConfigurationAttachCallback
-    ) = runOnMainThread {
+    ) = postToMainThread {
         loadingStates[EmptyContextKey]?.loadedConfig = null
         remoteConfigService.detachUserFromRemoteConfiguration(remoteConfigurationId, callback)
     }
@@ -257,7 +257,7 @@ internal class QRemoteConfigManager @Inject constructor(
     // removes the ConcurrentModificationException at its source without locks. Runs the
     // action inline when already on the main thread, preserving the synchronous
     // cached-config fast paths in loadRemoteConfig/loadRemoteConfigList.
-    private fun runOnMainThread(action: () -> Unit) {
+    private fun postToMainThread(action: () -> Unit) {
         if (Looper.myLooper() == Looper.getMainLooper()) {
             action()
         } else {

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -1,5 +1,7 @@
 package com.qonversion.android.sdk.internal
 
+import android.os.Handler
+import android.os.Looper
 import com.qonversion.android.sdk.dto.QFallbackObject
 import com.qonversion.android.sdk.dto.QRemoteConfig
 import com.qonversion.android.sdk.dto.QRemoteConfigList
@@ -40,12 +42,18 @@ internal class QRemoteConfigManager @Inject constructor(
     private var loadingStates = mutableMapOf<String?, LoadingState>()
     private val listRequests = mutableListOf<ListRequestData>()
     lateinit var userPropertiesManager: QUserPropertiesManager
+    private val mainHandler = Handler(Looper.getMainLooper())
 
-    fun handlePendingRequests() {
+    fun handlePendingRequests() = runOnMainThread {
         loadingStates.filter { it.value.callbacks.isNotEmpty() }
             .keys.forEach { contextKey -> loadRemoteConfig(contextKey, null) }
 
-        listRequests.forEach { requestData ->
+        // Snapshot then clear before handling: clearing stops stale requests being
+        // re-issued on every launch, and iterating the copy keeps a re-entrant add
+        // (when the user is still not stable) from mutating the list mid-iteration.
+        val pendingListRequests = listRequests.toList()
+        listRequests.clear()
+        pendingListRequests.forEach { requestData ->
             requestData.contextKeys?.let {
                 loadRemoteConfigList(it, requestData.includeEmptyContextKey, requestData.callback)
             } ?: run {
@@ -54,23 +62,23 @@ internal class QRemoteConfigManager @Inject constructor(
         }
     }
 
-    fun userChangingRequestFailedWithError(error: QonversionError) {
+    fun userChangingRequestFailedWithError(error: QonversionError) = runOnMainThread {
         loadingStates.keys.forEach {
             fireToCallbacks(it) { onError(error) }
         }
     }
 
-    fun onUserUpdate() {
+    fun onUserUpdate() = runOnMainThread {
         loadingStates = mutableMapOf()
     }
 
-    fun loadRemoteConfig(contextKey: String?, callback: QonversionRemoteConfigCallback?) {
+    fun loadRemoteConfig(contextKey: String?, callback: QonversionRemoteConfigCallback?) = runOnMainThread {
         loadingStates[contextKey]
             ?.loadedConfig
             ?.takeIf { userStateProvider.isUserStable }
             ?.let {
                 callback?.onSuccess(it)
-                return
+                return@runOnMainThread
             }
 
         val loadingState = loadingStates[contextKey] ?: LoadingState()
@@ -81,7 +89,7 @@ internal class QRemoteConfigManager @Inject constructor(
         }
 
         if (!userStateProvider.isUserStable || loadingState.isInProgress) {
-            return
+            return@runOnMainThread
         }
 
         loadingState.isInProgress = true
@@ -125,17 +133,17 @@ internal class QRemoteConfigManager @Inject constructor(
         contextKeys: List<String>,
         includeEmptyContextKey: Boolean,
         callback: QonversionRemoteConfigListCallback
-    ) {
+    ) = runOnMainThread {
         val allKeys = if (includeEmptyContextKey) contextKeys + EmptyContextKey else contextKeys
         if (allKeys.all { loadingStates[it]?.loadedConfig != null }) {
             val configs = allKeys.mapNotNull { loadingStates[it]?.loadedConfig }
             callback.onSuccess(QRemoteConfigList(configs))
-            return
+            return@runOnMainThread
         }
 
         if (!userStateProvider.isUserStable) {
             listRequests.add(ListRequestData(callback, contextKeys, includeEmptyContextKey))
-            return
+            return@runOnMainThread
         }
 
         userPropertiesManager.forceSendProperties(object : QonversionEmptyCallback {
@@ -149,10 +157,10 @@ internal class QRemoteConfigManager @Inject constructor(
         })
     }
 
-    fun loadRemoteConfigList(callback: QonversionRemoteConfigListCallback) {
+    fun loadRemoteConfigList(callback: QonversionRemoteConfigListCallback) = runOnMainThread {
         if (!userStateProvider.isUserStable) {
             listRequests.add(ListRequestData(callback))
-            return
+            return@runOnMainThread
         }
 
         userPropertiesManager.forceSendProperties(object : QonversionEmptyCallback {
@@ -162,12 +170,12 @@ internal class QRemoteConfigManager @Inject constructor(
         })
     }
 
-    fun attachUserToExperiment(experimentId: String, groupId: String, callback: QonversionExperimentAttachCallback) {
+    fun attachUserToExperiment(experimentId: String, groupId: String, callback: QonversionExperimentAttachCallback) = runOnMainThread {
         loadingStates[EmptyContextKey]?.loadedConfig = null
         remoteConfigService.attachUserToExperiment(experimentId, groupId, callback)
     }
 
-    fun detachUserFromExperiment(experimentId: String, callback: QonversionExperimentAttachCallback) {
+    fun detachUserFromExperiment(experimentId: String, callback: QonversionExperimentAttachCallback) = runOnMainThread {
         loadingStates[EmptyContextKey]?.loadedConfig = null
         remoteConfigService.detachUserFromExperiment(experimentId, callback)
     }
@@ -175,7 +183,7 @@ internal class QRemoteConfigManager @Inject constructor(
     fun attachUserToRemoteConfiguration(
         remoteConfigurationId: String,
         callback: QonversionRemoteConfigurationAttachCallback
-    ) {
+    ) = runOnMainThread {
         loadingStates[EmptyContextKey]?.loadedConfig = null
         remoteConfigService.attachUserToRemoteConfiguration(remoteConfigurationId, callback)
     }
@@ -183,7 +191,7 @@ internal class QRemoteConfigManager @Inject constructor(
     fun detachUserFromRemoteConfiguration(
         remoteConfigurationId: String,
         callback: QonversionRemoteConfigurationAttachCallback
-    ) {
+    ) = runOnMainThread {
         loadingStates[EmptyContextKey]?.loadedConfig = null
         remoteConfigService.detachUserFromRemoteConfiguration(remoteConfigurationId, callback)
     }
@@ -242,6 +250,18 @@ internal class QRemoteConfigManager @Inject constructor(
             val callbacks = loadingState.callbacks.toList()
             loadingState.callbacks.clear()
             callbacks.forEach { it.action() }
+        }
+    }
+
+    // Confines every access to the mutable loading/list state to the main thread, which
+    // removes the ConcurrentModificationException at its source without locks. Runs the
+    // action inline when already on the main thread, preserving the synchronous
+    // cached-config fast paths in loadRemoteConfig/loadRemoteConfigList.
+    private fun runOnMainThread(action: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            action()
+        } else {
+            mainHandler.post(action)
         }
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -63,7 +63,12 @@ internal class QRemoteConfigManager @Inject constructor(
     }
 
     fun userChangingRequestFailedWithError(error: QonversionError) = postToMainThread {
-        loadingStates.keys.forEach {
+        // Snapshot the keys: fireToCallbacks runs user callbacks, and a callback that
+        // re-enters loadRemoteConfig with a new key runs inline (already on the main thread)
+        // and registers that key in loadingStates. Iterating a copy keeps that re-entrant
+        // structural add from mutating the map mid-iteration. Main-thread confinement does
+        // not help here - the reentrancy is within a single thread.
+        loadingStates.keys.toList().forEach {
             fireToCallbacks(it) { onError(error) }
         }
     }

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -3,6 +3,8 @@ package com.qonversion.android.sdk.internal
 import android.os.Build
 import android.os.Looper
 import com.qonversion.android.sdk.dto.QRemoteConfig
+import com.qonversion.android.sdk.dto.QonversionError
+import com.qonversion.android.sdk.dto.QonversionErrorCode
 import com.qonversion.android.sdk.getPrivateField
 import com.qonversion.android.sdk.internal.provider.UserStateProvider
 import com.qonversion.android.sdk.internal.services.QFallbacksService
@@ -64,6 +66,25 @@ internal class QRemoteConfigManagerTest {
     }
 
     @Test
+    fun `loadRemoteConfig from a background thread defers the loadingStates mutation to the main thread`() {
+        // given - the user is not stable, so loadRemoteConfig registers a new loading state
+        every { mockUserStateProvider.isUserStable } returns false
+
+        // when - invoked from a non-main thread with a not-yet-cached context key
+        val backgroundThread = Thread { manager.loadRemoteConfig("ctx", null) }
+        backgroundThread.start()
+        backgroundThread.join()
+
+        // then - the map mutation was posted to the main looper, not applied on the
+        // background thread
+        assertEquals(0, loadingStates().size)
+
+        // and once the main looper runs, the loading state is registered on the main thread
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, loadingStates().size)
+    }
+
+    @Test
     fun `handlePendingRequests does not throw when a handled request re-enqueues itself`() {
         // given - three pending list requests queued while the user was not stable
         every { mockUserStateProvider.isUserStable } returns false
@@ -117,6 +138,41 @@ internal class QRemoteConfigManagerTest {
         try {
             repeat(iterations) {
                 manager.handlePendingRequests()
+                mainLooper.idle()
+            }
+        } catch (t: Throwable) {
+            errors.add(t)
+        }
+        adder.join()
+        mainLooper.idle()
+
+        assertTrue("Concurrent access threw: $errors", errors.isEmpty())
+    }
+
+    @Test
+    fun `concurrent loadRemoteConfig and userChangingRequestFailedWithError do not throw`() {
+        // Guards the loadingStates MAP race: userChangingRequestFailedWithError iterates
+        // loadingStates.keys on the main thread while loadRemoteConfig registers brand-new
+        // keys. Confinement serialises both onto the main thread, so the structural
+        // modification can no longer collide with the iteration.
+        every { mockUserStateProvider.isUserStable } returns false
+        val error = QonversionError(QonversionErrorCode.Unknown)
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val iterations = 1_000
+
+        val adder = Thread {
+            try {
+                repeat(iterations) { i -> manager.loadRemoteConfig("ctx_$i", null) }
+            } catch (t: Throwable) {
+                errors.add(t)
+            }
+        }
+
+        val mainLooper = shadowOf(Looper.getMainLooper())
+        adder.start()
+        try {
+            repeat(iterations) {
+                manager.userChangingRequestFailedWithError(error)
                 mainLooper.idle()
             }
         } catch (t: Throwable) {

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -1,0 +1,168 @@
+package com.qonversion.android.sdk.internal
+
+import android.os.Build
+import android.os.Looper
+import com.qonversion.android.sdk.dto.QRemoteConfig
+import com.qonversion.android.sdk.getPrivateField
+import com.qonversion.android.sdk.internal.provider.UserStateProvider
+import com.qonversion.android.sdk.internal.services.QFallbacksService
+import com.qonversion.android.sdk.internal.services.QRemoteConfigService
+import com.qonversion.android.sdk.listeners.QonversionRemoteConfigCallback
+import com.qonversion.android.sdk.listeners.QonversionRemoteConfigListCallback
+import io.mockk.Called
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.Collections
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+internal class QRemoteConfigManagerTest {
+    private val mockRemoteConfigService = mockk<QRemoteConfigService>(relaxed = true)
+    private val mockFallbacksService = mockk<QFallbacksService>(relaxed = true)
+    private val mockUserStateProvider = mockk<UserStateProvider>(relaxed = true)
+    private val mockUserPropertiesManager = mockk<QUserPropertiesManager>(relaxed = true)
+
+    private lateinit var manager: QRemoteConfigManager
+
+    @Before
+    fun setUp() {
+        clearAllMocks()
+
+        manager = QRemoteConfigManager(mockRemoteConfigService, mockFallbacksService)
+        manager.userStateProvider = mockUserStateProvider
+        manager.userPropertiesManager = mockUserPropertiesManager
+    }
+
+    @Test
+    fun `loadRemoteConfigList from a background thread defers the listRequests mutation to the main thread`() {
+        // given - the user is not stable, so loadRemoteConfigList enqueues the request
+        every { mockUserStateProvider.isUserStable } returns false
+        val callback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
+
+        // when - invoked from a non-main thread
+        val backgroundThread = Thread { manager.loadRemoteConfigList(callback) }
+        backgroundThread.start()
+        backgroundThread.join()
+
+        // then - the mutation has not happened yet: it was posted to the main looper
+        // instead of being applied on the background thread (this is what kills the race)
+        assertEquals(0, listRequests().size)
+
+        // and once the main looper runs, the request is recorded on the main thread
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(1, listRequests().size)
+    }
+
+    @Test
+    fun `handlePendingRequests does not throw when a handled request re-enqueues itself`() {
+        // given - three pending list requests queued while the user was not stable
+        every { mockUserStateProvider.isUserStable } returns false
+        repeat(3) { manager.loadRemoteConfigList(mockk(relaxed = true)) }
+        assertEquals(3, listRequests().size)
+
+        // when - handling them while the user is still not stable makes each one re-enqueue.
+        // Iterating a snapshot must keep this from throwing ConcurrentModificationException.
+        manager.handlePendingRequests()
+
+        // then - the originals were cleared and re-enqueued for the next launch
+        assertEquals(3, listRequests().size)
+    }
+
+    @Test
+    fun `handlePendingRequests clears the pending list requests after handling them`() {
+        // given - two pending list requests queued while the user was not stable
+        every { mockUserStateProvider.isUserStable } returns false
+        manager.loadRemoteConfigList(mockk(relaxed = true))
+        manager.loadRemoteConfigList(listOf("ctx"), false, mockk(relaxed = true))
+        assertEquals(2, listRequests().size)
+
+        // when - the user becomes stable and the pending requests are handled
+        every { mockUserStateProvider.isUserStable } returns true
+        manager.handlePendingRequests()
+
+        // then - nothing stale lingers to be re-issued on the next launch
+        assertEquals(0, listRequests().size)
+    }
+
+    @Test
+    fun `concurrent loadRemoteConfigList and handlePendingRequests do not throw`() {
+        // Reproduces SUP3-188: a caller thread adds to listRequests while the main thread
+        // iterates it in handlePendingRequests. Main-thread confinement serialises both
+        // onto the main thread, so the ConcurrentModificationException can no longer occur.
+        every { mockUserStateProvider.isUserStable } returns false
+        val callback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val iterations = 1_000
+
+        val adder = Thread {
+            try {
+                repeat(iterations) { manager.loadRemoteConfigList(callback) }
+            } catch (t: Throwable) {
+                errors.add(t)
+            }
+        }
+
+        val mainLooper = shadowOf(Looper.getMainLooper())
+        adder.start()
+        try {
+            repeat(iterations) {
+                manager.handlePendingRequests()
+                mainLooper.idle()
+            }
+        } catch (t: Throwable) {
+            errors.add(t)
+        }
+        adder.join()
+        mainLooper.idle()
+
+        assertTrue("Concurrent access threw: $errors", errors.isEmpty())
+    }
+
+    @Test
+    fun `loadRemoteConfig returns a cached config synchronously on the main thread`() {
+        // given - a previously loaded config for the empty context key, user is stable
+        every { mockUserStateProvider.isUserStable } returns true
+        val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
+        loadingStates()[null] = QRemoteConfigManager.LoadingState(loadedConfig = cachedConfig)
+        val callback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+
+        // when - called on the test (main) thread, with no looper draining in between
+        manager.loadRemoteConfig(null, callback)
+
+        // then - the cached config is delivered synchronously, without hitting the service
+        verify(exactly = 1) { callback.onSuccess(cachedConfig) }
+        verify { mockRemoteConfigService wasNot Called }
+    }
+
+    @Test
+    fun `loadRemoteConfigList returns cached configs synchronously on the main thread`() {
+        // given - a cached config for the requested context key, user is stable
+        every { mockUserStateProvider.isUserStable } returns true
+        val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
+        loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(loadedConfig = cachedConfig)
+        val callback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
+
+        // when - called on the test (main) thread, with no looper draining in between
+        manager.loadRemoteConfigList(listOf("ctx"), false, callback)
+
+        // then - the cached list is delivered synchronously, without hitting the service
+        verify(exactly = 1) { callback.onSuccess(any()) }
+        verify { mockRemoteConfigService wasNot Called }
+    }
+
+    private fun listRequests() =
+        manager.getPrivateField<List<*>>("listRequests")
+
+    private fun loadingStates() =
+        manager.getPrivateField<MutableMap<String?, QRemoteConfigManager.LoadingState>>("loadingStates")
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -3,6 +3,7 @@ package com.qonversion.android.sdk.internal
 import android.os.Build
 import android.os.Looper
 import com.qonversion.android.sdk.dto.QRemoteConfig
+import com.qonversion.android.sdk.dto.QRemoteConfigList
 import com.qonversion.android.sdk.dto.QonversionError
 import com.qonversion.android.sdk.dto.QonversionErrorCode
 import com.qonversion.android.sdk.getPrivateField
@@ -13,7 +14,6 @@ import com.qonversion.android.sdk.listeners.QonversionRemoteConfigCallback
 import com.qonversion.android.sdk.listeners.QonversionRemoteConfigListCallback
 import io.mockk.Called
 import io.mockk.clearAllMocks
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -31,7 +31,7 @@ import java.util.Collections
 internal class QRemoteConfigManagerTest {
     private val mockRemoteConfigService = mockk<QRemoteConfigService>(relaxed = true)
     private val mockFallbacksService = mockk<QFallbacksService>(relaxed = true)
-    private val mockUserStateProvider = mockk<UserStateProvider>(relaxed = true)
+    private val userStateProvider = FakeUserStateProvider()
     private val mockUserPropertiesManager = mockk<QUserPropertiesManager>(relaxed = true)
 
     private lateinit var manager: QRemoteConfigManager
@@ -41,14 +41,14 @@ internal class QRemoteConfigManagerTest {
         clearAllMocks()
 
         manager = QRemoteConfigManager(mockRemoteConfigService, mockFallbacksService)
-        manager.userStateProvider = mockUserStateProvider
+        manager.userStateProvider = userStateProvider
         manager.userPropertiesManager = mockUserPropertiesManager
     }
 
     @Test
     fun `loadRemoteConfigList from a background thread defers the listRequests mutation to the main thread`() {
         // given - the user is not stable, so loadRemoteConfigList enqueues the request
-        every { mockUserStateProvider.isUserStable } returns false
+        userStateProvider.stable = false
         val callback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
 
         // when - invoked from a non-main thread
@@ -68,7 +68,7 @@ internal class QRemoteConfigManagerTest {
     @Test
     fun `loadRemoteConfig from a background thread defers the loadingStates mutation to the main thread`() {
         // given - the user is not stable, so loadRemoteConfig registers a new loading state
-        every { mockUserStateProvider.isUserStable } returns false
+        userStateProvider.stable = false
 
         // when - invoked from a non-main thread with a not-yet-cached context key
         val backgroundThread = Thread { manager.loadRemoteConfig("ctx", null) }
@@ -87,7 +87,7 @@ internal class QRemoteConfigManagerTest {
     @Test
     fun `handlePendingRequests does not throw when a handled request re-enqueues itself`() {
         // given - three pending list requests queued while the user was not stable
-        every { mockUserStateProvider.isUserStable } returns false
+        userStateProvider.stable = false
         repeat(3) { manager.loadRemoteConfigList(mockk(relaxed = true)) }
         assertEquals(3, listRequests().size)
 
@@ -102,13 +102,13 @@ internal class QRemoteConfigManagerTest {
     @Test
     fun `handlePendingRequests clears the pending list requests after handling them`() {
         // given - two pending list requests queued while the user was not stable
-        every { mockUserStateProvider.isUserStable } returns false
+        userStateProvider.stable = false
         manager.loadRemoteConfigList(mockk(relaxed = true))
         manager.loadRemoteConfigList(listOf("ctx"), false, mockk(relaxed = true))
         assertEquals(2, listRequests().size)
 
         // when - the user becomes stable and the pending requests are handled
-        every { mockUserStateProvider.isUserStable } returns true
+        userStateProvider.stable = true
         manager.handlePendingRequests()
 
         // then - nothing stale lingers to be re-issued on the next launch
@@ -120,8 +120,12 @@ internal class QRemoteConfigManagerTest {
         // Reproduces SUP3-188: a caller thread adds to listRequests while the main thread
         // iterates it in handlePendingRequests. Main-thread confinement serialises both
         // onto the main thread, so the ConcurrentModificationException can no longer occur.
-        every { mockUserStateProvider.isUserStable } returns false
-        val callback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
+        userStateProvider.stable = false
+        // Hand-written no-op callback keeps the concurrent hot loop free of mockk proxies.
+        val callback = object : QonversionRemoteConfigListCallback {
+            override fun onSuccess(remoteConfigList: QRemoteConfigList) {}
+            override fun onError(error: QonversionError) {}
+        }
         val errors = Collections.synchronizedList(mutableListOf<Throwable>())
         val iterations = 1_000
 
@@ -155,7 +159,7 @@ internal class QRemoteConfigManagerTest {
         // loadingStates.keys on the main thread while loadRemoteConfig registers brand-new
         // keys. Confinement serialises both onto the main thread, so the structural
         // modification can no longer collide with the iteration.
-        every { mockUserStateProvider.isUserStable } returns false
+        userStateProvider.stable = false
         val error = QonversionError(QonversionErrorCode.Unknown)
         val errors = Collections.synchronizedList(mutableListOf<Throwable>())
         val iterations = 1_000
@@ -187,7 +191,7 @@ internal class QRemoteConfigManagerTest {
     @Test
     fun `loadRemoteConfig returns a cached config synchronously on the main thread`() {
         // given - a previously loaded config for the empty context key, user is stable
-        every { mockUserStateProvider.isUserStable } returns true
+        userStateProvider.stable = true
         val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
         loadingStates()[null] = QRemoteConfigManager.LoadingState(loadedConfig = cachedConfig)
         val callback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
@@ -203,7 +207,7 @@ internal class QRemoteConfigManagerTest {
     @Test
     fun `loadRemoteConfigList returns cached configs synchronously on the main thread`() {
         // given - a cached config for the requested context key, user is stable
-        every { mockUserStateProvider.isUserStable } returns true
+        userStateProvider.stable = true
         val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
         loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(loadedConfig = cachedConfig)
         val callback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
@@ -221,4 +225,14 @@ internal class QRemoteConfigManagerTest {
 
     private fun loadingStates() =
         manager.getPrivateField<MutableMap<String?, QRemoteConfigManager.LoadingState>>("loadingStates")
+
+    // Hand-written fake instead of a mockk: isUserStable is read thousands of times inside
+    // the concurrent stress loops, and driving a mockk proxy at that volume trips a
+    // byte-buddy instrumentation assertion under the CI JDK. A plain object keeps the hot
+    // path mock-free.
+    private class FakeUserStateProvider : UserStateProvider {
+        @Volatile
+        var stable: Boolean = false
+        override val isUserStable: Boolean get() = stable
+    }
 }

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -189,6 +189,42 @@ internal class QRemoteConfigManagerTest {
     }
 
     @Test
+    fun `userChangingRequestFailedWithError does not throw when a callback re-enters loadRemoteConfig`() {
+        // Reentrant variant of SUP3-188. userChangingRequestFailedWithError iterates
+        // loadingStates.keys on the main thread and fires user callbacks. If a callback
+        // synchronously calls loadRemoteConfig for a brand-new key, that load runs inline
+        // (already on the main thread) and registers the key in loadingStates - a structural
+        // modification mid-iteration. Main-thread confinement cannot prevent this; only
+        // iterating a snapshot (keys.toList()) does.
+        userStateProvider.stable = false
+        val error = QonversionError(QonversionErrorCode.Unknown)
+
+        val reentrantCallback = object : QonversionRemoteConfigCallback {
+            override fun onSuccess(remoteConfig: QRemoteConfig) = Unit
+            override fun onError(error: QonversionError) {
+                // re-enter with a not-yet-seen key, adding to loadingStates mid-iteration
+                manager.loadRemoteConfig("reentrant_key", null)
+            }
+        }
+        val noopCallback = object : QonversionRemoteConfigCallback {
+            override fun onSuccess(remoteConfig: QRemoteConfig) = Unit
+            override fun onError(error: QonversionError) = Unit
+        }
+        // Two pre-existing keys: the structural add happens while processing the first, and
+        // the iterator must still advance to the second - which is where a live-keySet
+        // iteration would trip ConcurrentModificationException.
+        loadingStates()["ctx0"] = QRemoteConfigManager.LoadingState(callbacks = mutableListOf(reentrantCallback))
+        loadingStates()["ctx1"] = QRemoteConfigManager.LoadingState(callbacks = mutableListOf(noopCallback))
+
+        // when - failing all in-flight requests on the main thread
+        manager.userChangingRequestFailedWithError(error)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // then - no ConcurrentModificationException, and the reentrant load registered its key
+        assertTrue(loadingStates().containsKey("reentrant_key"))
+    }
+
+    @Test
     fun `loadRemoteConfig returns a cached config synchronously on the main thread`() {
         // given - a previously loaded config for the empty context key, user is stable
         userStateProvider.stable = true


### PR DESCRIPTION
## Problem

`QRemoteConfigManager` intermittently crashes with `java.util.ConcurrentModificationException` thrown from `handlePendingRequests()`:

```
java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java)
    at java.util.ArrayList$Itr.next(ArrayList.java)
    at com.qonversion.android.sdk.internal.QRemoteConfigManager.handlePendingRequests(QRemoteConfigManager.kt)
    at com.qonversion.android.sdk.internal.QProductCenterManager.handlePendingRequests(QProductCenterManager.kt)
    at com.qonversion.android.sdk.internal.QProductCenterManager$getLaunchCallback$1.onError(QProductCenterManager.kt)
```

## Root cause

`QRemoteConfigManager` keeps its `loadingStates` map and `listRequests` list in plain, unsynchronized collections.

`handlePendingRequests()` iterates both on the main thread - it is invoked from `QProductCenterManager`'s launch/identity callbacks, which return on the main thread via Retrofit's default executor. Meanwhile the public entry points (`loadRemoteConfig`, both `loadRemoteConfigList` overloads, `attach/detach*`, and `onUserUpdate` via `logout`) mutate the same collections on the **caller's** thread while the user is not yet stable. When a caller invokes them from a non-main thread (for example a bridge / native-modules thread), the structural modification during iteration throws `ConcurrentModificationException`.

Two secondary issues compound it:
- `listRequests` is never cleared, so pending requests are re-issued on every launch, and a re-entrant add (user still not stable) can structurally modify the list mid-iteration on the same thread.
- `loadingStates` has the same cross-thread exposure (including its reassignment on user change).

## Fix

Confine every access to the mutable state to the main thread. Each public entry point that touches `loadingStates` / `listRequests` is routed through a main-thread `Handler` using the same synchronous short-circuit already used by `QonversionInternal.postToMainThread` (run inline when already on the main thread, otherwise post).

Because all network/identity callbacks already return on the main thread, this confines every read and write of `loadingStates`/`listRequests` to a single thread and removes the race at its source - no locks, and no change to observable behavior. Callbacks were already delivered on the main thread, and the synchronous cached-config fast paths still return synchronously for main-thread callers.

`handlePendingRequests()` additionally snapshots and clears `listRequests` before handling it, fixing the never-cleared / stale-reissue problem and the same-thread re-entrant modification.

The change is contained entirely within `QRemoteConfigManager` - no DI, public API, or call-site changes.

## Tests

Adds `QRemoteConfigManagerTest` (Robolectric), covering:
- a background-thread mutation is deferred to the main thread;
- no `ConcurrentModificationException` under concurrent add-vs-iterate or re-entrant re-enqueue;
- the `loadingStates` map race (`userChangingRequestFailedWithError` iterating keys vs background `loadRemoteConfig` registering new keys);
- `listRequests` is cleared after handling;
- the synchronous cached-config fast paths still return synchronously on the main thread.

```
./gradlew :sdk:testDebugUnitTest --tests "*QRemoteConfigManager*"
```
8/8 passing.

## Affected versions

`QRemoteConfigManager` has been unchanged since 7.5.1, so every release from 7.5.1 through 9.4.1 (current latest) carries this bug.

Ref: SUP3-188
