### PR TITLE
feat: [DEV-1168] Suppress native purchase spinner when web loader present

### DIFF
--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QAction.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QAction.kt
@@ -23,7 +23,13 @@ data class QAction(
         LoadProducts("getProducts"),
         GetContext("getContext"),
         ShowScreen("showScreen"),
-        ScreenAnalytics("screenAnalytics");
+        ScreenAnalytics("screenAnalytics"),
+
+        /**
+         * Internal action: the web page announces it renders its own purchase
+         * loader, so the native purchase spinner is suppressed (no double loader).
+         */
+        PurchaseLoaderPresent("purchaseLoaderPresent");
 
         companion object {
             fun from(type: String?): Type {

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -29,6 +29,8 @@ internal class ScreenContract {
         fun finishScreenPreparation()
 
         fun setVariable(name: String, value: String, completion: () -> Unit = {})
+
+        fun setHasWebPurchaseLoader(value: Boolean)
     }
 
     internal interface Presenter {

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -51,6 +51,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
 
     private var binding: NcFragmentScreenBinding? = null
     private var loadingView: NoCodesLoadingView? = null
+    private var hasWebPurchaseLoader = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -167,7 +168,9 @@ class ScreenFragment : Fragment(), ScreenContract.View {
     }
 
     override fun purchase(productId: String, screenId: String?) {
-        binding?.progressBarLayout?.progressBar?.visibility = View.VISIBLE
+        if (!hasWebPurchaseLoader) {
+            binding?.progressBarLayout?.progressBar?.visibility = View.VISIBLE
+        }
 
         val action = QAction(QAction.Type.Purchase, QAction.Parameter.ProductId, productId)
         delegate?.onActionStartedExecuting(action)
@@ -234,7 +237,9 @@ class ScreenFragment : Fragment(), ScreenContract.View {
     }
 
     override fun restore() {
-        binding?.progressBarLayout?.progressBar?.visibility = View.VISIBLE
+        if (!hasWebPurchaseLoader) {
+            binding?.progressBarLayout?.progressBar?.visibility = View.VISIBLE
+        }
 
         val action = QAction(QAction.Type.Restore)
         delegate?.onActionStartedExecuting(action)
@@ -505,6 +510,10 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         act.runOnUiThread {
             binding?.webView?.evaluateJavascript(js) { completion() }
         }
+    }
+
+    override fun setHasWebPurchaseLoader(value: Boolean) {
+        hasWebPurchaseLoader = value
     }
 
     @JavascriptInterface

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -187,6 +187,9 @@ internal class ScreenPresenter(
             QAction.Type.ScreenAnalytics -> {
                 handleScreenAnalyticsAction(action)
             }
+            QAction.Type.PurchaseLoaderPresent -> {
+                view.setHasWebPurchaseLoader(true)
+            }
             else -> {
                 logger.warn("ScreenPresenter -> action type ${action.type} is not supported")
             }


### PR DESCRIPTION
Issue: [DEV-1168](https://linear.app/qonversion/issue/DEV-1168)

Suppress the native purchase progress bar when the No-Code screen renders its own web purchase loader (from dash-mono#547), so there's no double loader over the web overlay.

## Change
- New `QAction.Type.PurchaseLoaderPresent("purchaseLoaderPresent")`. The web page sends it on load via the existing JS→native bridge, only when a custom purchase loader is configured.
- `ScreenPresenter` handles it → new `ScreenContract.View.setHasWebPurchaseLoader(true)` → `ScreenFragment` sets the flag; `purchase()` / `restore()` then skip showing `progressBar`. GONE resets unchanged.

Safe/no-op for the web flow and older screens.

Requires dash-mono#547 (sends the signal). iOS counterpart: qonversion/qonversion-ios-sdk#(same branch).

Part of [DEV-1168](https://linear.app/qonversion/issue/DEV-1168)