### PR TITLE
feat: [DEV-1167] NoCodes SDK — products + variables at screen load, purchase-loader gating

### DIFF
--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QAction.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QAction.kt
@@ -23,7 +23,13 @@ data class QAction(
         LoadProducts("getProducts"),
         GetContext("getContext"),
         ShowScreen("showScreen"),
-        ScreenAnalytics("screenAnalytics");
+        ScreenAnalytics("screenAnalytics"),
+
+        /**
+         * Internal action: the web page announces it renders its own purchase
+         * loader, so the native purchase spinner is suppressed (no double loader).
+         */
+        PurchaseLoaderPresent("purchaseLoaderPresent");
 
         companion object {
             fun from(type: String?): Type {

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
@@ -1,0 +1,18 @@
+package io.qonversion.nocodes.dto
+
+/**
+ * A No-Code screen variable authored in the builder, delivered to the SDK at screen load so it
+ * can be read by [key] after the screen appears.
+ *
+ * [value] keeps its authored native type (Boolean / String / Number) rather than being coerced
+ * to a String, matching the declared [type].
+ *
+ * @property key variable name it is addressed by (`variable.<key>` in the builder); may contain spaces.
+ * @property type authored type: `"boolean"`, `"string"` or `"number"`.
+ * @property value the authored default value, preserving its native type (may be null).
+ */
+data class QScreenVariable(
+    val key: String,
+    val type: String,
+    val value: Any?,
+)

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -1,6 +1,7 @@
 package io.qonversion.nocodes.interfaces
 
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.error.NoCodesError
 import com.qonversion.android.sdk.Qonversion
@@ -27,6 +28,22 @@ interface NoCodesDelegate {
      */
     fun onScreenShown(screenId: String, products: List<String>) {
         onScreenShown(screenId)
+    }
+
+    /**
+     * Called when No-Code screen is shown, providing the screen variables authored on it.
+     * Read them by [QScreenVariable.key] to react to the screen's configured values after it
+     * loads; each value keeps its authored type (bool / string / number).
+     *
+     * The default implementation delegates to [onScreenShown], so existing implementations keep
+     * working and this callback fires exactly once.
+     *
+     * @param screenId shown screen Id.
+     * @param products Qonversion product ids configured on the screen (may be empty).
+     * @param variables screen variables authored on the screen (may be empty).
+     */
+    fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        onScreenShown(screenId, products)
     }
 
     /**

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -15,6 +15,21 @@ interface NoCodesDelegate {
     fun onScreenShown(screenId: String) { }
 
     /**
+     * Called when No-Code screen is shown, providing the product ids configured on that screen.
+     * Use this to keep analytics consistent with the full set of products the screen was built
+     * with, not only the ones the rendered screen requested.
+     *
+     * The default implementation delegates to [onScreenShown], so existing implementations keep
+     * working and this callback fires exactly once.
+     *
+     * @param screenId shown screen Id.
+     * @param products Qonversion product ids configured on the screen (may be empty).
+     */
+    fun onScreenShown(screenId: String, products: List<String>) {
+        onScreenShown(screenId)
+    }
+
+    /**
      * Called when No-Code screen starts executing an action.
      *
      * @param action action that is being executed.

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
@@ -1,5 +1,6 @@
 package io.qonversion.nocodes.internal.common.mappers
 
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.internal.dto.NoCodeScreen
 
 internal class ScreenMapper : Mapper<NoCodeScreen?> {
@@ -16,11 +17,23 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
         // Missing/absent `products` (older payloads, bundled fallbacks) → empty list.
         val products = data.getList("products")?.filterIsInstance<String>() ?: emptyList()
 
+        // Missing/absent `variables` → empty list. Each entry is {key, type, value}; the value
+        // keeps its native type. Entries without a key are skipped; a missing type falls back to
+        // "string" (mirrors the backend extractor).
+        val variables = data.getList("variables")
+            ?.filterIsInstance<Map<*, *>>()
+            ?.mapNotNull { item ->
+                val key = item.getString("key") ?: return@mapNotNull null
+                val type = item.getString("type") ?: "string"
+                QScreenVariable(key, type, item["value"])
+            } ?: emptyList()
+
         return NoCodeScreen(
             id,
             body,
             contextKey,
             products,
+            variables,
         )
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
@@ -13,10 +13,14 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
             return null
         }
 
+        // Missing/absent `products` (older payloads, bundled fallbacks) → empty list.
+        val products = data.getList("products")?.filterIsInstance<String>() ?: emptyList()
+
         return NoCodeScreen(
             id,
             body,
             contextKey,
+            products,
         )
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
@@ -1,9 +1,13 @@
 package io.qonversion.nocodes.internal.dto
 
+import io.qonversion.nocodes.dto.QScreenVariable
+
 internal data class NoCodeScreen(
     val id: String,
     val body: String,
     val contextKey: String,
     // Qonversion product ids configured in the builder for this screen (may be empty).
-    val products: List<String> = emptyList()
+    val products: List<String> = emptyList(),
+    // Screen variables authored in the builder for this screen, read by key (may be empty).
+    val variables: List<QScreenVariable> = emptyList()
 )

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
@@ -3,5 +3,7 @@ package io.qonversion.nocodes.internal.dto
 internal data class NoCodeScreen(
     val id: String,
     val body: String,
-    val contextKey: String
+    val contextKey: String,
+    // Qonversion product ids configured in the builder for this screen (may be empty).
+    val products: List<String> = emptyList()
 )

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
@@ -3,6 +3,7 @@ package io.qonversion.nocodes.internal.dto.config
 import android.os.Handler
 import android.os.Looper
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
 import io.qonversion.nocodes.error.NoCodesError
 
@@ -15,6 +16,12 @@ class NoCodesDelegateWrapper(
     override fun onScreenShown(screenId: String, products: List<String>) {
         mainHandler.post {
             delegate.onScreenShown(screenId, products)
+        }
+    }
+
+    override fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        mainHandler.post {
+            delegate.onScreenShown(screenId, products, variables)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
@@ -12,9 +12,9 @@ class NoCodesDelegateWrapper(
 
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    override fun onScreenShown(screenId: String) {
+    override fun onScreenShown(screenId: String, products: List<String>) {
         mainHandler.post {
-            delegate.onScreenShown(screenId)
+            delegate.onScreenShown(screenId, products)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -30,6 +30,8 @@ internal class ScreenContract {
         fun finishScreenPreparation()
 
         fun setVariable(name: String, value: String, completion: () -> Unit = {})
+
+        fun setHasWebPurchaseLoader(value: Boolean)
     }
 
     internal interface Presenter {

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -4,7 +4,7 @@ import io.qonversion.nocodes.dto.QAction
 
 internal class ScreenContract {
     interface View {
-        fun displayScreen(screenId: String, html: String)
+        fun displayScreen(screenId: String, html: String, products: List<String>)
 
         fun navigateToScreen(screenId: String)
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -1,10 +1,11 @@
 package io.qonversion.nocodes.internal.screen.view
 
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 
 internal class ScreenContract {
     interface View {
-        fun displayScreen(screenId: String, html: String, products: List<String>)
+        fun displayScreen(screenId: String, html: String, products: List<String>, variables: List<QScreenVariable>)
 
         fun navigateToScreen(screenId: String)
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -52,6 +52,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
 
     private var binding: NcFragmentScreenBinding? = null
     private var loadingView: NoCodesLoadingView? = null
+    private var hasWebPurchaseLoader = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -168,7 +169,9 @@ class ScreenFragment : Fragment(), ScreenContract.View {
     }
 
     override fun purchase(productId: String, screenId: String?) {
-        binding?.progressBarLayout?.progressBar?.visibility = View.VISIBLE
+        if (!hasWebPurchaseLoader) {
+            binding?.progressBarLayout?.progressBar?.visibility = View.VISIBLE
+        }
 
         val action = QAction(QAction.Type.Purchase, QAction.Parameter.ProductId, productId)
         delegate?.onActionStartedExecuting(action)
@@ -235,7 +238,9 @@ class ScreenFragment : Fragment(), ScreenContract.View {
     }
 
     override fun restore() {
-        binding?.progressBarLayout?.progressBar?.visibility = View.VISIBLE
+        if (!hasWebPurchaseLoader) {
+            binding?.progressBarLayout?.progressBar?.visibility = View.VISIBLE
+        }
 
         val action = QAction(QAction.Type.Restore)
         delegate?.onActionStartedExecuting(action)
@@ -506,6 +511,10 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         act.runOnUiThread {
             binding?.webView?.evaluateJavascript(js) { completion() }
         }
+    }
+
+    override fun setHasWebPurchaseLoader(value: Boolean) {
+        hasWebPurchaseLoader = value
     }
 
     @JavascriptInterface

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -113,7 +113,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         binding = null
     }
 
-    override fun displayScreen(screenId: String, html: String) {
+    override fun displayScreen(screenId: String, html: String, products: List<String>) {
         activity?.runOnUiThread {
             binding?.webView?.loadDataWithBaseURL(
                 null,
@@ -122,7 +122,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
                 ENCODING,
                 null
             )
-            delegate?.onScreenShown(screenId)
+            delegate?.onScreenShown(screenId, products)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -31,6 +31,7 @@ import com.qonversion.android.sdk.listeners.QonversionPurchaseCallback
 import io.qonversion.nocodes.databinding.NcFragmentScreenBinding
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.NoCodesLoadingView
 import io.qonversion.nocodes.internal.di.DependenciesAssembly
@@ -113,7 +114,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         binding = null
     }
 
-    override fun displayScreen(screenId: String, html: String, products: List<String>) {
+    override fun displayScreen(screenId: String, html: String, products: List<String>, variables: List<QScreenVariable>) {
         activity?.runOnUiThread {
             binding?.webView?.loadDataWithBaseURL(
                 null,
@@ -122,7 +123,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
                 ENCODING,
                 null
             )
-            delegate?.onScreenShown(screenId, products)
+            delegate?.onScreenShown(screenId, products, variables)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -82,7 +82,7 @@ internal class ScreenPresenter(
 
             var processedHtml = injectCustomLocale(screen.body)
             processedHtml = injectTheme(processedHtml)
-            view.displayScreen(screen.id, processedHtml)
+            view.displayScreen(screen.id, processedHtml, screen.products)
 
             val shownEvent = ScreenEvent(data = mapOf(
                 "type" to ScreenEventType.ScreenShown.value,

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -187,6 +187,9 @@ internal class ScreenPresenter(
             QAction.Type.ScreenAnalytics -> {
                 handleScreenAnalyticsAction(action)
             }
+            QAction.Type.PurchaseLoaderPresent -> {
+                view.setHasWebPurchaseLoader(true)
+            }
             else -> {
                 logger.warn("ScreenPresenter -> action type ${action.type} is not supported")
             }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -82,7 +82,7 @@ internal class ScreenPresenter(
 
             var processedHtml = injectCustomLocale(screen.body)
             processedHtml = injectTheme(processedHtml)
-            view.displayScreen(screen.id, processedHtml, screen.products)
+            view.displayScreen(screen.id, processedHtml, screen.products, screen.variables)
 
             val shownEvent = ScreenEvent(data = mapOf(
                 "type" to ScreenEventType.ScreenShown.value,

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.CustomVariablesDelegate
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
@@ -109,8 +110,9 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
     }
 
     // NoCodesDelegate implementation
-    override fun onScreenShown(screenId: String, products: List<String>) {
-        addEvent(getString(R.string.screen_shown, "$screenId, products: $products"))
+    override fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        val vars = variables.joinToString(", ") { "${it.key}=${it.value}" }
+        addEvent(getString(R.string.screen_shown, "$screenId, products: $products, variables: [$vars]"))
     }
 
     override fun onScreenFailedToLoad(error: NoCodesError) {

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -109,8 +109,8 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
     }
 
     // NoCodesDelegate implementation
-    override fun onScreenShown(screenId: String) {
-        addEvent(getString(R.string.screen_shown, screenId))
+    override fun onScreenShown(screenId: String, products: List<String>) {
+        addEvent(getString(R.string.screen_shown, "$screenId, products: $products"))
     }
 
     override fun onScreenFailedToLoad(error: NoCodesError) {


### PR DESCRIPTION
NoCodes SDK batch for the three DEV-1167 subtasks, combined into one PR per repo (supersedes the previous stacked PRs).

## Included
- **[DEV-1169] products at screen load** — decode `products` in the screen DTO; surface them on the screen-shown callback.
- **[DEV-1170] screen variables at screen load** — decode authored screen `variables`; surface them on the same callback (Android also adds the module's first JVM unit test).
- **[DEV-1168] suppress native purchase spinner** — new `purchaseLoaderPresent` action; gate the native spinner when the web page renders its own purchase loader (pairs with dash-mono#547).

Linear: [DEV-1167](https://linear.app/qonversion/issue/DEV-1167) (umbrella). Base `develop`. Commits are per-feature and linear.

Supersedes: iOS #693/#694/#695 · Android #828/#829/#830 (closed in favour of this PR).