### PR TITLE
feat(nocodes): surface configured products + screen variables at screen load [DEV-1169][DEV-1170]

### DIFF
--- a/nocodes/build.gradle
+++ b/nocodes/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     
     api project(':sdk')
 
+    testImplementation 'junit:junit:4.13.2'
+
     androidTestImplementation 'androidx.test:core:1.5.0'
     androidTestImplementation "androidx.test:runner:1.5.2"
     androidTestImplementation "androidx.test:rules:1.5.0"

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
@@ -1,0 +1,18 @@
+package io.qonversion.nocodes.dto
+
+/**
+ * A No-Code screen variable authored in the builder, delivered to the SDK at screen load so it
+ * can be read by [key] after the screen appears.
+ *
+ * [value] keeps its authored native type (Boolean / String / Number) rather than being coerced
+ * to a String, matching the declared [type].
+ *
+ * @property key variable name it is addressed by (`variable.<key>` in the builder); may contain spaces.
+ * @property type authored type: `"boolean"`, `"string"` or `"number"`.
+ * @property value the authored default value, preserving its native type (may be null).
+ */
+data class QScreenVariable(
+    val key: String,
+    val type: String,
+    val value: Any?,
+)

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -1,6 +1,7 @@
 package io.qonversion.nocodes.interfaces
 
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.error.NoCodesError
 import com.qonversion.android.sdk.Qonversion
