### PR TITLE
chore: deprecate public Offerings API

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -183,9 +183,9 @@ interface Qonversion {
      * An offering is a group of products that you can offer to a user on a given paywall based on your business logic.
      * For example, you can offer one set of products on a paywall immediately after onboarding and another set of products with discounts later on if a user has not converted.
      * Offerings allow changing the products offered remotely without releasing app updates.
-     * @see [Offerings](https://qonversion.io/docs/offerings)
-     * @see [Product Center](https://qonversion.io/docs/product-center)
+     * @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs)
      */
+    @Deprecated("Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs")
     fun offerings(callback: QonversionOfferingsCallback)
 
     /**

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -245,6 +245,7 @@ internal class QonversionInternal(
         })
     }
 
+    @Suppress("DEPRECATION")
     override fun offerings(callback: QonversionOfferingsCallback) {
         productCenterManager.offerings(object : QonversionOfferingsCallback {
             override fun onSuccess(offerings: QOfferings) =

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -245,7 +245,7 @@ internal class QonversionInternal(
         })
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun offerings(callback: QonversionOfferingsCallback) {
         productCenterManager.offerings(object : QonversionOfferingsCallback {
             override fun onSuccess(offerings: QOfferings) =


### PR DESCRIPTION
## Deprecate the public Offerings API

Offerings is a legacy Qonversion feature that has been superseded by **Remote Configs**. As part of the Offerings sunset, this PR marks the public entry point as deprecated so integrating developers are guided toward the supported approach.

### What changed

- Added `@Deprecated` (default `WARNING` level) to `Qonversion.offerings(callback)` — the single public entry point.
- Updated the method's KDoc `@see` links from the legacy `qonversion.io/docs/offerings` and `qonversion.io/docs/product-center` to the migration guide.
- Added a targeted `@Suppress("DEPRECATION")` on the internal `QonversionInternal.offerings` override (implementation detail, not a public entry point) to keep the build warning-free.

### What did NOT change

- **Behavior is unchanged** — the method continues to work exactly as before. This is a source-level deprecation hint only.
- DTOs (`QOfferings`, `QOffering`, `QOfferingTag`) and callback interfaces (`QonversionOfferingsCallback`) are intentionally **not** deprecated.
- No version bump and no CHANGELOG edits.

### Migration guide

https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs

### Related

- documentation_mintlify#100
- dash-mono#571

> Please do not merge — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
