### PR TITLE
feat(nocodes): surface configured product ids at screen load [DEV-1169]

### DIFF
--- a/nocodes/build.gradle
+++ b/nocodes/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     
     api project(':sdk')
 
+    testImplementation 'junit:junit:4.13.2'
+
     androidTestImplementation 'androidx.test:core:1.5.0'
     androidTestImplementation "androidx.test:runner:1.5.2"
     androidTestImplementation "androidx.test:rules:1.5.0"

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -15,6 +15,21 @@ interface NoCodesDelegate {
     fun onScreenShown(screenId: String) { }
 
     /**
+     * Called when No-Code screen is shown, providing the product ids configured on that screen.
+     * Use this to keep analytics consistent with the full set of products the screen was built
+     * with, not only the ones the rendered screen requested.
+     *
+     * The default implementation delegates to [onScreenShown], so existing implementations keep
+     * working and this callback fires exactly once.
+     *
+     * @param screenId shown screen Id.
+     * @param products Qonversion product ids configured on the screen (may be empty).
+     */
+    fun onScreenShown(screenId: String, products: List<String>) {
+        onScreenShown(screenId)
+    }
+
+    /**
      * Called when No-Code screen starts executing an action.
      *
      * @param action action that is being executed.

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
@@ -13,10 +13,14 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
             return null
         }
 
+        // Missing/absent `products` (older payloads, bundled fallbacks) → empty list.
+        val products = data.getList("products")?.filterIsInstance<String>() ?: emptyList()
+
         return NoCodeScreen(
             id,
             body,
             contextKey,
+            products,
         )
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
@@ -3,5 +3,7 @@ package io.qonversion.nocodes.internal.dto
 internal data class NoCodeScreen(
     val id: String,
     val body: String,
-    val contextKey: String
+    val contextKey: String,
+    // Qonversion product ids configured in the builder for this screen (may be empty).
+    val products: List<String> = emptyList()
 )

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
@@ -12,9 +12,9 @@ class NoCodesDelegateWrapper(
 
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    override fun onScreenShown(screenId: String) {
+    override fun onScreenShown(screenId: String, products: List<String>) {
         mainHandler.post {
-            delegate.onScreenShown(screenId)
+            delegate.onScreenShown(screenId, products)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -4,7 +4,7 @@ import io.qonversion.nocodes.dto.QAction
 
 internal class ScreenContract {
     interface View {
-        fun displayScreen(screenId: String, html: String)
+        fun displayScreen(screenId: String, html: String, products: List<String>)
 
         fun navigateToScreen(screenId: String)
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -113,7 +113,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         binding = null
     }
 
-    override fun displayScreen(screenId: String, html: String) {
+    override fun displayScreen(screenId: String, html: String, products: List<String>) {
         activity?.runOnUiThread {
             binding?.webView?.loadDataWithBaseURL(
                 null,
@@ -122,7 +122,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
                 ENCODING,
                 null
             )
-            delegate?.onScreenShown(screenId)
+            delegate?.onScreenShown(screenId, products)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -82,7 +82,7 @@ internal class ScreenPresenter(
 
             var processedHtml = injectCustomLocale(screen.body)
             processedHtml = injectTheme(processedHtml)
-            view.displayScreen(screen.id, processedHtml)
+            view.displayScreen(screen.id, processedHtml, screen.products)
 
             val shownEvent = ScreenEvent(data = mapOf(
                 "type" to ScreenEventType.ScreenShown.value,

--- a/nocodes/src/test/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapperTest.kt
+++ b/nocodes/src/test/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapperTest.kt
@@ -1,0 +1,42 @@
+package io.qonversion.nocodes.internal.common.mappers
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScreenMapperTest {
+
+    private val mapper = ScreenMapper()
+
+    private fun baseScreen(vararg extra: Pair<String, Any?>): Map<String, Any?> =
+        mapOf("id" to "s1", "body" to "<html>", "context_key" to "ctx", *extra)
+
+    @Test
+    fun `decodes configured products list`() {
+        val screen = mapper.fromMap(baseScreen("products" to listOf("annual", "weekly")))
+        assertEquals(listOf("annual", "weekly"), screen?.products)
+    }
+
+    @Test
+    fun `missing products defaults to empty list`() {
+        val screen = mapper.fromMap(baseScreen())
+        assertEquals(emptyList<String>(), screen?.products)
+    }
+
+    @Test
+    fun `empty products stays empty`() {
+        val screen = mapper.fromMap(baseScreen("products" to emptyList<String>()))
+        assertEquals(emptyList<String>(), screen?.products)
+    }
+
+    @Test
+    fun `non-string product entries are dropped`() {
+        val screen = mapper.fromMap(baseScreen("products" to listOf("a", 1, null, "b")))
+        assertEquals(listOf("a", "b"), screen?.products)
+    }
+
+    @Test
+    fun `returns null when a required field is missing`() {
+        assertNull(mapper.fromMap(mapOf("id" to "s1", "body" to "<html>")))
+    }
+}

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -109,8 +109,8 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
     }
 
     // NoCodesDelegate implementation
-    override fun onScreenShown(screenId: String) {
-        addEvent(getString(R.string.screen_shown, screenId))
+    override fun onScreenShown(screenId: String, products: List<String>) {
+        addEvent(getString(R.string.screen_shown, "$screenId, products: $products"))
     }
 
     override fun onScreenFailedToLoad(error: NoCodesError) {


### PR DESCRIPTION
## What & why

[DEV-1169](https://linear.app/qonversion/issue/DEV-1169). The dash-mono backend now returns a `products` array (Qonversion product ids configured in the builder for a screen) in the NoCode screen payload. This PR decodes it in the Android SDK and surfaces it to the app **at screen load**, so customers get the full set of configured products for analytics consistency — not only the products the rendered screen requested at runtime.

Backend contract: dash-mono PR #546 (adds `products` to `POST /v1/no-code/fallback`).

## Changes

- **`NoCodeScreen`** — add `products: List<String>` (defaults to `emptyList()`).
- **`ScreenMapper`** — decode `products` defensively: `data.getList("products")?.filterIsInstance<String>() ?: emptyList()`. Missing key (older payloads, bundled fallback file) → empty. Both decode paths (live network and the fallback file) go through this mapper, so both are covered.
- **`NoCodesDelegate`** — new default method `onScreenShown(screenId, products)` whose default body delegates to the existing `onScreenShown(screenId)`. The SDK fires **only** the 2-arg variant, so:
  - existing implementers (only `onScreenShown(screenId)`) keep getting the id-only callback, **exactly once** — no double-firing;
  - new integrators override the 2-arg variant to receive `products`.
  Fully additive — matches the default-method idiom every callback in this interface already uses.
- Threaded `products` through the internal `ScreenContract.View.displayScreen` → `ScreenPresenter` (where the `NoCodeScreen` is in scope) → `ScreenFragment` fire site. Updated `NoCodesDelegateWrapper` to forward the 2-arg callback (otherwise the inherited default would route back to the 1-arg path and drop `products`).
- Sample updated to show the new callback.

## Compatibility / verification

- **Public API change is additive only** — a new default interface method; nothing removed or resignatured on the public surface (`NoCodeScreen`, `ScreenContract`, the wrapper are all `internal`).
- Traced every affected call site: only `ScreenMapper` constructs `NoCodeScreen`; `screen.copy(body = …)` preserves `products`; `ScreenFragment` is the sole `ScreenContract.View` implementer; the wrapper's `onScreenShown` is only ever fired (now 2-arg) from `ScreenFragment`.
- The dispatch design (2-arg default → 1-arg; fire 2-arg only; overriding 1-arg still fires once) is the same pattern used and independently verified on the iOS side.
- No JVM/Gradle available locally, so compile + tests run in CI. A `nocodes` unit-test source set doesn't exist today (only instrumentation tests hitting live API); adding one is a reasonable follow-up.

## Scope

Additive only. Part of DEV-1169 alongside the backend (shipped) and the iOS SDK (separate PR).
