### PR TITLE
feat: add load-before-present API for No-Codes screens

### DIFF
--- a/nocodes/src/androidTest/java/io/qonversion/nocodes/internal/NoCodesIntegrationTest.kt
+++ b/nocodes/src/androidTest/java/io/qonversion/nocodes/internal/NoCodesIntegrationTest.kt
@@ -1,22 +1,34 @@
 package io.qonversion.nocodes.internal
 
+import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.NoCodesConfig
 import io.qonversion.nocodes.dto.LogLevel
+import io.qonversion.nocodes.dto.QNoCodeScreen
 import io.qonversion.nocodes.error.ErrorCode
+import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.error.NoCodesException
+import io.qonversion.nocodes.interfaces.NoCodesScreenLoadCallback
 import io.qonversion.nocodes.internal.di.DependenciesAssembly
 import io.qonversion.nocodes.internal.dto.config.InternalConfig
+import io.qonversion.nocodes.internal.networkLayer.RetryPolicy
+import io.qonversion.nocodes.internal.networkLayer.apiInteractor.ApiInteractor
+import io.qonversion.nocodes.internal.networkLayer.dto.Request
+import io.qonversion.nocodes.internal.networkLayer.dto.Response
 import io.qonversion.nocodes.internal.screen.service.ScreenService
+import io.qonversion.nocodes.internal.screen.service.ScreenServiceImpl
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 private const val PROJECT_KEY = "V4pK6FQo3PiDPj_2vYO1qZpNBbFXNP-a"
 private const val INCORRECT_PROJECT_KEY = "V4pK6FQo3PiDPj_2vYO1qZpNBbFXNP-aaaaa"
@@ -28,6 +40,8 @@ private const val NON_EXISTENT_CONTEXT_KEY = "non_existent_test_context_key"
 private const val VALID_SCREEN_ID = "RkgXghGq"
 private const val CONTEXT_KEY_FOR_SCREEN_BY_ID = "another_test_context_key"
 private const val NON_EXISTENT_SCREEN_ID = "non_existent_screen_id"
