### PR TITLE
feat: [DEV-1180] NoCodes — typed defaultVariables on the loadScreen entity, remove onScreenShown overloads

### DIFF
--- a/nocodes/src/main/java/io/qonversion/nocodes/NoCodes.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/NoCodes.kt
@@ -126,6 +126,10 @@ interface NoCodes {
      * A successful load warms the shared screens cache, so a following [showScreen] call
      * with the same context key renders from cache.
      *
+     * The returned screen carries the typed default variables configured in the builder
+     * ([QNoCodeScreen.defaultVariables]) — authored custom variables and product slots —
+     * so you can read them by key before presenting.
+     *
      * Unlike [showScreen], this call does not flush pending user properties, so the targeting
      * basis may differ slightly from a direct [showScreen] call.
      *

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QNoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QNoCodeScreen.kt
@@ -3,13 +3,25 @@ package io.qonversion.nocodes.dto
 /**
  * A loaded No-Code screen returned from [io.qonversion.nocodes.NoCodes.loadScreen].
  *
- * Exposes only the screen identifiers — the screen content stays internal, as rendering
- * remains the SDK's job via [io.qonversion.nocodes.NoCodes.showScreen].
+ * Exposes the screen identifiers and the typed default variables configured in the builder —
+ * the screen content stays internal, as rendering remains the SDK's job via
+ * [io.qonversion.nocodes.NoCodes.showScreen].
  *
  * @property id identifier of the screen.
  * @property contextKey the context key of the screen set in the No-Codes builder.
+ * @property defaultVariables typed default variables configured in the builder — authored
+ * custom variables and product slots. Read them by [QScreenVariable.key] (may be empty).
  */
 data class QNoCodeScreen(
     val id: String,
     val contextKey: String,
-)
+    val defaultVariables: List<QScreenVariable> = emptyList(),
+) {
+
+    /**
+     * Returns the default variable configured under the given [key], or `null` when the
+     * screen has no variable with that exact (case-sensitive) key.
+     */
+    fun defaultVariable(key: String): QScreenVariable? =
+        defaultVariables.firstOrNull { it.key == key }
+}

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QNoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QNoCodeScreen.kt
@@ -19,12 +19,24 @@ data class QNoCodeScreen(
 ) {
 
     /**
+     * The Qonversion product id selected by default when the screen opens (the builder's
+     * Default Product), or `null` when none is configured. Convenience over the
+     * [QScreenVariable.Kind.SelectedProduct] entry of [defaultVariables].
+     */
+    val defaultSelectedProductId: String?
+        get() = defaultVariables
+            .firstOrNull { it.kind == QScreenVariable.Kind.SelectedProduct }
+            ?.let { (it.value as? QScreenVariableValue.Str)?.value }
+
+    /**
      * Returns the default variable configured under the given [key], or `null` when the
      * screen has no variable with that exact (case-sensitive) key.
      *
      * Keys are only unique within a kind — a custom variable and a product slot may share
      * a name — so pass [kind] to disambiguate; without it the first match in payload order
      * (custom variables, then product slots, then the selected product) is returned.
+     *
+     * For the default selected product prefer [defaultSelectedProductId] — it needs no key.
      */
     @JvmOverloads
     fun defaultVariable(key: String, kind: QScreenVariable.Kind? = null): QScreenVariable? =

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QNoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QNoCodeScreen.kt
@@ -21,7 +21,12 @@ data class QNoCodeScreen(
     /**
      * Returns the default variable configured under the given [key], or `null` when the
      * screen has no variable with that exact (case-sensitive) key.
+     *
+     * Keys are only unique within a kind — a custom variable and a product slot may share
+     * a name — so pass [kind] to disambiguate; without it the first match in payload order
+     * (custom variables, then product slots, then the selected product) is returned.
      */
-    fun defaultVariable(key: String): QScreenVariable? =
-        defaultVariables.firstOrNull { it.key == key }
+    @JvmOverloads
+    fun defaultVariable(key: String, kind: QScreenVariable.Kind? = null): QScreenVariable? =
+        defaultVariables.firstOrNull { it.key == key && (kind == null || it.kind == kind) }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
@@ -1,18 +1,75 @@
 package io.qonversion.nocodes.dto
 
 /**
- * A No-Code screen variable authored in the builder, delivered to the SDK at screen load so it
- * can be read by [key] after the screen appears.
+ * A typed default variable of a No-Code screen, configured in the builder and delivered to
+ * the SDK at screen load so it can be read by [key] via
+ * [io.qonversion.nocodes.dto.QNoCodeScreen.defaultVariables].
  *
- * [value] keeps its authored native type (Boolean / String / Number) rather than being coerced
- * to a String, matching the declared [type].
+ * [value] keeps its configured native type (see [QScreenVariableValue]) rather than being
+ * coerced to a String, matching the declared [type].
  *
- * @property key variable name it is addressed by (`variable.<key>` in the builder); may contain spaces.
- * @property type authored type: `"boolean"`, `"string"` or `"number"`.
- * @property value the authored default value, preserving its native type (may be null).
+ * @property kind what the variable represents — see [Kind].
+ * @property key variable name it is addressed by (`variable.<key>` in the builder for custom
+ * variables, the slot name for product slots); may contain spaces.
+ * @property type configured value type: `"boolean"`, `"string"` or `"number"`.
+ * @property value the configured default value, preserving its native type.
  */
 data class QScreenVariable(
+    val kind: Kind,
     val key: String,
     val type: String,
-    val value: Any?,
-)
+    val value: QScreenVariableValue,
+) {
+
+    /**
+     * Kind of a [QScreenVariable] — what it was configured as in the builder.
+     * The set may grow in future backend versions; values this SDK version does not know
+     * are delivered as [Unknown] instead of failing the screen load.
+     */
+    enum class Kind {
+        /**
+         * A Screen Variable authored in the builder's Variables section.
+         */
+        Custom,
+
+        /**
+         * A product slot: [key] is the slot name and [value] is the default Qonversion
+         * product id assigned to it.
+         */
+        Product,
+
+        /**
+         * A kind introduced on the backend after this SDK version was released.
+         */
+        Unknown,
+    }
+}
+
+/**
+ * Typed value of a [QScreenVariable]. Preserves the configured JSON type instead of
+ * collapsing everything to a String.
+ */
+sealed class QScreenVariableValue {
+    /**
+     * A boolean default value.
+     * @property value the configured boolean.
+     */
+    data class Bool(val value: Boolean) : QScreenVariableValue()
+
+    /**
+     * A string default value.
+     * @property value the configured string (may be empty).
+     */
+    data class Str(val value: String) : QScreenVariableValue()
+
+    /**
+     * A numeric default value. JSON numbers are normalized to [Double].
+     * @property value the configured number.
+     */
+    data class Num(val value: Double) : QScreenVariableValue()
+
+    /**
+     * A `null`/absent configured default.
+     */
+    object None : QScreenVariableValue()
+}

--- a/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/dto/QScreenVariable.kt
@@ -39,6 +39,13 @@ data class QScreenVariable(
         Product,
 
         /**
+         * The screen's Default Product configured in the builder: [key] is always
+         * `"default_selected_product"` and [value] is the Qonversion product id selected
+         * by default.
+         */
+        SelectedProduct,
+
+        /**
          * A kind introduced on the backend after this SDK version was released.
          */
         Unknown,
@@ -50,6 +57,22 @@ data class QScreenVariable(
  * collapsing everything to a String.
  */
 sealed class QScreenVariableValue {
+
+    /**
+     * The value rendered as a plain string regardless of its native type: `"true"`/`"false"`
+     * for booleans, the string itself, a number without a trailing `.0` when integral
+     * (`34`, `3.5`), or an empty string for [None].
+     */
+    fun asString(): String = when (this) {
+        is Bool -> value.toString()
+        is Str -> value
+        is Num -> if (value % 1.0 == 0.0 && kotlin.math.abs(value) < MAX_INTEGRAL_AS_LONG) {
+            value.toLong().toString()
+        } else {
+            value.toString()
+        }
+        None -> ""
+    }
     /**
      * A boolean default value.
      * @property value the configured boolean.
@@ -72,4 +95,9 @@ sealed class QScreenVariableValue {
      * A `null`/absent configured default.
      */
     object None : QScreenVariableValue()
+
+    private companion object {
+        // Doubles lose integer precision beyond 2^53; render such values as-is.
+        const val MAX_INTEGRAL_AS_LONG = 1e15
+    }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/interfaces/NoCodesDelegate.kt
@@ -1,7 +1,6 @@
 package io.qonversion.nocodes.interfaces
 
 import io.qonversion.nocodes.dto.QAction
-import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.error.NoCodesError
 import com.qonversion.android.sdk.Qonversion
@@ -11,40 +10,12 @@ interface NoCodesDelegate {
     /**
      * Called when No-Code screen is shown.
      *
+     * To read the screen's configured default variables, load the screen entity via
+     * [NoCodes.loadScreen] and use [io.qonversion.nocodes.dto.QNoCodeScreen.defaultVariables].
+     *
      * @param screenId shown screen Id.
      */
     fun onScreenShown(screenId: String) { }
-
-    /**
-     * Called when No-Code screen is shown, providing the product ids configured on that screen.
-     * Use this to keep analytics consistent with the full set of products the screen was built
-     * with, not only the ones the rendered screen requested.
-     *
-     * The default implementation delegates to [onScreenShown], so existing implementations keep
-     * working and this callback fires exactly once.
-     *
-     * @param screenId shown screen Id.
-     * @param products Qonversion product ids configured on the screen (may be empty).
-     */
-    fun onScreenShown(screenId: String, products: List<String>) {
-        onScreenShown(screenId)
-    }
-
-    /**
-     * Called when No-Code screen is shown, providing the screen variables authored on it.
-     * Read them by [QScreenVariable.key] to react to the screen's configured values after it
-     * loads; each value keeps its authored type (bool / string / number).
-     *
-     * The default implementation delegates to [onScreenShown], so existing implementations keep
-     * working and this callback fires exactly once.
-     *
-     * @param screenId shown screen Id.
-     * @param products Qonversion product ids configured on the screen (may be empty).
-     * @param variables screen variables authored on the screen (may be empty).
-     */
-    fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
-        onScreenShown(screenId, products)
-    }
 
     /**
      * Called when No-Code screen starts executing an action.

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/NoCodesInternal.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/NoCodesInternal.kt
@@ -90,7 +90,7 @@ internal class NoCodesInternal(
             throw e as? NoCodesException
                 ?: NoCodesException(ErrorCode.NetworkRequestExecution, e.message, e)
         }
-        return QNoCodeScreen(screen.id, screen.contextKey)
+        return QNoCodeScreen(screen.id, screen.contextKey, screen.variables)
     }
 
     override fun loadScreen(contextKey: String, callback: NoCodesScreenLoadCallback) {

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
@@ -41,6 +41,7 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
     private fun mapVariableKind(rawKind: String?): QScreenVariable.Kind = when (rawKind) {
         null, KIND_CUSTOM -> QScreenVariable.Kind.Custom
         KIND_PRODUCT -> QScreenVariable.Kind.Product
+        KIND_SELECTED_PRODUCT -> QScreenVariable.Kind.SelectedProduct
         else -> QScreenVariable.Kind.Unknown
     }
 
@@ -54,5 +55,6 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
     companion object {
         private const val KIND_CUSTOM = "custom"
         private const val KIND_PRODUCT = "product"
+        private const val KIND_SELECTED_PRODUCT = "selected_product"
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/common/mappers/ScreenMapper.kt
@@ -1,6 +1,7 @@
 package io.qonversion.nocodes.internal.common.mappers
 
 import io.qonversion.nocodes.dto.QScreenVariable
+import io.qonversion.nocodes.dto.QScreenVariableValue
 import io.qonversion.nocodes.internal.dto.NoCodeScreen
 
 internal class ScreenMapper : Mapper<NoCodeScreen?> {
@@ -14,26 +15,44 @@ internal class ScreenMapper : Mapper<NoCodeScreen?> {
             return null
         }
 
-        // Missing/absent `products` (older payloads, bundled fallbacks) → empty list.
-        val products = data.getList("products")?.filterIsInstance<String>() ?: emptyList()
-
-        // Missing/absent `variables` → empty list. Each entry is {key, type, value}; the value
-        // keeps its native type. Entries without a key are skipped; a missing type falls back to
-        // "string" (mirrors the backend extractor).
+        // Missing/absent `variables` (older payloads, bundled fallbacks) → empty list.
+        // Each entry is {kind, key, type, value}; the value keeps its native type. Entries
+        // without a key are skipped; a missing type falls back to "string" (mirrors the
+        // backend extractor).
         val variables = data.getList("variables")
             ?.filterIsInstance<Map<*, *>>()
             ?.mapNotNull { item ->
                 val key = item.getString("key") ?: return@mapNotNull null
                 val type = item.getString("type") ?: "string"
-                QScreenVariable(key, type, item["value"])
+                QScreenVariable(mapVariableKind(item.getString("kind")), key, type, mapVariableValue(item["value"]))
             } ?: emptyList()
 
         return NoCodeScreen(
             id,
             body,
             contextKey,
-            products,
             variables,
         )
+    }
+
+    // A missing kind means a payload predating the field, which carries only authored
+    // custom variables; an unknown kind (added on the backend after this SDK version)
+    // must not fail the screen load.
+    private fun mapVariableKind(rawKind: String?): QScreenVariable.Kind = when (rawKind) {
+        null, KIND_CUSTOM -> QScreenVariable.Kind.Custom
+        KIND_PRODUCT -> QScreenVariable.Kind.Product
+        else -> QScreenVariable.Kind.Unknown
+    }
+
+    private fun mapVariableValue(rawValue: Any?): QScreenVariableValue = when (rawValue) {
+        is Boolean -> QScreenVariableValue.Bool(rawValue)
+        is Number -> QScreenVariableValue.Num(rawValue.toDouble())
+        is String -> QScreenVariableValue.Str(rawValue)
+        else -> QScreenVariableValue.None
+    }
+
+    companion object {
+        private const val KIND_CUSTOM = "custom"
+        private const val KIND_PRODUCT = "product"
     }
 }

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/NoCodeScreen.kt
@@ -6,8 +6,6 @@ internal data class NoCodeScreen(
     val id: String,
     val body: String,
     val contextKey: String,
-    // Qonversion product ids configured in the builder for this screen (may be empty).
-    val products: List<String> = emptyList(),
-    // Screen variables authored in the builder for this screen, read by key (may be empty).
+    // Typed default variables configured in the builder for this screen (may be empty).
     val variables: List<QScreenVariable> = emptyList()
 )

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/dto/config/NoCodesDelegateWrapper.kt
@@ -3,7 +3,6 @@ package io.qonversion.nocodes.internal.dto.config
 import android.os.Handler
 import android.os.Looper
 import io.qonversion.nocodes.dto.QAction
-import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
 import io.qonversion.nocodes.error.NoCodesError
 
@@ -13,15 +12,9 @@ class NoCodesDelegateWrapper(
 
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    override fun onScreenShown(screenId: String, products: List<String>) {
+    override fun onScreenShown(screenId: String) {
         mainHandler.post {
-            delegate.onScreenShown(screenId, products)
-        }
-    }
-
-    override fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
-        mainHandler.post {
-            delegate.onScreenShown(screenId, products, variables)
+            delegate.onScreenShown(screenId)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenContract.kt
@@ -1,11 +1,10 @@
 package io.qonversion.nocodes.internal.screen.view
 
 import io.qonversion.nocodes.dto.QAction
-import io.qonversion.nocodes.dto.QScreenVariable
 
 internal class ScreenContract {
     interface View {
-        fun displayScreen(screenId: String, html: String, products: List<String>, variables: List<QScreenVariable>)
+        fun displayScreen(screenId: String, html: String)
 
         fun navigateToScreen(screenId: String)
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenFragment.kt
@@ -31,7 +31,6 @@ import com.qonversion.android.sdk.listeners.QonversionPurchaseCallback
 import io.qonversion.nocodes.databinding.NcFragmentScreenBinding
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
-import io.qonversion.nocodes.dto.QScreenVariable
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.NoCodesLoadingView
 import io.qonversion.nocodes.internal.di.DependenciesAssembly
@@ -115,7 +114,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
         binding = null
     }
 
-    override fun displayScreen(screenId: String, html: String, products: List<String>, variables: List<QScreenVariable>) {
+    override fun displayScreen(screenId: String, html: String) {
         activity?.runOnUiThread {
             binding?.webView?.loadDataWithBaseURL(
                 null,
@@ -124,7 +123,7 @@ class ScreenFragment : Fragment(), ScreenContract.View {
                 ENCODING,
                 null
             )
-            delegate?.onScreenShown(screenId, products, variables)
+            delegate?.onScreenShown(screenId)
         }
     }
 

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/screen/view/ScreenPresenter.kt
@@ -82,7 +82,7 @@ internal class ScreenPresenter(
 
             var processedHtml = injectCustomLocale(screen.body)
             processedHtml = injectTheme(processedHtml)
-            view.displayScreen(screen.id, processedHtml, screen.products, screen.variables)
+            view.displayScreen(screen.id, processedHtml)
 
             val shownEvent = ScreenEvent(data = mapOf(
                 "type" to ScreenEventType.ScreenShown.value,

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -10,7 +10,6 @@ import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
 import io.qonversion.nocodes.dto.QNoCodeScreen
-import io.qonversion.nocodes.dto.QScreenVariableValue
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.CustomVariablesDelegate
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
@@ -116,10 +115,11 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
                 addEvent(getString(R.string.screen_loaded_presenting, screen.id))
 
                 // The loaded entity carries the typed default variables configured in the
-                // builder — authored custom variables and product slots — readable by key
-                // (e.g. screen.defaultVariable("show_trial")) before anything is presented.
+                // builder — custom variables, product slots and the default selected
+                // product — readable by key (e.g. screen.defaultVariable("primary",
+                // QScreenVariable.Kind.Product)) before anything is presented.
                 val variables = screen.defaultVariables.joinToString(", ") { variable ->
-                    "${variable.kind} ${variable.key} = ${formatVariableValue(variable.value)}"
+                    "${variable.kind} ${variable.key} = ${variable.value.asString()}"
                 }
                 addEvent(getString(R.string.screen_default_variables, variables))
 
@@ -144,13 +144,6 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
         } else {
             binding.eventsText.text = events.joinToString("\n\n")
         }
-    }
-
-    private fun formatVariableValue(value: QScreenVariableValue): String = when (value) {
-        is QScreenVariableValue.Bool -> value.value.toString()
-        is QScreenVariableValue.Str -> "\"${value.value}\""
-        is QScreenVariableValue.Num -> value.value.toString()
-        QScreenVariableValue.None -> "null"
     }
 
     // NoCodesDelegate implementation

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -10,7 +10,7 @@ import io.qonversion.nocodes.NoCodes
 import io.qonversion.nocodes.dto.NoCodesTheme
 import io.qonversion.nocodes.dto.QAction
 import io.qonversion.nocodes.dto.QNoCodeScreen
-import io.qonversion.nocodes.dto.QScreenVariable
+import io.qonversion.nocodes.dto.QScreenVariableValue
 import io.qonversion.nocodes.error.NoCodesError
 import io.qonversion.nocodes.interfaces.CustomVariablesDelegate
 import io.qonversion.nocodes.interfaces.NoCodesDelegate
@@ -114,6 +114,15 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
         NoCodes.shared.loadScreen(contextKey, object : NoCodesScreenLoadCallback {
             override fun onSuccess(screen: QNoCodeScreen) {
                 addEvent(getString(R.string.screen_loaded_presenting, screen.id))
+
+                // The loaded entity carries the typed default variables configured in the
+                // builder — authored custom variables and product slots — readable by key
+                // (e.g. screen.defaultVariable("show_trial")) before anything is presented.
+                val variables = screen.defaultVariables.joinToString(", ") { variable ->
+                    "${variable.kind} ${variable.key} = ${formatVariableValue(variable.value)}"
+                }
+                addEvent(getString(R.string.screen_default_variables, variables))
+
                 NoCodes.shared.showScreen(contextKey)
             }
 
@@ -137,10 +146,16 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
         }
     }
 
+    private fun formatVariableValue(value: QScreenVariableValue): String = when (value) {
+        is QScreenVariableValue.Bool -> value.value.toString()
+        is QScreenVariableValue.Str -> "\"${value.value}\""
+        is QScreenVariableValue.Num -> value.value.toString()
+        QScreenVariableValue.None -> "null"
+    }
+
     // NoCodesDelegate implementation
-    override fun onScreenShown(screenId: String, products: List<String>, variables: List<QScreenVariable>) {
-        val vars = variables.joinToString(", ") { "${it.key}=${it.value}" }
-        addEvent(getString(R.string.screen_shown, "$screenId, products: $products, variables: [$vars]"))
+    override fun onScreenShown(screenId: String) {
+        addEvent(getString(R.string.screen_shown, screenId))
     }
 
     override fun onScreenFailedToLoad(error: NoCodesError) {

--- a/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/NoCodesFragment.kt
@@ -122,6 +122,7 @@ class NoCodesFragment : Fragment(), NoCodesDelegate, CustomVariablesDelegate {
                     "${variable.kind} ${variable.key} = ${variable.value.asString()}"
                 }
                 addEvent(getString(R.string.screen_default_variables, variables))
+                addEvent(getString(R.string.screen_default_selected_product, screen.defaultSelectedProductId ?: "none"))
 
                 NoCodes.shared.showScreen(contextKey)
             }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="load_before_present_description">Ask-first: load the screen, then present it or show your own fallback.</string>
     <string name="load_then_show_nocodes_screen">Load, Then Present or Fallback</string>
     <string name="screen_loaded_presenting">Screen loaded (id: %1$s), presenting from warm cache</string>
+    <string name="screen_default_variables">Default variables: [%1$s]</string>
     <string name="screen_load_failed_fallback">Load failed (%1$s), showing app fallback instead of the No-Code screen</string>
     <string name="presentation_config">Presentation Config</string>
     <string name="presentation_style">Presentation Style:</string>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="load_then_show_nocodes_screen">Load, Then Present or Fallback</string>
     <string name="screen_loaded_presenting">Screen loaded (id: %1$s), presenting from warm cache</string>
     <string name="screen_default_variables">Default variables: [%1$s]</string>
+    <string name="screen_default_selected_product">Default selected product: %1$s</string>
     <string name="screen_load_failed_fallback">Load failed (%1$s), showing app fallback instead of the No-Code screen</string>
     <string name="presentation_config">Presentation Config</string>
     <string name="presentation_style">Presentation Style:</string>


### PR DESCRIPTION
Issue: [DEV-1180](https://linear.app/qonversion/issue/DEV-1180)

Android counterpart of qonversion/qonversion-ios-sdk#702 — rework of the DEV-1167 exposure API (#830/#831). That API shipped only in `prerelease-nocodes/1.10.0` — the latest public release No-Codes 1.9.3 does not contain it, so removing it is **not** a public breaking change.

## What changed
- **`QNoCodeScreen.defaultVariables`** — typed default variables configured in the builder, plus a `defaultVariable(key)` lookup; mapped from the payload in `loadScreen`.
- **`QScreenVariable.kind`** (`Custom` / `Product` / `Unknown`) with tolerant mapping: missing kind (pre-DEV-1180 payload) → `Custom`, unknown kind (future backend) → `Unknown`. `value` is now a typed sealed class (`Bool` / `Str` / `Num` / `None`) instead of `Any?` — never publicly released, so free to change.
- **Delegate overloads removed**: `onScreenShown(screenId, products)` and `(screenId, products, variables)` are gone from `NoCodesDelegate`, `NoCodesDelegateWrapper` and the `ScreenContract`/`ScreenPresenter`/`ScreenFragment` chain; only the id-only callback remains (the wrapper now overrides it to keep main-thread posting).
- `products` removed from the internal `NoCodeScreen` DTO and `ScreenMapper`.

## Wire compatibility
Payload key stays `variables` (additive `kind` per entry); `products` key dropped. Backend counterparts: qonversion/dash-mono#556, qonversion/configurator#259, qonversion/api-gateway#580.

## Testing
- `:nocodes:compileReleaseKotlin` + root `detektAll` clean; `:nocodes`/`:sdk` unit tests green.

Part of [DEV-1180](https://linear.app/qonversion/issue/DEV-1180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YXuzBxSjRGXowA2ovkXx2