### PR TITLE
DEV-1208: select Google Play one-time purchase option by base plan id

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProductInAppDetails.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProductInAppDetails.kt
@@ -17,4 +17,17 @@ data class QProductInAppDetails(
     val price: QProductPrice = originalOneTimePurchaseOfferDetails.let {
         QProductPrice(it.priceAmountMicros, it.priceCurrencyCode, it.formattedPrice)
     }
+
+    /**
+     * Identifier of the Google Play purchase option this offer belongs to.
+     * Null for one-time products configured without purchase options.
+     */
+    val purchaseOptionId: String? = originalOneTimePurchaseOfferDetails.purchaseOptionId
+
+    /**
+     * The offer token required to pass to [com.android.billingclient.api.BillingFlowParams]
+     * to purchase this in-app product. Null for a one-time product without a
+     * per-transaction offer token.
+     */
+    val offerToken: String? = originalOneTimePurchaseOfferDetails.offerToken
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProductStoreDetails.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProductStoreDetails.kt
@@ -15,8 +15,9 @@ data class QProductStoreDetails(
     val originalProductDetails: ProductDetails,
 
     /**
-     * Identifier of the base plan to which these details relate.
-     * Null for in-app products.
+     * Identifier of the base plan (for subscriptions) or the purchase option (for
+     * one-time products) to which these details relate.
+     * Null when no base plan / purchase option is configured for the product.
      */
     val basePlanId: String?,
 ) {
@@ -78,15 +79,23 @@ data class QProductStoreDetails(
      * purchase option is specified or none matches.
      */
     val inAppOfferDetails: QProductInAppDetails? = run {
-        val offerDetails = if (basePlanId != null) {
+        val requestedOffer = basePlanId?.let { purchaseOptionId ->
             originalProductDetails.oneTimePurchaseOfferDetailsList
-                ?.firstOrNull { it.purchaseOptionId == basePlanId }
-                ?: originalProductDetails.oneTimePurchaseOfferDetails
-        } else {
-            originalProductDetails.oneTimePurchaseOfferDetails
+                ?.firstOrNull { it.purchaseOptionId == purchaseOptionId }
         }
-        offerDetails?.let { QProductInAppDetails(it) }
+        (requestedOffer ?: originalProductDetails.oneTimePurchaseOfferDetails)
+            ?.let { QProductInAppDetails(it) }
     }
+
+    /**
+     * True when a purchase option was requested via [basePlanId] for this in-app product
+     * and a matching one-time purchase option was actually found. False for plain in-app
+     * products, subscriptions, or a stale/mistyped purchase option that fell back to the
+     * default one-time offer.
+     */
+    val isInAppPurchaseOptionResolved: Boolean = basePlanId != null &&
+            originalProductDetails.oneTimePurchaseOfferDetailsList
+                ?.any { it.purchaseOptionId == basePlanId } == true
 
     /**
      * True, if there is any eligible offer with a trial

--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProductStoreDetails.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProductStoreDetails.kt
@@ -70,11 +70,23 @@ data class QProductStoreDetails(
     /**
      * Offer details for the in-app product.
      * Null for subscriptions.
+     *
+     * When a purchase option is specified via [basePlanId] (Google Play one-time
+     * products use the same "product : purchase option" model as subscriptions), the
+     * matching one-time purchase option is selected, mirroring the subscription
+     * base-plan filtering above. Falls back to the default one-time offer when no
+     * purchase option is specified or none matches.
      */
-    val inAppOfferDetails: QProductInAppDetails? =
-        originalProductDetails.oneTimePurchaseOfferDetails?.let {
-            QProductInAppDetails(it)
+    val inAppOfferDetails: QProductInAppDetails? = run {
+        val offerDetails = if (basePlanId != null) {
+            originalProductDetails.oneTimePurchaseOfferDetailsList
+                ?.firstOrNull { it.purchaseOptionId == basePlanId }
+                ?: originalProductDetails.oneTimePurchaseOfferDetails
+        } else {
+            originalProductDetails.oneTimePurchaseOfferDetails
         }
+        offerDetails?.let { QProductInAppDetails(it) }
+    }
 
     /**
      * True, if there is any eligible offer with a trial

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/billing/BillingClientWrapper.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/billing/BillingClientWrapper.kt
@@ -14,7 +14,7 @@ import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchasesParams
 import com.android.billingclient.api.UnfetchedProduct
 import com.qonversion.android.sdk.dto.products.QProduct
-import com.qonversion.android.sdk.dto.products.QProductOfferDetails
+import com.qonversion.android.sdk.dto.products.QProductStoreDetails
 import com.qonversion.android.sdk.internal.dto.QStoreProductType
 import com.qonversion.android.sdk.internal.dto.ProductStoreId
 import com.qonversion.android.sdk.internal.logger.Logger
@@ -75,31 +75,17 @@ internal class BillingClientWrapper(
 
         logger.debug("makePurchase() -> Purchasing the product: ${storeDetails.productId}")
 
-        val offerDetails: QProductOfferDetails? = when {
-            storeDetails.isInApp -> null
-            applyOffer == false -> {
-                storeDetails.basePlanSubscriptionOfferDetails ?: run {
-                    fireError("Failed to find base plan offer for Qonversion product ${product.qonversionId}")
-                    return
-                }
-            }
-            offerId?.isNotEmpty() == true -> {
-                storeDetails.findOffer(offerId) ?: run {
-                    fireError("Failed to find offer $offerId for Qonversion product ${product.qonversionId}")
-                    return
-                }
-            }
-            else -> {
-                storeDetails.defaultSubscriptionOfferDetails ?: run {
-                    fireError("No offer found for purchasing Qonversion subscription product ${product.qonversionId}")
-                    return
-                }
+        val offerToken: String? = when (val resolution = resolveOfferToken(product, storeDetails, offerId, applyOffer)) {
+            is OfferTokenResolution.Success -> resolution.offerToken
+            is OfferTokenResolution.Failure -> {
+                fireError(resolution.message)
+                return
             }
         }
 
         val productDetailsParamList = BillingFlowParams.ProductDetailsParams.newBuilder()
             .setProductDetails(storeDetails.originalProductDetails)
-            .applyOffer(offerDetails)
+            .applyOffer(offerToken)
             .build()
 
         val params = BillingFlowParams.newBuilder()
@@ -355,11 +341,51 @@ internal class BillingClientWrapper(
     }
 
     private fun BillingFlowParams.ProductDetailsParams.Builder.applyOffer(
-        offer: QProductOfferDetails?
+        offerToken: String?
     ): BillingFlowParams.ProductDetailsParams.Builder {
-        offer?.let {
-            setOfferToken(offer.offerToken)
+        offerToken?.let {
+            setOfferToken(it)
         }
         return this
+    }
+
+    private sealed class OfferTokenResolution {
+        data class Success(val offerToken: String?) : OfferTokenResolution()
+        data class Failure(val message: String) : OfferTokenResolution()
+    }
+
+    private fun resolveOfferToken(
+        product: QProduct,
+        storeDetails: QProductStoreDetails,
+        offerId: String?,
+        applyOffer: Boolean?
+    ): OfferTokenResolution = when {
+        storeDetails.isInApp -> resolveInAppOfferToken(product, storeDetails)
+        applyOffer == false ->
+            storeDetails.basePlanSubscriptionOfferDetails?.offerToken?.let { OfferTokenResolution.Success(it) }
+                ?: OfferTokenResolution.Failure("Failed to find base plan offer for Qonversion product ${product.qonversionId}")
+        offerId?.isNotEmpty() == true ->
+            storeDetails.findOffer(offerId)?.offerToken?.let { OfferTokenResolution.Success(it) }
+                ?: OfferTokenResolution.Failure("Failed to find offer $offerId for Qonversion product ${product.qonversionId}")
+        else ->
+            storeDetails.defaultSubscriptionOfferDetails?.offerToken?.let { OfferTokenResolution.Success(it) }
+                ?: OfferTokenResolution.Failure("No offer found for purchasing Qonversion subscription product ${product.qonversionId}")
+    }
+
+    /**
+     * Resolves the offer token for a one-time (in-app) product. A plain product without
+     * a configured purchase option keeps the legacy behavior (no offer token); when a
+     * purchase option is configured via [QProductStoreDetails.basePlanId], its token is
+     * used, mirroring subscription base-plan selection.
+     */
+    private fun resolveInAppOfferToken(
+        product: QProduct,
+        storeDetails: QProductStoreDetails
+    ): OfferTokenResolution {
+        if (storeDetails.basePlanId == null) {
+            return OfferTokenResolution.Success(null)
+        }
+        return storeDetails.inAppOfferDetails?.offerToken?.let { OfferTokenResolution.Success(it) }
+            ?: OfferTokenResolution.Failure("Failed to find purchase option ${storeDetails.basePlanId} for Qonversion product ${product.qonversionId}")
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/billing/BillingClientWrapper.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/billing/BillingClientWrapper.kt
@@ -373,19 +373,35 @@ internal class BillingClientWrapper(
     }
 
     /**
-     * Resolves the offer token for a one-time (in-app) product. A plain product without
-     * a configured purchase option keeps the legacy behavior (no offer token); when a
-     * purchase option is configured via [QProductStoreDetails.basePlanId], its token is
-     * used, mirroring subscription base-plan selection.
+     * Resolves the offer token for a one-time (in-app) product.
+     *
+     * - A plain product without a configured purchase option keeps the legacy behavior
+     *   (no offer token).
+     * - When a purchase option is configured via [QProductStoreDetails.basePlanId] and it
+     *   matches an available one-time offer, that offer's token is used, mirroring
+     *   subscription base-plan selection.
+     * - When a purchase option is configured but no offer matches it (e.g. a stale or
+     *   mistyped id), we log a warning and fall back to the default one-time offer rather
+     *   than failing the purchase — otherwise existing integrations with a stale
+     *   base_plan_id would start failing where they used to succeed.
      */
     private fun resolveInAppOfferToken(
         product: QProduct,
         storeDetails: QProductStoreDetails
-    ): OfferTokenResolution {
-        if (storeDetails.basePlanId == null) {
-            return OfferTokenResolution.Success(null)
+    ): OfferTokenResolution = when {
+        storeDetails.basePlanId == null -> OfferTokenResolution.Success(null)
+
+        !storeDetails.isInAppPurchaseOptionResolved -> {
+            logger.warn(
+                "makePurchase() -> Purchase option ${storeDetails.basePlanId} not found for " +
+                    "Qonversion product ${product.qonversionId}; falling back to the default one-time offer"
+            )
+            OfferTokenResolution.Success(storeDetails.inAppOfferDetails?.offerToken)
         }
-        return storeDetails.inAppOfferDetails?.offerToken?.let { OfferTokenResolution.Success(it) }
-            ?: OfferTokenResolution.Failure("Failed to find purchase option ${storeDetails.basePlanId} for Qonversion product ${product.qonversionId}")
+
+        else -> storeDetails.inAppOfferDetails?.offerToken?.let { OfferTokenResolution.Success(it) }
+            ?: OfferTokenResolution.Failure(
+                "Purchase option ${storeDetails.basePlanId} for Qonversion product ${product.qonversionId} has no offer token"
+            )
     }
 }


### PR DESCRIPTION
Issue: [DEV-1208](https://linear.app/qonversion/issue/DEV-1208)

**PR 3 of 5 — independent** (no backend dependency; uses the existing `base_plan_id` product field).

## What
Google Play one-time products now use the same product → purchase option → offer model as subscriptions. When a purchase option is configured for an in-app product (carried as `base_plan_id`, mirroring subscriptions), select the matching one-time purchase option and launch the billing flow with its offer token.

## How
- `QProductStoreDetails.inAppOfferDetails` picks the one-time offer from `oneTimePurchaseOfferDetailsList` whose `purchaseOptionId == basePlanId`, mirroring the subscription base-plan filtering; falls back to the default one-time offer when no purchase option is configured or none matches.
- `QProductInAppDetails` exposes `purchaseOptionId` and `offerToken`.
- `BillingClientWrapper.makePurchase` sets the one-time offer token for in-app products with a configured purchase option; plain in-app products keep the legacy no-token behavior. Offer-token resolution was extracted to a helper to keep `makePurchase` within the detekt complexity budget.

## Notes
- No Play Billing version guard needed: `getOneTimePurchaseOfferDetailsList` / `getPurchaseOptionId` / `getOfferToken` exist in both PBL 8.1.0 (develop) and 9.1.0.
- `:sdk:compileReleaseKotlin`, unit-test compile, and `detektAll` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)