### PR TITLE
fix(web2app): scope sample App Link to Qonversion sample project uid (kZfGkwHa)

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -46,7 +46,9 @@
               SDK. Production merchants set this to their project's uid
               issued in Qonversion Connect Apps onboarding.
 
-              Local dev uses project `PcnB70vn` (Openchat).
+              Scoped to the Qonversion sample project uid `kZfGkwHa`
+              (matches DEFAULT_PROJECT_KEY in App.java). Must stay in sync
+              with whatever project this sample initializes the SDK with.
             -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -55,7 +57,7 @@
                 <data
                     android:scheme="https"
                     android:host="screens.qonversion.io"
-                    android:pathPattern="/r/PcnB70vn/.*" />
+                    android:pathPattern="/r/kZfGkwHa/.*" />
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
The redemption App Link in the sample was scoped to `/r/PcnB70vn/.*` — project **Openchat (a client project)**, a local-dev leftover from #812-era commit 4714cca2. But the sample initializes the SDK with the **Qonversion sample project** (`DEFAULT_PROJECT_KEY` in App.java).

**Effect of the bug:** redemption links for the sample's own project look like `/r/{sample_uid}/{token}`, which the `/r/PcnB70vn/.*` filter does NOT match → the sample would never auto-open its own project's redemption email. Also: shipping a sample scoped to a client's project is wrong.

**Fix:** scope the App Link to the sample project uid `kZfGkwHa` so it matches the SDK project; drop the Openchat reference.

Note: for the App Link to auto-verify in prod, `screens.qonversion.io/.well-known/assetlinks.json` must list this sample app's package + signing SHA-256 (DEV-1101 AASA population).

Related: DEV-847, DEV-1102.