### PR TITLE
DEV-1215: split purchaseOptionId from basePlanId on QProduct

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProduct.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProduct.kt
@@ -8,10 +8,27 @@ import com.squareup.moshi.JsonClass
 data class QProduct(
     @Json(name = "id") val qonversionId: String,
     @Json(name = "store_id") val storeId: String?,
-    @Json(name = "base_plan_id") val basePlanId: String?,
+    @Json(name = "base_plan_id") internal val storeBasePlanId: String?,
     @Json(name = "type") internal val apiType: Int = TYPE_CONSUMABLE,
 ) {
     internal val isNonConsumable: Boolean get() = apiType == TYPE_NON_CONSUMABLE
+
+    internal val isOneTimeProduct: Boolean get() =
+        apiType == TYPE_CONSUMABLE || apiType == TYPE_NON_CONSUMABLE
+
+    /**
+     * Identifier of the base plan this product relates to, for a Google Play
+     * subscription product. `Null` for one-time (in-app) products — use
+     * [purchaseOptionId] for those.
+     */
+    val basePlanId: String? get() = if (isOneTimeProduct) null else storeBasePlanId
+
+    /**
+     * Identifier of the Google Play [purchase option](https://developer.android.com/google/play/billing/one-time-products)
+     * this product relates to, for a one-time (in-app) product. `Null` for
+     * subscription products — use [basePlanId] for those.
+     */
+    val purchaseOptionId: String? get() = if (isOneTimeProduct) storeBasePlanId else null
 
     companion object {
         internal const val TYPE_CONSUMABLE = 2
@@ -69,6 +86,8 @@ data class QProduct(
     }
 
     internal fun setStoreProductDetails(productDetails: ProductDetails) {
-        storeDetails = QProductStoreDetails(productDetails, basePlanId)
+        // The raw store-config value feeds both subscription base-plan filtering and
+        // one-time purchase-option selection, so pass it regardless of product type.
+        storeDetails = QProductStoreDetails(productDetails, storeBasePlanId)
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProductStoreDetails.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/products/QProductStoreDetails.kt
@@ -15,12 +15,24 @@ data class QProductStoreDetails(
     val originalProductDetails: ProductDetails,
 
     /**
-     * Identifier of the base plan (for subscriptions) or the purchase option (for
-     * one-time products) to which these details relate.
-     * Null when no base plan / purchase option is configured for the product.
+     * The raw store-config identifier - the base plan id for subscriptions or the
+     * purchase option id for one-time products. Kept for offer selection; consumers
+     * should read the type-scoped [basePlanId] / [purchaseOptionId] instead.
      */
-    val basePlanId: String?,
+    internal val storeBasePlanId: String?,
 ) {
+    /**
+     * Identifier of the base plan for a subscription product.
+     * Null for one-time products - use [purchaseOptionId] for those.
+     */
+    val basePlanId: String? get() = if (isInApp) null else storeBasePlanId
+
+    /**
+     * Identifier of the Google Play purchase option for a one-time (in-app) product.
+     * Null for subscription products - use [basePlanId] for those.
+     */
+    val purchaseOptionId: String? get() = if (isInApp) storeBasePlanId else null
+
     /**
      * Identifier of the subscription or the in-app product.
      */
@@ -51,7 +63,7 @@ data class QProductStoreDetails(
      */
     val subscriptionOfferDetails: List<QProductOfferDetails>? =
         originalProductDetails.subscriptionOfferDetails
-            ?.filter { it.basePlanId == basePlanId }
+            ?.filter { it.basePlanId == storeBasePlanId }
             ?.map { QProductOfferDetails(it) }
 
     /**
@@ -72,14 +84,14 @@ data class QProductStoreDetails(
      * Offer details for the in-app product.
      * Null for subscriptions.
      *
-     * When a purchase option is specified via [basePlanId] (Google Play one-time
+     * When a purchase option is specified via [purchaseOptionId] (Google Play one-time
      * products use the same "product : purchase option" model as subscriptions), the
      * matching one-time purchase option is selected, mirroring the subscription
      * base-plan filtering above. Falls back to the default one-time offer when no
      * purchase option is specified or none matches.
      */
     val inAppOfferDetails: QProductInAppDetails? = run {
-        val requestedOffer = basePlanId?.let { purchaseOptionId ->
+        val requestedOffer = storeBasePlanId?.let { purchaseOptionId ->
             originalProductDetails.oneTimePurchaseOfferDetailsList
                 ?.firstOrNull { it.purchaseOptionId == purchaseOptionId }
         }
@@ -88,14 +100,14 @@ data class QProductStoreDetails(
     }
 
     /**
-     * True when a purchase option was requested via [basePlanId] for this in-app product
-     * and a matching one-time purchase option was actually found. False for plain in-app
-     * products, subscriptions, or a stale/mistyped purchase option that fell back to the
-     * default one-time offer.
+     * True when a purchase option was requested via [purchaseOptionId] for this in-app
+     * product and a matching one-time purchase option was actually found. False for plain
+     * in-app products, subscriptions, or a stale/mistyped purchase option that fell back
+     * to the default one-time offer.
      */
-    val isInAppPurchaseOptionResolved: Boolean = basePlanId != null &&
+    val isInAppPurchaseOptionResolved: Boolean = storeBasePlanId != null &&
             originalProductDetails.oneTimePurchaseOfferDetailsList
-                ?.any { it.purchaseOptionId == basePlanId } == true
+                ?.any { it.purchaseOptionId == storeBasePlanId } == true
 
     /**
      * True, if there is any eligible offer with a trial

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/billing/BillingClientWrapper.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/billing/BillingClientWrapper.kt
@@ -377,23 +377,23 @@ internal class BillingClientWrapper(
      *
      * - A plain product without a configured purchase option keeps the legacy behavior
      *   (no offer token).
-     * - When a purchase option is configured via [QProductStoreDetails.basePlanId] and it
-     *   matches an available one-time offer, that offer's token is used, mirroring
+     * - When a purchase option is configured via [QProductStoreDetails.purchaseOptionId]
+     *   and it matches an available one-time offer, that offer's token is used, mirroring
      *   subscription base-plan selection.
      * - When a purchase option is configured but no offer matches it (e.g. a stale or
      *   mistyped id), we log a warning and fall back to the default one-time offer rather
      *   than failing the purchase — otherwise existing integrations with a stale
-     *   base_plan_id would start failing where they used to succeed.
+     *   purchase option would start failing where they used to succeed.
      */
     private fun resolveInAppOfferToken(
         product: QProduct,
         storeDetails: QProductStoreDetails
     ): OfferTokenResolution = when {
-        storeDetails.basePlanId == null -> OfferTokenResolution.Success(null)
+        storeDetails.purchaseOptionId == null -> OfferTokenResolution.Success(null)
 
         !storeDetails.isInAppPurchaseOptionResolved -> {
             logger.warn(
-                "makePurchase() -> Purchase option ${storeDetails.basePlanId} not found for " +
+                "makePurchase() -> Purchase option ${storeDetails.purchaseOptionId} not found for " +
                     "Qonversion product ${product.qonversionId}; falling back to the default one-time offer"
             )
             OfferTokenResolution.Success(storeDetails.inAppOfferDetails?.offerToken)
@@ -401,7 +401,7 @@ internal class BillingClientWrapper(
 
         else -> storeDetails.inAppOfferDetails?.offerToken?.let { OfferTokenResolution.Success(it) }
             ?: OfferTokenResolution.Failure(
-                "Purchase option ${storeDetails.basePlanId} for Qonversion product ${product.qonversionId} has no offer token"
+                "Purchase option ${storeDetails.purchaseOptionId} for Qonversion product ${product.qonversionId} has no offer token"
             )
     }
 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/billing/QonversionBillingService.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/billing/QonversionBillingService.kt
@@ -47,7 +47,7 @@ internal class QonversionBillingService internal constructor(
             val actualStoreIds = products.filter { it.storeId != null }
                 .map { ProductStoreId(
                     it.storeId!!,
-                    it.basePlanId
+                    it.storeBasePlanId
                 ) }
             billingClientWrapper.withStoreDataLoaded(
                 actualStoreIds,
@@ -74,7 +74,7 @@ internal class QonversionBillingService internal constructor(
             product.storeId?.let { storeId ->
                 val productStoreId = ProductStoreId(
                     storeId,
-                    product.basePlanId
+                    product.storeBasePlanId
                 )
                 billingClientWrapper.getStoreData(productStoreId)?.let { storeData ->
                     product.setStoreProductDetails(storeData)

--- a/sdk/src/test/java/com/qonversion/android/sdk/dto/products/QProductTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/dto/products/QProductTest.kt
@@ -1,0 +1,38 @@
+package com.qonversion.android.sdk.dto.products
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class QProductTest {
+
+    @Test
+    fun `one-time product exposes purchaseOptionId and null basePlanId`() {
+        val consumable = QProduct("id", "store_id", "premium-option", QProduct.TYPE_CONSUMABLE)
+        assertEquals("premium-option", consumable.purchaseOptionId)
+        assertNull(consumable.basePlanId)
+
+        val nonConsumable = QProduct("id", "store_id", "remove-ads", QProduct.TYPE_NON_CONSUMABLE)
+        assertEquals("remove-ads", nonConsumable.purchaseOptionId)
+        assertNull(nonConsumable.basePlanId)
+    }
+
+    @Test
+    fun `subscription product exposes basePlanId and null purchaseOptionId`() {
+        // apiType 0/1 = subscription (weekly/monthly etc.), not one-time.
+        val subscription = QProduct("id", "store_id", "monthly-plan", 1)
+        assertEquals("monthly-plan", subscription.basePlanId)
+        assertNull(subscription.purchaseOptionId)
+    }
+
+    @Test
+    fun `null store config yields null on both fields`() {
+        val consumable = QProduct("id", "store_id", null, QProduct.TYPE_CONSUMABLE)
+        assertNull(consumable.purchaseOptionId)
+        assertNull(consumable.basePlanId)
+
+        val subscription = QProduct("id", "store_id", null, 1)
+        assertNull(subscription.purchaseOptionId)
+        assertNull(subscription.basePlanId)
+    }
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/storage/util.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/storage/util.kt
@@ -37,17 +37,17 @@ internal class Util {
                 "main" to QProduct(
                     qonversionId = "main",
                     storeId = "qonversion_subs_weekly",
-                    basePlanId = null,
+                    storeBasePlanId = null,
                 ),
                 "in_app" to QProduct(
                     qonversionId = "in_app",
                     storeId = "qonversion_inapp_consumable",
-                    basePlanId = null,
+                    storeBasePlanId = null,
                 ),
                 "annual" to QProduct(
                     qonversionId = "annual",
                     storeId = "qonversion_subs_annual",
-                    basePlanId = null,
+                    storeBasePlanId = null,
                 )
             ),
             permissions = mapOf(
@@ -88,7 +88,7 @@ internal class Util {
                 "in_app" to QProduct(
                     qonversionId = "in_app",
                     storeId = "qonversion_inapp_consumable",
-                    basePlanId = null,
+                    storeBasePlanId = null,
                 )
             ),
             offerings = QOfferings(
@@ -99,12 +99,12 @@ internal class Util {
                         QProduct(
                             qonversionId = "in_app",
                             storeId = "qonversion_inapp_consumable",
-                            basePlanId = null,
+                            storeBasePlanId = null,
                         ),
                         QProduct(
                             qonversionId = "main",
                             storeId = "qonversion_subs_weekly",
-                            basePlanId = null,
+                            storeBasePlanId = null,
                         )
                     )
                 ),
@@ -116,12 +116,12 @@ internal class Util {
                             QProduct(
                                 qonversionId = "in_app",
                                 storeId = "qonversion_inapp_consumable",
-                                basePlanId = null,
+                                storeBasePlanId = null,
                             ),
                             QProduct(
                                 qonversionId = "main",
                                 storeId = "qonversion_subs_weekly",
-                                basePlanId = null,
+                                storeBasePlanId = null,
                             )
                         )
                     )


### PR DESCRIPTION
Issue: [DEV-1215](https://linear.app/qonversion/issue/DEV-1215)

**Stacked on DEV-1208 #845** (shares QProduct/store-details files). Base retargets to develop once #845 merges.

## What
Give one-time products a dedicated client-facing field instead of overloading the subscription base-plan field. SDK public API only — no wire/backend change; `purchaseOptionId` is derived from the `base_plan_id` the SDK already receives, keyed on the config product type.

Clean split of the public contract:
- `basePlanId` → base plan for **subscriptions**, `null` for one-time products.
- `purchaseOptionId` → purchase option for **one-time** (in-app) products, `null` for subscriptions.

The raw store-config value stays available internally (`storeBasePlanId`) and still feeds `QProductStoreDetails` for both subscription base-plan filtering and one-time purchase-option selection, so no purchase logic changes.

## Tests
`QProductTest` covers the type-scoped split; `:sdk:compileReleaseKotlin`, unit-test compile, and `detektAll` green.

First link in the chain: native → sandwich (`toMap`) → cross-platform wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)