### PR TITLE
Migrate to Google Play Billing Library 9.1.0

### DIFF
--- a/nocodes/build.gradle
+++ b/nocodes/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace 'io.qonversion.nocodes'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdk 23
-        targetSdk 34
+        targetSdk 35
 
         group = 'io.qonversion.nocodes'
         version = nocodes.versionName

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'io.qonversion.sample'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "io.qonversion.sampleapp"
         minSdk 23
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName '1.0.0'
         multiDexEnabled true

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         consumerProguardFiles 'consumer-rules.pro'
         group = 'io.qonversion.android.sdk'
@@ -65,7 +65,7 @@ ext {
     moshiVersion = '1.15.2'
     retrofit_version = '2.9.0'
     okhttp_version = '3.12.13'
-    billing = '8.1.0'
+    billing = '9.1.0'
     lifecycle_version = '2.1.0'
     assertj_version = '3.16.1'
     junit_version = '5.6.2'

--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -172,7 +172,7 @@ interface Qonversion {
 
     /**
      * Return Qonversion Products in association with Google Play Store Products
-     * If you get an empty SkuDetails be sure your products are correctly set up in Google Play Store.
+     * If you get empty ProductDetails be sure your products are correctly set up in Google Play Store.
      * @param callback - callback that will be called when response is received
      * @see [Product Center](https://qonversion.io/docs/product-center)
      */

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/EnvironmentProvider.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/EnvironmentProvider.kt
@@ -44,7 +44,7 @@ internal class EnvironmentProvider(
                 context.packageManager.getPackageInfo(context.packageName, 0)
             }
 
-            packageInfo.versionName
+            packageInfo.versionName ?: UNKNOWN
         } catch (throwable: Throwable) {
             UNKNOWN
         }

--- a/sdk/src/test/java/com/qonversion/android/sdk/utils.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/utils.kt
@@ -1,10 +1,5 @@
 package com.qonversion.android.sdk
 
-import com.android.billingclient.api.Purchase
-import com.qonversion.android.sdk.Constants.DEFAULT_SUBS_SKU
-import com.qonversion.android.sdk.Constants.INAPP_PURCHASE
-import com.qonversion.android.sdk.Constants.SUBS_PURCHASE_INCOMPLETE
-import com.qonversion.android.sdk.Constants.PURCHASE_SIGNATURE
 import java.lang.reflect.Modifier
 
 fun Any.mockPrivateField(fieldName: String, field: Any?) {
@@ -20,40 +15,4 @@ fun <T> Any.getPrivateField(name: String): T {
     field.isAccessible = true
     @Suppress("UNCHECKED_CAST")
     return field.get(this) as T
-}
-
-fun mockSubsPurchase(sku: String = DEFAULT_SUBS_SKU): Purchase {
-    return Purchase("{$SUBS_PURCHASE_INCOMPLETE, \"productId\":\"$sku\"}", PURCHASE_SIGNATURE)
-}
-
-fun mockIncorrectSubsPurchase(): Purchase {
-    return Purchase("{$SUBS_PURCHASE_INCOMPLETE}", PURCHASE_SIGNATURE)
-}
-
-fun mockInAppPurchase(): Purchase {
-    return Purchase("{$INAPP_PURCHASE}", PURCHASE_SIGNATURE)
-}
-
-object Constants {
-    // Subscription purchase without productId
-    const val SUBS_PURCHASE_INCOMPLETE = "\"orderId\":\"GPA.0000-0000-0000-0000\"," +
-            "\"packageName\":\"io.qonversion.sample\"," +
-            "\"purchaseTime\":1631867965714," +
-            "\"purchaseState\":1," +
-            "\"purchaseToken\":\"XXXXXXX\"," +
-            "\"quantity\":1," +
-            "\"autoRenewing\":true," +
-            "\"acknowledged\":true"
-
-    const val INAPP_PURCHASE = "\"orderId\":\"GPA.0000-0000-0000-0000\"," +
-            "\"packageName\":\"io.qonversion.sample\"," +
-            "\"productId\":\"qonversion_inapp_consumable\"," +
-            "\"purchaseTime\":1632238801527," +
-            "\"purchaseState\":1," +
-            "\"purchaseToken\":\"XXXXXXX\"," +
-            "\"quantity\":1," +
-            "\"acknowledged\":true"
-
-    const val PURCHASE_SIGNATURE = "mockSignature"
-    const val DEFAULT_SUBS_SKU = "subs_weekly"
 }

--- a/sdk/src/test/java/com/qonversion/android/sdk/utils.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/utils.kt
@@ -1,14 +1,10 @@
 package com.qonversion.android.sdk
 
 import com.android.billingclient.api.Purchase
-import com.android.billingclient.api.*
-import com.qonversion.android.sdk.Constants.DEFAULT_SUBS_PERIOD
 import com.qonversion.android.sdk.Constants.DEFAULT_SUBS_SKU
 import com.qonversion.android.sdk.Constants.INAPP_PURCHASE
-import com.qonversion.android.sdk.Constants.INAPP_SKU_DETAILS
 import com.qonversion.android.sdk.Constants.SUBS_PURCHASE_INCOMPLETE
 import com.qonversion.android.sdk.Constants.PURCHASE_SIGNATURE
-import com.qonversion.android.sdk.Constants.SUBS_SKU_DETAILS_INCOMPLETE
 import java.lang.reflect.Modifier
 
 fun Any.mockPrivateField(fieldName: String, field: Any?) {
@@ -26,31 +22,12 @@ fun <T> Any.getPrivateField(name: String): T {
     return field.get(this) as T
 }
 
-fun mockSubsSkuDetailsJson(
-    sku: String = DEFAULT_SUBS_SKU,
-    subsPeriod: String = DEFAULT_SUBS_PERIOD,
-    freeTrialPeriod: String? = null
-): String {
-    val sb = StringBuilder()
-    sb.append("$SUBS_SKU_DETAILS_INCOMPLETE, \"productId\":\"$sku\", \"subscriptionPeriod\":$subsPeriod")
-    freeTrialPeriod?.let {
-        sb.append(",\"freeTrialPeriod\":\"$it\"")
-    }
-
-    return "{${sb}}"
-}
-
 fun mockSubsPurchase(sku: String = DEFAULT_SUBS_SKU): Purchase {
     return Purchase("{$SUBS_PURCHASE_INCOMPLETE, \"productId\":\"$sku\"}", PURCHASE_SIGNATURE)
 }
 
 fun mockIncorrectSubsPurchase(): Purchase {
     return Purchase("{$SUBS_PURCHASE_INCOMPLETE}", PURCHASE_SIGNATURE)
-}
-
-fun mockInAppSkuDetailsJson(
-): String {
-    return "{$INAPP_SKU_DETAILS}"
 }
 
 fun mockInAppPurchase(): Purchase {
@@ -68,30 +45,6 @@ object Constants {
             "\"autoRenewing\":true," +
             "\"acknowledged\":true"
 
-    // Subscription SkuDetails without productId, subscriptionPeriod, freeTrialPeriod
-    const val SUBS_SKU_DETAILS_INCOMPLETE = "\"type\":\"subs\"," +
-            "\"title\":\"Qonversion Subs\"," +
-            "\"name\":\"Qonversion Subscription Weekly\"," +
-            "\"price\":\"RUB 439.00\"," +
-            "\"price_amount_micros\":439000000," +
-            "\"price_currency_code\":\"RUB\"," +
-            "\"description\":\"Weekly\"," +
-            "\"introductoryPriceAmountMicros\":85000000," +
-            "\"introductoryPricePeriod\":\"P3D\"," +
-            "\"introductoryPrice\":\"RUB 85.00\"," +
-            "\"introductoryPriceCycles\":1," +
-            "\"skuDetailsToken\":\"XXXXXXX\""
-
-    const val INAPP_SKU_DETAILS = "\"productId\":\"qonversion_inapp_consumable\"," +
-            "\"type\":\"inapp\"," +
-            "\"title\":\"Qonversion In-app\"," +
-            "\"name\":\"Qonversion In-app Consumable\"," +
-            "\"price\":\"RUB 75.00\"," +
-            "\"price_amount_micros\":75000000," +
-            "\"price_currency_code\":\"RUB\"," +
-            "\"description\":\"Consumable\"," +
-            "\"skuDetailsToken\":\"XXXXXXX\"}"
-
     const val INAPP_PURCHASE = "\"orderId\":\"GPA.0000-0000-0000-0000\"," +
             "\"packageName\":\"io.qonversion.sample\"," +
             "\"productId\":\"qonversion_inapp_consumable\"," +
@@ -102,6 +55,5 @@ object Constants {
             "\"acknowledged\":true"
 
     const val PURCHASE_SIGNATURE = "mockSignature"
-    const val DEFAULT_SUBS_PERIOD = "P1W"
     const val DEFAULT_SUBS_SKU = "subs_weekly"
 }

--- a/sdk/src/test/java/com/qonversion/android/sdk/utils.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/utils.kt
@@ -26,16 +26,6 @@ fun <T> Any.getPrivateField(name: String): T {
     return field.get(this) as T
 }
 
-@Suppress("DEPRECATION")
-fun mockSubsSkuDetails(
-    sku: String = DEFAULT_SUBS_SKU,
-    subsPeriod: String = DEFAULT_SUBS_PERIOD,
-    freeTrialPeriod: String? = null
-): SkuDetails {
-    val skuDetailsJson = mockSubsSkuDetailsJson(sku, subsPeriod, freeTrialPeriod)
-    return SkuDetails(skuDetailsJson)
-}
-
 fun mockSubsSkuDetailsJson(
     sku: String = DEFAULT_SUBS_SKU,
     subsPeriod: String = DEFAULT_SUBS_PERIOD,
@@ -56,11 +46,6 @@ fun mockSubsPurchase(sku: String = DEFAULT_SUBS_SKU): Purchase {
 
 fun mockIncorrectSubsPurchase(): Purchase {
     return Purchase("{$SUBS_PURCHASE_INCOMPLETE}", PURCHASE_SIGNATURE)
-}
-
-@Suppress("DEPRECATION")
-fun mockInAppSkuDetails(): SkuDetails {
-    return SkuDetails(mockInAppSkuDetailsJson())
 }
 
 fun mockInAppSkuDetailsJson(


### PR DESCRIPTION
## Summary

Upgrades the SDK from Google Play Billing Library 8.1.0 to 9.1.0.

The heavy v7→v8 migration was already done earlier, so this step is small:

- Bump `com.android.billingclient:billing` **8.1.0 → 9.1.0**
- Bump `compileSdk`/`targetSdk` **34 → 35** in `sdk`, `nocodes`, `sample` (PBL 9 targets SDK 35)
- Handle nullable `PackageInfo.versionName` in `EnvironmentProvider` (nullability tightened in SDK 35) — falls back to `UNKNOWN`
- Drop dead `SkuDetails`-based test helpers (`SkuDetails` class removed in PBL 9) and a stale KDoc mention

## Behavior change shipped by PBL 9 (no code change needed)

When the Play Store app is blocked by the system (e.g. OEM kids mode), connection setup now finishes with `BILLING_UNAVAILABLE` instead of generic `ERROR`. In our `BillingClientHolder` this routes into the existing `onBillingClientUnavailable` branch, so queued requests fail fast with a meaningful `BillingUnavailable` error instead of hanging until reconnect — strictly better than the previous behavior.

Not included (possible follow-up): exposing new v9 sub-response codes (`PAYMENT_DECLINED_DUE_TO_INSUFFICIENT_FUNDS`, `USER_INELIGIBLE`) through the public error API.

## Testing

- `:sdk:assembleRelease`, `:nocodes:assembleRelease` — OK
- `:sample:assembleDebug` — OK (samples are not CI-gated)
- `:sdk:testReleaseUnitTest`, `:nocodes:testReleaseUnitTest` — OK
- `detektAll` — OK

Linear: [DEV-1196](https://linear.app/qonversion/issue/DEV-1196/migrate-android-sdk-to-google-play-billing-library-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gkK8UCtMzk324y5meDWLw