### PR TITLE
Pass original client Throwable through NoCodesError.fromClientThrowable

### DIFF
--- a/nocodes/src/main/java/io/qonversion/nocodes/error/NoCodesError.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/error/NoCodesError.kt
@@ -6,6 +6,7 @@ class NoCodesError(
     val code: ErrorCode,
     val details: String? = null,
     val qonversionError: QonversionError? = null, /** is present, if the [code] is [ErrorCode.QonversionError] */
+    val cause: Throwable? = null, /** is present, if the [code] is [ErrorCode.ClientError] - the original error thrown by the client's purchase delegate */
 ) {
     constructor(qonversionError: QonversionError) : this(ErrorCode.QonversionError, null, qonversionError)
 
@@ -19,7 +20,8 @@ class NoCodesError(
         fun fromClientThrowable(throwable: Throwable?): NoCodesError {
             return NoCodesError(
                 ErrorCode.ClientError,
-                throwable?.message ?: throwable?.toString() ?: "Unknown error"
+                throwable?.message ?: throwable?.toString() ?: "Unknown error",
+                cause = throwable
             )
         }
     }

--- a/nocodes/src/main/java/io/qonversion/nocodes/error/NoCodesError.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/error/NoCodesError.kt
@@ -5,8 +5,10 @@ import com.qonversion.android.sdk.dto.QonversionError
 class NoCodesError(
     val code: ErrorCode,
     val details: String? = null,
-    val qonversionError: QonversionError? = null, /** is present, if the [code] is [ErrorCode.QonversionError] */
-    val cause: Throwable? = null, /** is present, if the [code] is [ErrorCode.ClientError] - the original error thrown by the client's purchase delegate */
+    /** is present, if the [code] is [ErrorCode.QonversionError] */
+    val qonversionError: QonversionError? = null,
+    /** is present, if the [code] is [ErrorCode.ClientError] - the original error thrown by the client's purchase delegate */
+    val cause: Throwable? = null,
 ) {
     constructor(qonversionError: QonversionError) : this(ErrorCode.QonversionError, null, qonversionError)
 


### PR DESCRIPTION
## Problem

Android counterpart of qonversion/qonversion-ios-sdk#698. When a custom `PurchaseDelegate` (or `PurchaseDelegateWithCallbacks` via the adapter) throws from `purchase()` or `restore()`, `ScreenFragment` wraps the error via `NoCodesError.fromClientThrowable(throwable)` and forwards it to the main `NoCodesDelegate` through `action.error` in `onActionFailedToExecute(action)`. Only `throwable.message` was copied into `details` — the original `Throwable` was dropped, and `NoCodesError` had no field to carry it.

## Fix

Add `cause: Throwable?` to `NoCodesError` (populated only for `ErrorCode.ClientError`) and pass the original throwable in `fromClientThrowable`. Clients access it via `action.error?.cause`.

- The `?: throwable?.toString()` fallback is kept — `Throwable.message` is nullable in Kotlin, unlike Swift's `localizedDescription`.
- New constructor param has a default value — source-compatible, no call-site changes.
- Covers both purchase and restore paths (both call sites use the same factory).

Verified: `:nocodes:compileReleaseKotlin` passes.

[DEV-1172](https://linear.app/qonversion/issue/DEV-1172/no-codes-android-original-client-throwable-is-lost-when-wrapping-into)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zCom8YGU7znenFE52cWoP