@@ -27,6 +28,22 @@ interface NoCodesDelegate {
      */
     fun onScreenShown(screenId: String, products: List<String>) {
         onScreenShown(screenId)
+    }
+
+    /**
+     * Called when No-Code screen is shown, providing the screen variables authored on it.
+     * Read them by [QScreenVariable.key] to react to the screen's configured values after it
+     * loads; each value keeps its authored type (bool / string / number).
+     *
+     * The default implementation delegates to [onScreenShown], so existing implementations keep
+     * working and this callback fires exactly once.
+     *
+     * @param screenId shown screen Id.
+     * @param products Qonversion product ids configured on the screen (may be empty).
+     * @param variables screen variables authored on the screen (may be empty).
+     */
+    fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        onScreenShown(screenId, products)
     }
 
     /**

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -15,6 +15,21 @@ interface NoCodesDelegate {
     fun onScreenShown(screenId: String) { }
 
     /**
+     * Called when No-Code screen is shown, providing the product ids configured on that screen.
+     * Use this to keep analytics consistent with the full set of products the screen was built
+     * with, not only the ones the rendered screen requested.
+     *
+     * The default implementation delegates to [onScreenShown], so existing implementations keep
+     * working and this callback fires exactly once.
+     *
+     * @param screenId shown screen Id.
+     * @param products Qonversion product ids configured on the screen (may be empty).
+     */
+    fun onScreenShown(screenId: String, products: List<String>) {
+        onScreenShown(screenId)
+    }
+
+    /**
      * Called when No-Code screen starts executing an action.
      *
      * @param action action that is being executed.

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
@@ -1,5 +1,6 @@
 package io.qonversion.nocodes.internal.common.mappers
 
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.internal.dto.NoCodeScreen
 
 internal class ScreenMapper : Mapper<NoCodeScreen?> {
@@ -16,11 +17,23 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
         // Missing/absent `products` (older payloads, bundled fallbacks) → empty list.
         val products = data.getList("products")?.filterIsInstance<String>() ?: emptyList()
 
+        // Missing/absent `variables` → empty list. Each entry is {key, type, value}; the value
+        // keeps its native type. Entries without a key are skipped; a missing type falls back to
+        // "string" (mirrors the backend extractor).
+        val variables = data.getList("variables")
+            ?.filterIsInstance<Map<*, *>>()
+            ?.mapNotNull { item ->
+                val key = item.getString("key") ?: return@mapNotNull null
+                val type = item.getString("type") ?: "string"
+                QScreenVariable(key, type, item["value"])
+            } ?: emptyList()
+
         return NoCodeScreen(
             id,
             body,
             contextKey,
             products,
+            variables,
         )
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
@@ -13,10 +13,14 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
             return null
         }
 
+        // Missing/absent `products` (older payloads, bundled fallbacks) → empty list.
+        val products = data.getList("products")?.filterIsInstance<String>() ?: emptyList()
+
         return NoCodeScreen(
             id,
             body,
             contextKey,
+            products,
         )
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
@@ -1,9 +1,13 @@
 package io.qonversion.nocodes.internal.dto
 
+import io.qonversion.nocodes.dto.QScreenVariable
+
 internal data class NoCodeScreen(
     val id: String,
     val body: String,
     val contextKey: String,
     // Qonversion product ids configured in the builder for this screen (may be empty).
-    val products: List<String> = emptyList()
+    val products: List<String> = emptyList(),
+    // Screen variables authored in the builder for this screen, read by key (may be empty).
+    val variables: List<QScreenVariable> = emptyList()
 )

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
@@ -3,5 +3,7 @@ package io.qonversion.nocodes.internal.dto
 internal data class NoCodeScreen(
     val id: String,
     val body: String,
-    val contextKey: String
+    val contextKey: String,
+    // Qonversion product ids configured in the builder for this screen (may be empty).
+    val products: List<String> = emptyList()
 )

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
@@ -3,6 +3,7 @@ package io.qonversion.nocodes.internal.dto.config
 import android.os.Handler
 import android.os.Looper
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
 import io.qonversion.nocodes.error.NoCodesError
 
@@ -15,6 +16,12 @@ class NoCodesDelegateWrapper(
     override fun onScreenShown(screenId: String, products: List<String>) {
         mainHandler.post {
             delegate.onScreenShown(screenId, products)
+        }
+    }
+
+    override fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        mainHandler.post {
+            delegate.onScreenShown(screenId, products, variables)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
@@ -12,9 +12,9 @@ class NoCodesDelegateWrapper(
 
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    override fun onScreenShown(screenId: String) {
+    override fun onScreenShown(screenId: String, products: List<String>) {
         mainHandler.post {
-            delegate.onScreenShown(screenId)
+            delegate.onScreenShown(screenId, products)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -4,7 +4,7 @@ import io.qonversion.nocodes.dto.QAction
 
 internal class ScreenContract {
     interface View {
-        fun displayScreen(screenId: String, html: String)
+        fun displayScreen(screenId: String, html: String, products: List<String>)
 
         fun navigateToScreen(screenId: String)
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -1,10 +1,11 @@
 package io.qonversion.nocodes.internal.screen.view
 
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 
 internal class ScreenContract {
     interface View {
-        fun displayScreen(screenId: String, html: String, products: List<String>)
+        fun displayScreen(screenId: String, html: String, products: List<String>, variables: List<QScreenVariable>)
 
         fun navigateToScreen(screenId: String)
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -113,7 +113,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         binding = null
     }
 
-    override fun displayScreen(screenId: String, html: String) {
+    override fun displayScreen(screenId: String, html: String, products: List<String>) {
         activity?.runOnUiThread {
             binding?.webView?.loadDataWithBaseURL(
                 null,
@@ -122,7 +122,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
                 ENCODING,
                 null
             )
-            delegate?.onScreenShown(screenId)
+            delegate?.onScreenShown(screenId, products)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -31,6 +31,7 @@ import com.qonversion.android.sdk.listeners.QonversionPurchaseCallback
 import io.qonversion.nocodes.databinding.NcFragmentScreenBinding
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.NoCodesLoadingView
 import io.qonversion.nocodes.internal.di.DependenciesAssembly
@@ -113,7 +114,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         binding = null
     }
 
-    override fun displayScreen(screenId: String, html: String, products: List<String>) {
+    override fun displayScreen(screenId: String, html: String, products: List<String>, variables: List<QScreenVariable>) {
         activity?.runOnUiThread {
             binding?.webView?.loadDataWithBaseURL(
                 null,
@@ -122,7 +123,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
                 ENCODING,
                 null
             )
-            delegate?.onScreenShown(screenId, products)
+            delegate?.onScreenShown(screenId, products, variables)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -82,7 +82,7 @@ internal class ScreenPresenter(
 
             var processedHtml = injectCustomLocale(screen.body)
             processedHtml = injectTheme(processedHtml)
-            view.displayScreen(screen.id, processedHtml)
+            view.displayScreen(screen.id, processedHtml, screen.products)
 
             val shownEvent = ScreenEvent(data = mapOf(
                 "type" to ScreenEventType.ScreenShown.value,

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -82,7 +82,7 @@ internal class ScreenPresenter(
 
             var processedHtml = injectCustomLocale(screen.body)
             processedHtml = injectTheme(processedHtml)
-            view.displayScreen(screen.id, processedHtml, screen.products)
+            view.displayScreen(screen.id, processedHtml, screen.products, screen.variables)
 
             val shownEvent = ScreenEvent(data = mapOf(
                 "type" to ScreenEventType.ScreenShown.value,

--- a/nocodes/src/test/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapperTest.kt
+++ b/nocodes/src/test/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapperTest.kt
@@ -1,0 +1,42 @@
+package io.qonversion.nocodes.internal.common.mappers
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScreenMapperTest {
+
+    private val mapper = ScreenMapper()
+
+    private fun baseScreen(vararg extra: Pair<String, Any?>): Map<String, Any?> =
+        mapOf("id" to "s1", "body" to "<html>", "context_key" to "ctx", *extra)
+
+    @Test
+    fun `decodes configured products list`() {
+        val screen = mapper.fromMap(baseScreen("products" to listOf("annual", "weekly")))
+        assertEquals(listOf("annual", "weekly"), screen?.products)
+    }
+
+    @Test
+    fun `missing products defaults to empty list`() {
+        val screen = mapper.fromMap(baseScreen())
+        assertEquals(emptyList<String>(), screen?.products)
+    }
+
+    @Test
+    fun `empty products stays empty`() {
+        val screen = mapper.fromMap(baseScreen("products" to emptyList<String>()))
+        assertEquals(emptyList<String>(), screen?.products)
+    }
+
+    @Test
+    fun `non-string product entries are dropped`() {
+        val screen = mapper.fromMap(baseScreen("products" to listOf("a", 1, null, "b")))
+        assertEquals(listOf("a", "b"), screen?.products)
+    }
+
+    @Test
+    fun `returns null when a required field is missing`() {
+        assertNull(mapper.fromMap(mapOf("id" to "s1", "body" to "<html>")))
+    }
+}

--- a/nocodes/src/test/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapperTest.kt
+++ b/nocodes/src/test/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapperTest.kt
@@ -1,5 +1,6 @@
 package io.qonversion.nocodes.internal.common.mappers
 
+import io.qonversion.nocodes.dto.QScreenVariable
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -38,5 +39,59 @@ class ScreenMapperTest {
     @Test
     fun `returns null when a required field is missing`() {
         assertNull(mapper.fromMap(mapOf("id" to "s1", "body" to "<html>")))
+    }
+
+    // DEV-1170 — authored screen variables, native types preserved by key.
+    @Test
+    fun `decodes typed variables preserving native types`() {
+        val screen = mapper.fromMap(
+            baseScreen(
+                "variables" to listOf(
+                    mapOf("key" to "isTrial", "type" to "boolean", "value" to true),
+                    mapOf("key" to "headline", "type" to "string", "value" to "Go Premium"),
+                    mapOf("key" to "discount", "type" to "number", "value" to 30.0),
+                ),
+            ),
+        )
+        assertEquals(
+            listOf(
+                QScreenVariable("isTrial", "boolean", true),
+                QScreenVariable("headline", "string", "Go Premium"),
+                QScreenVariable("discount", "number", 30.0),
+            ),
+            screen?.variables,
+        )
+    }
+
+    // Real-data edge cases (staging): space in key, empty-string default kept.
+    @Test
+    fun `preserves space in key and empty string default`() {
+        val screen = mapper.fromMap(
+            baseScreen(
+                "variables" to listOf(
+                    mapOf("key" to "variable name", "type" to "string", "value" to ""),
+                ),
+            ),
+        )
+        assertEquals(listOf(QScreenVariable("variable name", "string", "")), screen?.variables)
+    }
+
+    @Test
+    fun `skips variable without a key and defaults missing type to string`() {
+        val screen = mapper.fromMap(
+            baseScreen(
+                "variables" to listOf(
+                    mapOf("type" to "string", "value" to "orphan"), // no key -> dropped
+                    mapOf("key" to "legacy", "value" to "y"), // missing type -> "string"
+                ),
+            ),
+        )
+        assertEquals(listOf(QScreenVariable("legacy", "string", "y")), screen?.variables)
+    }
+
+    @Test
+    fun `missing variables defaults to empty list`() {
+        val screen = mapper.fromMap(baseScreen())
+        assertEquals(emptyList<QScreenVariable>(), screen?.variables)
     }
 }

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.CustomVariablesDelegate
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
@@ -109,8 +110,9 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
     }
 
     // NoCodesDelegate implementation
-    override fun onScreenShown(screenId: String, products: List<String>) {
-        addEvent(getString(R.string.screen_shown, "$screenId, products: $products"))
+    override fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
+        val vars = variables.joinToString(", ") { "${it.key}=${it.value}" }
+        addEvent(getString(R.string.screen_shown, "$screenId, products: $products, variables: [$vars]"))
     }
 
     override fun onScreenFailedToLoad(error: NoCodesError) {

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -109,8 +109,8 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
     }
 
     // NoCodesDelegate implementation
-    override fun onScreenShown(screenId: String) {
-        addEvent(getString(R.string.screen_shown, screenId))
+    override fun onScreenShown(screenId: String, products: List<String>) {
+        addEvent(getString(R.string.screen_shown, "$screenId, products: $products"))
     }
 
     override fun onScreenFailedToLoad(error: NoCodesError) {


### PR DESCRIPTION
Combines the two DEV-1167 sibling features into **one PR / one release per repo** instead of shipping products (DEV-1169) and variables (DEV-1170) as separate rollouts:

- **DEV-1169** — configured product IDs at screen load
- **DEV-1170** — authored screen variables (read by key, native types) at screen load

Both surface the same way (computed on read from the screen configs blob; additive field/callback; defensive parsing; no schema change). This branch = the DEV-1169 commits + the DEV-1170 commit(s) folded in. Supersedes the separate DEV-1169 and DEV-1170 PRs (closed).

Verification recap (local, on real data/DB where possible): PHP + Go extractors unit-tested and parity-checked against the same real staging `published_configs` blobs; configurator read path exercised through the real repo query on a live MySQL; iOS decode executed in Swift runtime; Android `ScreenMapper` JVM unit tests pass (`:nocodes:testDebugUnitTest`).