### PR TITLE
feat(nocodes): surface authored screen variables at screen load [DEV-1170]

### DIFF
--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
@@ -1,0 +1,18 @@
+package io.qonversion.nocodes.dto
+
+/**
+ * A No-Code screen variable authored in the builder, delivered to the SDK at screen load so it
+ * can be read by [key] after the screen appears.
+ *
+ * [value] keeps its authored native type (Boolean / String / Number) rather than being coerced
+ * to a String, matching the declared [type].
+ *
+ * @property key variable name it is addressed by (`variable.<key>` in the builder); may contain spaces.
+ * @property type authored type: `"boolean"`, `"string"` or `"number"`.
+ * @property value the authored default value, preserving its native type (may be null).
+ */
+data class QScreenVariable(
+    val key: String,
+    val type: String,
+    val value: Any?,
+)

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -1,6 +1,7 @@
 package io.qonversion.nocodes.interfaces
 
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.error.NoCodesError
 import com.qonversion.android.sdk.Qonversion
@@ -27,6 +28,22 @@ interface NoCodesDelegate {
      */
     fun onScreenShown(screenId: String, products: List<String>) {
         onScreenShown(screenId)
+    }
+
+    /**
+     * Called when No-Code screen is shown, providing the screen variables authored on it.
+     * Read them by [QScreenVariable.key] to react to the screen's configured values after it
+     * loads; each value keeps its authored type (bool / string / number).
+     *
+     * The default implementation delegates to [onScreenShown], so existing implementations keep
+     * working and this callback fires exactly once.
+     *
+     * @param screenId shown screen Id.
+     * @param products Qonversion product ids configured on the screen (may be empty).
+     * @param variables screen variables authored on the screen (may be empty).
+     */
+    fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        onScreenShown(screenId, products)
     }
 
     /**

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
@@ -1,5 +1,6 @@
 package io.qonversion.nocodes.internal.common.mappers
 
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.internal.dto.NoCodeScreen
 
 internal class ScreenMapper : Mapper<NoCodeScreen?> {
@@ -16,11 +17,23 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
         // Missing/absent `products` (older payloads, bundled fallbacks) → empty list.
         val products = data.getList("products")?.filterIsInstance<String>() ?: emptyList()
 
+        // Missing/absent `variables` → empty list. Each entry is {key, type, value}; the value
+        // keeps its native type. Entries without a key are skipped; a missing type falls back to
+        // "string" (mirrors the backend extractor).
+        val variables = data.getList("variables")
+            ?.filterIsInstance<Map<*, *>>()
+            ?.mapNotNull { item ->
+                val key = item.getString("key") ?: return@mapNotNull null
+                val type = item.getString("type") ?: "string"
+                QScreenVariable(key, type, item["value"])
+            } ?: emptyList()
+
         return NoCodeScreen(
             id,
             body,
             contextKey,
             products,
+            variables,
         )
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
@@ -1,9 +1,13 @@
 package io.qonversion.nocodes.internal.dto
 
+import io.qonversion.nocodes.dto.QScreenVariable
+
 internal data class NoCodeScreen(
     val id: String,
     val body: String,
     val contextKey: String,
     // Qonversion product ids configured in the builder for this screen (may be empty).
-    val products: List<String> = emptyList()
+    val products: List<String> = emptyList(),
+    // Screen variables authored in the builder for this screen, read by key (may be empty).
+    val variables: List<QScreenVariable> = emptyList()
 )

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
@@ -3,6 +3,7 @@ package io.qonversion.nocodes.internal.dto.config
 import android.os.Handler
 import android.os.Looper
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
 import io.qonversion.nocodes.error.NoCodesError
 
@@ -15,6 +16,12 @@ class NoCodesDelegateWrapper(
     override fun onScreenShown(screenId: String, products: List<String>) {
         mainHandler.post {
             delegate.onScreenShown(screenId, products)
+        }
+    }
+
+    override fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        mainHandler.post {
+            delegate.onScreenShown(screenId, products, variables)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -1,10 +1,11 @@
 package io.qonversion.nocodes.internal.screen.view
 
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 
 internal class ScreenContract {
     interface View {
-        fun displayScreen(screenId: String, html: String, products: List<String>)
+        fun displayScreen(screenId: String, html: String, products: List<String>, variables: List<QScreenVariable>)
 
         fun navigateToScreen(screenId: String)
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -31,6 +31,7 @@ import com.qonversion.android.sdk.listeners.QonversionPurchaseCallback
 import io.qonversion.nocodes.databinding.NcFragmentScreenBinding
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.NoCodesLoadingView
 import io.qonversion.nocodes.internal.di.DependenciesAssembly
@@ -113,7 +114,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         binding = null
     }
 
-    override fun displayScreen(screenId: String, html: String, products: List<String>) {
+    override fun displayScreen(screenId: String, html: String, products: List<String>, variables: List<QScreenVariable>) {
         activity?.runOnUiThread {
             binding?.webView?.loadDataWithBaseURL(
                 null,
@@ -122,7 +123,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
                 ENCODING,
                 null
             )
-            delegate?.onScreenShown(screenId, products)
+            delegate?.onScreenShown(screenId, products, variables)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -82,7 +82,7 @@ internal class ScreenPresenter(
 
             var processedHtml = injectCustomLocale(screen.body)
             processedHtml = injectTheme(processedHtml)
-            view.displayScreen(screen.id, processedHtml, screen.products)
+            view.displayScreen(screen.id, processedHtml, screen.products, screen.variables)
 
             val shownEvent = ScreenEvent(data = mapOf(
                 "type" to ScreenEventType.ScreenShown.value,

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.CustomVariablesDelegate
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
@@ -109,8 +110,9 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
     }
 
     // NoCodesDelegate implementation
-    override fun onScreenShown(screenId: String, products: List<String>) {
-        addEvent(getString(R.string.screen_shown, "$screenId, products: $products"))
+    override fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        val vars = variables.joinToString(", ") { "${it.key}=${it.value}" }
+        addEvent(getString(R.string.screen_shown, "$screenId, products: $products, variables: [$vars]"))
     }
 
     override fun onScreenFailedToLoad(error: NoCodesError) {


### PR DESCRIPTION
## DEV-1170 (Android) — read No-Code screen variables by key at screen load

Part of DEV-1167 (customer request #3). Delivers the authored No-Code **screen variables** to the app so it can read them **by key** after the paywall loads. Consumes the new `variables` field added to the screen-download payload by the backend (dash-mono#548).

**Mirror of the products sibling DEV-1169 (#828).** Same delivery mechanism — the `onScreenShown` delegate callback — extended from `(screenId, products)` to `(screenId, products, variables)`.

### What changed
- New public **`QScreenVariable`** (`key`, `type`, `value: Any?`) — the value keeps its **authored native type** (Boolean / String / Number) instead of being stringified (resolves the ticket's typing open-question).
- `ScreenMapper` parses `variables` from the payload: each entry `{key, type, value}` → `QScreenVariable`; entries without a `key` are skipped, a missing `type` falls back to `"string"`; absent → empty list. Mirrors the products parsing + the backend extractor.
- `NoCodeScreen` gains `variables: List<QScreenVariable>`.
- New `NoCodesDelegate.onScreenShown(screenId, products, variables)` with a default impl chaining to the products variant → existing delegates keep working and the event fires exactly once.
- Plumbed through `ScreenContract` / `ScreenFragment` / `ScreenPresenter` / `NoCodesDelegateWrapper`; sample prints the variables.

### Stacking
**Stacked on the DEV-1169 branch** (`danya/dev-1169-nocodes-products-at-screen-load`), because both extend the *same* `onScreenShown` callback — stacking makes it cleanly `(screenId, products, variables)` with zero conflict. Merge/retarget after #828.

### Scope / verification
- Option A (static authored defaults); live-after-mutation values are a separate future item (umbrella open-question #1).
- No unit test added — the `nocodes` module has no test source set (same as DEV-1169 #828). Gradle build/tests run in CI.

Closes DEV-1170 (Android layer).
