### PR TITLE
feat: [DEV-1174] Support custom builder actions delivered via NoCodesDelegate

### DIFF
--- a/nocodes/build.gradle
+++ b/nocodes/build.gradle
@@ -34,6 +34,13 @@ android {
         jvmToolchain(17)
     }
 
+    kotlinOptions {
+        // Compile interface default methods (NoCodesDelegate & co.) to real JVM default
+        // methods so adding a new one stays source- and binary-compatible for Java
+        // clients; -compatibility keeps DefaultImpls for previously compiled Kotlin code.
+        freeCompilerArgs += ['-Xjvm-default=all-compatibility']
+    }
+
     buildFeatures {
         viewBinding true
         buildConfig true

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QAction.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QAction.kt
@@ -29,7 +29,14 @@ data class QAction(
          * Internal action: the web page announces it renders its own purchase
          * loader, so the native purchase spinner is suppressed (no double loader).
          */
-        PurchaseLoaderPresent("purchaseLoaderPresent");
+        PurchaseLoaderPresent("purchaseLoaderPresent"),
+
+        /**
+         * Custom action configured in the builder. The SDK does not execute anything
+         * itself — the configured string value is delivered to the app code via
+         * [io.qonversion.nocodes.interfaces.NoCodesDelegate.onCustomAction].
+         */
+        Custom("custom");
 
         companion object {
             fun from(type: String?): Type {
@@ -48,7 +55,8 @@ data class QAction(
         ProductIds("productIds"),
         ScreenId("screenId"),
         AnalyticsType("type"),
-        PageIndex("page_index");
+        PageIndex("page_index"),
+        Value("value");
 
         companion object {
             fun from(key: String?) = entries.find { it.key == key }

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -74,7 +74,8 @@ interface NoCodesDelegate {
      * The No-Codes SDK does not execute anything itself — handle the value in your app code.
      * The screen stays open; close it using [NoCodes.close] if needed.
      *
-     * @param value the string value configured for the custom action in the builder.
+     * @param value the string value configured for the custom action in the builder,
+     * or an empty string if no value was configured.
      */
     fun onCustomAction(value: String) { }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -70,6 +70,15 @@ interface NoCodesDelegate {
     fun onActionFinishedExecuting(action: QAction) { }
 
     /**
+     * Called when a custom action configured in the builder is triggered on the screen.
+     * The No-Codes SDK does not execute anything itself — handle the value in your app code.
+     * The screen stays open; close it using [NoCodes.close] if needed.
+     *
+     * @param value the string value configured for the custom action in the builder.
+     */
+    fun onCustomAction(value: String) { }
+
+    /**
      * Called when No-Code flow is finished and the screen is closed.
      */
     fun onFinished() { }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
@@ -43,6 +43,12 @@ class NoCodesDelegateWrapper(
         }
     }
 
+    override fun onCustomAction(value: String) {
+        mainHandler.post {
+            delegate.onCustomAction(value)
+        }
+    }
+
     override fun onFinished() {
         mainHandler.post {
             delegate.onFinished()

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -32,6 +32,8 @@ internal class ScreenContract {
         fun setVariable(name: String, value: String, completion: () -> Unit = {})
 
         fun setHasWebPurchaseLoader(value: Boolean)
+
+        fun handleCustomAction(value: String)
     }
 
     internal interface Presenter {

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -140,6 +140,13 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         }
     }
 
+    override fun handleCustomAction(value: String) {
+        val action = QAction(QAction.Type.Custom, QAction.Parameter.Value, value)
+        delegate?.onActionStartedExecuting(action)
+        delegate?.onCustomAction(value)
+        delegate?.onActionFinishedExecuting(action)
+    }
+
     override fun openLink(url: String) {
         val action = QAction(QAction.Type.Url, QAction.Parameter.Url, url)
         delegate?.onActionStartedExecuting(action)

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -191,12 +191,8 @@ internal class ScreenPresenter(
                 view.setHasWebPurchaseLoader(true)
             }
             QAction.Type.Custom -> {
-                val value = action.parameters?.get(QAction.Parameter.Value) as? String
-                if (value != null) {
-                    view.handleCustomAction(value)
-                } else {
-                    logger.warn("ScreenPresenter -> custom action is missing the 'value' parameter")
-                }
+                val value = action.parameters?.get(QAction.Parameter.Value) as? String ?: ""
+                view.handleCustomAction(value)
             }
             else -> {
                 logger.warn("ScreenPresenter -> action type ${action.type} is not supported")

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -190,6 +190,14 @@ internal class ScreenPresenter(
             QAction.Type.PurchaseLoaderPresent -> {
                 view.setHasWebPurchaseLoader(true)
             }
+            QAction.Type.Custom -> {
+                val value = action.parameters?.get(QAction.Parameter.Value) as? String
+                if (value != null) {
+                    view.handleCustomAction(value)
+                } else {
+                    logger.warn("ScreenPresenter -> custom action is missing the 'value' parameter")
+                }
+            }
             else -> {
                 logger.warn("ScreenPresenter -> action type ${action.type} is not supported")
             }


### PR DESCRIPTION
Issue: [DEV-1174](https://linear.app/qonversion/issue/DEV-1174)

## Summary
Adds support for the new **Custom action** configured in the No Codes builder (dash-mono#554). Wire contract: `{type: 'custom', parameters: {value: '<string>'}}`.

- New `QAction.Type.Custom("custom")` and `QAction.Parameter.Value("value")`
- New delegate method `onCustomAction(value: String)` with a default no-op body — existing implementations keep compiling, **minor release**
- The SDK executes nothing itself: `onActionStartedExecuting` → `onCustomAction(value)` → `onActionFinishedExecuting` (main-thread via `NoCodesDelegateWrapper`); a missing `value` is delivered as an empty string
- The screen stays open — the client decides whether to close it
- Enables `-Xjvm-default=all-compatibility` for the nocodes module so interface default methods compile to real JVM defaults: adding delegate callbacks stays source/binary-compatible for Java clients too (`-compatibility` keeps DefaultImpls for previously compiled Kotlin code)

## Testing
- `./gradlew :nocodes:assembleRelease` passes
- `./gradlew detektAll` passes

Fixes [DEV-1174](https://linear.app/qonversion/issue/DEV-1174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KQDQpPzKctBcLGHVpet57