+
+private const val CALLBACK_TIMEOUT_SEC = 30L
 
 @RunWith(AndroidJUnit4::class)
 internal class NoCodesIntegrationTest {
@@ -239,6 +253,140 @@ internal class NoCodesIntegrationTest {
         signal.await()
     }
 
+    // loadScreen — load-before-present
+
+    @Test
+    fun loadScreenByContextKeyReturnsScreenWithPublicIdentifiers() {
+        // given
+        val noCodes = getNoCodes()
+
+        // when
+        runBlocking {
+            val screen = noCodes.loadScreen(VALID_CONTEXT_KEY)
+
+            // then
+            // The public identifiers must be readable by consumers outside the module.
+            assertEquals("Public context key should match", VALID_CONTEXT_KEY, screen.contextKey)
+            assertEquals("Public screen ID should match", ID_FOR_SCREEN_BY_CONTEXT_KEY, screen.id)
+        }
+    }
+
+    @Test
+    fun loadScreenWithNonExistentContextKeyThrowsScreenNotFound() {
+        // given
+        val noCodes = getNoCodes()
+
+        // when
+        runBlocking {
+            try {
+                noCodes.loadScreen(NON_EXISTENT_CONTEXT_KEY)
+                fail("Should fail with non-existent context key")
+            } catch (e: NoCodesException) {
+                // then
+                // A genuinely absent screen is surfaced with a distinct code, so callers can
+                // branch "show fallback" vs "transient failure, maybe retry".
+                assertEquals("Error code should be ScreenNotFound", ErrorCode.ScreenNotFound, e.code)
+            }
+        }
+    }
+
+    @Test
+    fun loadScreenWithCallbackDeliversScreenOnMainThread() {
+        // given
+        val signal = CountDownLatch(1)
+        val noCodes = getNoCodes()
+        var loadedScreen: QNoCodeScreen? = null
+        var loadError: NoCodesError? = null
+        var wasMainThread = false
+
+        // when
+        noCodes.loadScreen(VALID_CONTEXT_KEY, object : NoCodesScreenLoadCallback {
+            override fun onSuccess(screen: QNoCodeScreen) {
+                loadedScreen = screen
+                wasMainThread = Looper.myLooper() == Looper.getMainLooper()
+                signal.countDown()
+            }
+
+            override fun onError(error: NoCodesError) {
+                loadError = error
+                signal.countDown()
+            }
+        })
+
+        // then
+        assertTrue("Callback should be invoked", signal.await(CALLBACK_TIMEOUT_SEC, TimeUnit.SECONDS))
+        assertNull("Should not fail: $loadError", loadError)
+        assertEquals("Public context key should match", VALID_CONTEXT_KEY, loadedScreen?.contextKey)
+        assertEquals("Public screen ID should match", ID_FOR_SCREEN_BY_CONTEXT_KEY, loadedScreen?.id)
+        assertTrue("Callback should be delivered on the main thread", wasMainThread)
+    }
+
+    @Test
+    fun loadScreenWithCallbackDeliversScreenNotFoundError() {
+        // given
+        val signal = CountDownLatch(1)
+        val noCodes = getNoCodes()
+        var loadedScreen: QNoCodeScreen? = null
+        var loadError: NoCodesError? = null
+        var wasMainThread = false
+
+        // when
+        noCodes.loadScreen(NON_EXISTENT_CONTEXT_KEY, object : NoCodesScreenLoadCallback {
+            override fun onSuccess(screen: QNoCodeScreen) {
+                loadedScreen = screen
+                signal.countDown()
+            }
+
+            override fun onError(error: NoCodesError) {
+                loadError = error
+                wasMainThread = Looper.myLooper() == Looper.getMainLooper()
+                signal.countDown()
+            }
+        })
+
+        // then
+        assertTrue("Callback should be invoked", signal.await(CALLBACK_TIMEOUT_SEC, TimeUnit.SECONDS))
+        assertNull("Should not succeed for non-existent context key", loadedScreen)
+        assertEquals("Error code should be ScreenNotFound", ErrorCode.ScreenNotFound, loadError?.code)
+        assertTrue("Callback should be delivered on the main thread", wasMainThread)
+    }
+
+    @Test
+    fun loadScreenWarmsCacheForSubsequentLoad() {
+        // given
+        // Count network executions to prove the second load is served from cache rather than
+        // the network — a live-backend-only variant would pass even with no caching at all.
+        val dependenciesAssembly = getDependenciesAssembly()
+        val countingApiInteractor = CountingApiInteractor(dependenciesAssembly.exponentialApiInteractor())
+        val screenService = ScreenServiceImpl(
+            dependenciesAssembly.requestConfigurator(),
+            countingApiInteractor,
+            dependenciesAssembly.screenMapper(),
+            null,
+            null,
+            dependenciesAssembly.logger()
+        )
+
+        // when
+        runBlocking {
+            val firstLoad = screenService.getScreen(VALID_CONTEXT_KEY)
+            val secondLoad = screenService.getScreen(VALID_CONTEXT_KEY)
+
+            // then
+            assertEquals("Cached load should return the same screen ID", firstLoad.id, secondLoad.id)
+            assertEquals(
+                "Cached load should return the same context key",
+                firstLoad.contextKey,
+                secondLoad.contextKey
+            )
+            assertEquals(
+                "Second load should be served from cache without a second network request",
+                1,
+                countingApiInteractor.executeCallCount
+            )
+        }
+    }
+
     @Test
     fun preloadScreens() {
         // given
@@ -298,19 +446,51 @@ internal class NoCodesIntegrationTest {
     }
 
     private fun getScreenService(projectKey: String = PROJECT_KEY): ScreenService {
-        val config = NoCodesConfig.Builder(
-            ApplicationProvider.getApplicationContext(),
-            projectKey
-        )
-            .setLogLevel(LogLevel.Verbose)
-            .build()
+        return getDependenciesAssembly(projectKey).screenService()
+    }
 
+    private fun getNoCodes(projectKey: String = PROJECT_KEY): NoCodes {
+        val config = buildConfig(projectKey)
         val internalConfig = InternalConfig(config)
         val dependenciesAssembly = DependenciesAssembly.Builder(
             config.application,
             internalConfig
         ).build()
 
-        return dependenciesAssembly.screenService()
+        return NoCodesInternal(internalConfig, dependenciesAssembly)
+    }
+
+    private fun getDependenciesAssembly(projectKey: String = PROJECT_KEY): DependenciesAssembly {
+        val config = buildConfig(projectKey)
+
+        return DependenciesAssembly.Builder(
+            config.application,
+            InternalConfig(config)
+        ).build()
+    }
+
+    private fun buildConfig(projectKey: String): NoCodesConfig {
+        return NoCodesConfig.Builder(
+            ApplicationProvider.getApplicationContext(),
+            projectKey
+        )
+            .setLogLevel(LogLevel.Verbose)
+            .build()
+    }
+}
+
+private class CountingApiInteractor(private val wrapped: ApiInteractor) : ApiInteractor {
+
+    var executeCallCount = 0
+        private set
+
+    override suspend fun execute(request: Request): Response {
+        executeCallCount++
+        return wrapped.execute(request)
+    }
+
+    override suspend fun execute(request: Request, retryPolicy: RetryPolicy): Response {
+        executeCallCount++
+        return wrapped.execute(request, retryPolicy)
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/NoCodes.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/NoCodes.kt
@@ -3,7 +3,10 @@ package io.qonversion.nocodes
 import android.util.Log
 import io.qonversion.nocodes.dto.LogLevel
 import io.qonversion.nocodes.dto.NoCodesTheme
+import io.qonversion.nocodes.dto.QNoCodeScreen
+import io.qonversion.nocodes.error.NoCodesException
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
+import io.qonversion.nocodes.interfaces.NoCodesScreenLoadCallback
 import io.qonversion.nocodes.interfaces.PurchaseDelegate
 import io.qonversion.nocodes.interfaces.PurchaseDelegateWithCallbacks
 import io.qonversion.nocodes.internal.NoCodesInternal
@@ -111,6 +114,44 @@ interface NoCodes {
      * @param contextKey the context key of the screen which must be shown.
      */
     fun showScreen(contextKey: String)
+
+    /**
+     * Load a No-Code screen (from cache or network) without presenting it, so you can decide
+     * whether to present it or show your own fallback UI before any SDK screen appears.
+     *
+     * This is an optional entry point, not the primary loader: screens with the "Preload" option
+     * enabled in the No-Codes builder are preloaded automatically at SDK initialization,
+     * and [showScreen] works on its own.
+     *
+     * A successful load warms the shared screens cache, so a following [showScreen] call
+     * with the same context key renders from cache.
+     *
+     * Unlike [showScreen], this call does not flush pending user properties, so the targeting
+     * basis may differ slightly from a direct [showScreen] call.
+     *
+     * For Java or callback-based usage, see the [loadScreen] overload accepting
+     * a [NoCodesScreenLoadCallback].
+     *
+     * @param contextKey the context key of the screen.
+     * @return the loaded [QNoCodeScreen].
+     * @throws NoCodesException with the code [io.qonversion.nocodes.error.ErrorCode.ScreenNotFound]
+     * when no screen exists for the provided context key, or another code on a network
+     * or other load failure.
+     */
+    @Throws(NoCodesException::class)
+    suspend fun loadScreen(contextKey: String): QNoCodeScreen
+
+    /**
+     * Load a No-Code screen (from cache or network) without presenting it, so you can decide
+     * whether to present it or show your own fallback UI before any SDK screen appears.
+     *
+     * This is a callback-based variant of the suspend [loadScreen] — see its documentation
+     * for details. The [callback] is invoked on the main thread.
+     *
+     * @param contextKey the context key of the screen.
+     * @param callback callback to be notified with the loaded screen or an error.
+     */
+    fun loadScreen(contextKey: String, callback: NoCodesScreenLoadCallback)
 
     /**
      * Use this function to close all No-Code Screens.

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QNoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QNoCodeScreen.kt
@@ -1,0 +1,15 @@
+package io.qonversion.nocodes.dto
+
+/**
+ * A loaded No-Code screen returned from [io.qonversion.nocodes.NoCodes.loadScreen].
+ *
+ * Exposes only the screen identifiers — the screen content stays internal, as rendering
+ * remains the SDK's job via [io.qonversion.nocodes.NoCodes.showScreen].
+ *
+ * @property id identifier of the screen.
+ * @property contextKey the context key of the screen set in the No-Codes builder.
+ */
+data class QNoCodeScreen(
+    val id: String,
+    val contextKey: String,
+)

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesScreenLoadCallback.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesScreenLoadCallback.kt
@@ -1,0 +1,30 @@
+package io.qonversion.nocodes.interfaces
+
+import io.qonversion.nocodes.dto.QNoCodeScreen
+import io.qonversion.nocodes.error.NoCodesError
+
+/**
+ * Callback for the result of [io.qonversion.nocodes.NoCodes.loadScreen].
+ * Invoked on the main thread.
+ *
+ * This interface uses callback-based methods.
+ * For Kotlin coroutines, use the suspend variant of [io.qonversion.nocodes.NoCodes.loadScreen].
+ */
+interface NoCodesScreenLoadCallback {
+
+    /**
+     * Invoked when the screen was successfully loaded and cached.
+     *
+     * @param screen the loaded screen.
+     */
+    fun onSuccess(screen: QNoCodeScreen)
+
+    /**
+     * Invoked when the screen failed to load.
+     *
+     * @param error the error occurred. [NoCodesError.code] is
+     * [io.qonversion.nocodes.error.ErrorCode.ScreenNotFound] when no screen exists
+     * for the provided context key; other codes indicate a transient load failure.
+     */
+    fun onError(error: NoCodesError)
+}

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/NoCodesInternal.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/NoCodesInternal.kt
@@ -3,7 +3,12 @@ package io.qonversion.nocodes.internal
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.dto.LogLevel
 import io.qonversion.nocodes.dto.NoCodesTheme
+import io.qonversion.nocodes.dto.QNoCodeScreen
+import io.qonversion.nocodes.error.ErrorCode
+import io.qonversion.nocodes.error.NoCodesError
+import io.qonversion.nocodes.error.NoCodesException
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
+import io.qonversion.nocodes.interfaces.NoCodesScreenLoadCallback
 import io.qonversion.nocodes.interfaces.PurchaseDelegate
 import io.qonversion.nocodes.interfaces.PurchaseDelegateWithCallbacks
 import io.qonversion.nocodes.interfaces.CustomVariablesDelegate
@@ -17,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 internal class NoCodesInternal(
     private val internalConfig: InternalConfig,
@@ -65,6 +71,36 @@ internal class NoCodesInternal(
         scope.launch {
             suspendFlushPendingUserProperties()
             screenController.showScreen(contextKey)
+        }
+    }
+
+    override suspend fun loadScreen(contextKey: String): QNoCodeScreen {
+        logger.verbose("loadScreen() -> Loading the screen with the context key $contextKey without presenting")
+        // Pure data load, no presentation. Deliberately skips the pending user properties flush
+        // (unlike showScreen) since nothing is displayed yet.
+        val screen = try {
+            screenService.getScreen(contextKey)
+        } catch (e: Exception) {
+            // The public contract promises NoCodesException, while raw network exceptions
+            // may escape the service layer.
+            throw e as? NoCodesException
+                ?: NoCodesException(ErrorCode.NetworkRequestExecution, e.message, e)
+        }
+        return QNoCodeScreen(screen.id, screen.contextKey)
+    }
+
+    override fun loadScreen(contextKey: String, callback: NoCodesScreenLoadCallback) {
+        scope.launch {
+            try {
+                val screen = loadScreen(contextKey)
+                withContext(Dispatchers.Main) {
+                    callback.onSuccess(screen)
+                }
+            } catch (e: NoCodesException) {
+                withContext(Dispatchers.Main) {
+                    callback.onError(NoCodesError(e))
+                }
+            }
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/NoCodesInternal.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/NoCodesInternal.kt
@@ -18,6 +18,7 @@ import io.qonversion.nocodes.internal.dto.config.InternalConfig
 import io.qonversion.nocodes.internal.dto.config.NoCodesDelegateWrapper
 import io.qonversion.nocodes.internal.dto.config.PurchaseDelegateWithCallbacksAdapter
 import kotlin.coroutines.resume
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -81,6 +82,9 @@ internal class NoCodesInternal(
         val screen = try {
             screenService.getScreen(contextKey)
         } catch (e: Exception) {
+            // Coroutine cancellation must propagate as-is to keep structured concurrency
+            // cooperative — wrapping it would turn a caller's cancel into a "network error".
+            if (e is CancellationException) throw e
             // The public contract promises NoCodesException, while raw network exceptions
             // may escape the service layer.
             throw e as? NoCodesException

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -9,10 +9,12 @@ import androidx.fragment.app.Fragment
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
+import io.qonversion.nocodes.dto.QNoCodeScreen
 import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.CustomVariablesDelegate
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
+import io.qonversion.nocodes.interfaces.NoCodesScreenLoadCallback
 import io.qonversion.sample.databinding.FragmentNocodesBinding
 
 class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
@@ -49,6 +51,16 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
             if (contextKey.isNotEmpty()) {
                 saveLastContextKey(requireContext(), contextKey)
                 showScreen(contextKey)
+            } else {
+                Toast.makeText(context, getString(R.string.please_enter_context_key), Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        binding.buttonLoadThenShowScreen.setOnClickListener {
+            val contextKey = binding.editContextKey.text.toString()
+            if (contextKey.isNotEmpty()) {
+                saveLastContextKey(requireContext(), contextKey)
+                loadThenShowScreen(contextKey)
             } else {
                 Toast.makeText(context, getString(R.string.please_enter_context_key), Toast.LENGTH_SHORT).show()
             }
@@ -94,6 +106,22 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
     private fun showScreen(contextKey: String) {
         addEvent(getString(R.string.showing_screen, contextKey))
         NoCodes.shared.showScreen(contextKey)
+    }
+
+    private fun loadThenShowScreen(contextKey: String) {
+        // Ask-first gate: check the screen's availability before anything is presented,
+        // so on failure we can show our own fallback UI instead of the SDK skeleton.
+        NoCodes.shared.loadScreen(contextKey, object : NoCodesScreenLoadCallback {
+            override fun onSuccess(screen: QNoCodeScreen) {
+                addEvent(getString(R.string.screen_loaded_presenting, screen.id))
+                NoCodes.shared.showScreen(contextKey)
+            }
+
+            override fun onError(error: NoCodesError) {
+                // The SDK skeleton never appeared, so the app can show its own fallback UI here.
+                addEvent(getString(R.string.screen_load_failed_fallback, error.code.toString()))
+            }
+        })
     }
 
     private fun addEvent(event: String) {

--- a/sample/src/main/res/layout/fragment_nocodes.xml
+++ b/sample/src/main/res/layout/fragment_nocodes.xml
@@ -61,6 +61,50 @@
             </LinearLayout>
         </androidx.cardview.widget.CardView>
 
+        <!-- Load Before Present Section -->
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/load_before_present"
+                    android:textColor="@color/colorBlack"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/load_before_present_description"
+                    android:textColor="@color/colorBlack"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonLoadThenShowScreen"
+                    style="@style/Widget.MaterialComponents.Button"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/load_then_show_nocodes_screen"
+                    android:textColor="@color/colorWhite"
+                    app:backgroundTint="@color/colorDark"
+                    app:cornerRadius="8dp" />
+
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
         <!-- Theme Settings Section -->
         <androidx.cardview.widget.CardView
             android:layout_width="match_parent"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -144,6 +144,11 @@
     <string name="show_screen">Show Screen</string>
     <string name="context_key">Context Key</string>
     <string name="show_nocodes_screen">Show No-Code Screen</string>
+    <string name="load_before_present">Load Before Present</string>
+    <string name="load_before_present_description">Ask-first: load the screen, then present it or show your own fallback.</string>
+    <string name="load_then_show_nocodes_screen">Load, Then Present or Fallback</string>
+    <string name="screen_loaded_presenting">Screen loaded (id: %1$s), presenting from warm cache</string>
+    <string name="screen_load_failed_fallback">Load failed (%1$s), showing app fallback instead of the No-Code screen</string>
     <string name="presentation_config">Presentation Config</string>
     <string name="presentation_style">Presentation Style:</string>
     <string name="set_presentation_config">Set Presentation Config</string>


### PR DESCRIPTION
## Summary

Android counterpart of [qonversion-ios-sdk#692](https://github.com/qonversion/qonversion-ios-sdk/pull/692) (Linear: DEV-1178).

Adds a public **ask-first gate** to the No-Codes module so integrators can check a screen's availability (and identifiers) **before** presenting it — then either present the No-Code screen (rendered from a warm cache) or show their own fallback UI, without the SDK screen ever appearing.

```kotlin
// Kotlin coroutines
try {
    NoCodes.shared.loadScreen(contextKey)   // warms cache
    NoCodes.shared.showScreen(contextKey)   // renders from cache
} catch (e: NoCodesException) {
    presentOwnFallbackUi()                  // SDK screen never shown
}

// Callback-based (Java-friendly), delivered on the main thread
NoCodes.shared.loadScreen(contextKey, object : NoCodesScreenLoadCallback {
    override fun onSuccess(screen: QNoCodeScreen) = NoCodes.shared.showScreen(contextKey)
    override fun onError(error: NoCodesError) = presentOwnFallbackUi()
})
```

This is **purely additive** — `showScreen` and the delegate APIs are unchanged.

## What changed

- **`NoCodes.loadScreen(contextKey)`** — two public variants, following the module's existing `PurchaseDelegate` (suspend) / `PurchaseDelegateWithCallbacks` duality:
  - `suspend fun loadScreen(contextKey: String): QNoCodeScreen` — throws `NoCodesException`; wraps raw network exceptions escaping the service layer into `NoCodesException(ErrorCode.NetworkRequestExecution)` so the public contract holds, while `ScreenNotFound` stays distinguishable.
  - `fun loadScreen(contextKey: String, callback: NoCodesScreenLoadCallback)` — callback invoked on the main thread.
- **`QNoCodeScreen`** — new public DTO with `id` and `contextKey` only; the internal `NoCodeScreen` (with `body`) stays internal, mirroring iOS where only `id`/`contextKey` became public (rendering remains the SDK's job).
- **`NoCodesScreenLoadCallback`** — new public callback interface (`onSuccess`/`onError(NoCodesError)`).
- **`NoCodesInternal`** — thin passthrough to the existing cache-first `ScreenService.getScreen(contextKey)`. Deliberately skips the `forceSendProperties` flush (unlike `showScreen`) — nothing is presented yet. No screen events fire on a load-only call (events fire only in the presentation path, `ScreenFragment`).
- **Tests** — integration cases: public identifiers, top-level `ScreenNotFound` (suspend + callback), main-thread callback delivery, and cache warming proven via a counting `ApiInteractor` decorator (a live-backend-only variant would pass even with no caching).
- **Sample app** — a "Load Before Present" section demonstrating the ask-first → present-or-fallback flow.

## Differences from the iOS PR

- iOS had to surface `.screenNotFound` unwrapped at the service level — **not needed here**: `ScreenServiceImpl` already throws a top-level `NoCodesException(ErrorCode.ScreenNotFound)`, so callers can already branch "genuinely absent → fallback" vs "transient failure → maybe retry".
- No "not initialized" error path: on Android, `NoCodes.shared` itself throws `UninitializedPropertyAccessException` before `initialize` — existing behavior.
- iOS's load-only "no impression events" test isn't ported: on Android the load path structurally has no reference to `ScreenEventsService`, and asserting that would require heavy DI surgery for little value.

## Known limitations (same as iOS)

- `loadScreen` skips the user-properties flush, so the targeting basis may differ slightly from a direct `showScreen` call.
- On-demand loads cache HTML without base64-embedded images; init-time preloading embeds them. If the two race, the cached variant is nondeterministic — affects image embedding only, not correctness.

Cross-platform wrapper propagation (Flutter/RN/Cordova/Unity/KMP) is out of scope — separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TB8Jm2H8f4Dvw82aofK7FR