### PR TITLE
feat: invalidateRemoteConfigsCache() + remote config refetch after same-uid identify (DEV-1236)

### DIFF
--- a/sample/src/main/java/io/qonversion/sample/RemoteConfigsFragment.kt
+++ b/sample/src/main/java/io/qonversion/sample/RemoteConfigsFragment.kt
@@ -57,6 +57,11 @@ class RemoteConfigsFragment : Fragment() {
             getRemoteConfig(contextKey.ifEmpty { null })
         }
 
+        binding.buttonInvalidateRemoteConfigsCache.setOnClickListener {
+            Qonversion.shared.invalidateRemoteConfigsCache()
+            Toast.makeText(context, getString(R.string.remote_configs_cache_invalidated), Toast.LENGTH_SHORT).show()
+        }
+
         binding.buttonAttachExperiment.setOnClickListener {
             val experimentId = binding.editExperimentId.text.toString()
             val groupId = binding.editGroupId.text.toString()

--- a/sample/src/main/res/layout/fragment_remote_configs.xml
+++ b/sample/src/main/res/layout/fragment_remote_configs.xml
@@ -115,6 +115,15 @@
                     app:backgroundTint="@color/colorDark"
                     app:cornerRadius="8dp" />
 
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonInvalidateRemoteConfigsCache"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/invalidate_remote_configs_cache"
+                    app:cornerRadius="8dp" />
+
             </LinearLayout>
         </androidx.cardview.widget.CardView>
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -84,6 +84,8 @@
     <string name="single_remote_config">Single Remote Config</string>
     <string name="context_key_optional">Context Key (optional)</string>
     <string name="get_remote_config">Get Remote Config</string>
+    <string name="invalidate_remote_configs_cache">Invalidate Remote Configs Cache</string>
+    <string name="remote_configs_cache_invalidated">Cache invalidated — the next request fetches a fresh evaluation</string>
     <string name="experiments">Experiments</string>
     <string name="experiment_id">Experiment ID</string>
     <string name="group_id">Group ID</string>

--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -223,6 +223,15 @@ interface Qonversion {
     fun remoteConfigList(callback: QonversionRemoteConfigListCallback)
 
     /**
+     * Drops the cached remote configs so the next [remoteConfig] or
+     * [remoteConfigList] call fetches a fresh targeting evaluation from the
+     * server instead of returning the in-memory copy.
+     * Call it after changing user properties that participate in remote config
+     * targeting when you need the updated evaluation immediately.
+     */
+    fun refreshRemoteConfigs()
+
+    /**
      * This function should be used for the test purposes only. Do not forget to delete the usage of this function before the release.
      * Use this function to attach the user to the experiment.
      * @param experimentId identifier of the experiment

--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -250,7 +250,9 @@ interface Qonversion {
      * shown by No-Code products are not affected by this method.
      *
      * Call it from the same thread you use for the other Qonversion calls
-     * (typically the main thread).
+     * (typically the main thread). On Android, calling from any thread is
+     * also safe — the conservative wording is the shared cross-platform
+     * contract.
      *
      * @see remoteConfig
      * @see remoteConfigList

--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -250,9 +250,8 @@ interface Qonversion {
      * shown by No-Code products are not affected by this method.
      *
      * Call it from the same thread you use for the other Qonversion calls
-     * (typically the main thread). On Android, calling from any thread is
-     * also safe — the conservative wording is the shared cross-platform
-     * contract.
+     * (typically the main thread). On Android this method is also safe to
+     * call from any thread.
      *
      * @see remoteConfig
      * @see remoteConfigList

--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -231,23 +231,26 @@ interface Qonversion {
      * it only marks the cached values as stale. A [remoteConfig] load that is
      * already in flight when this method is called is re-issued once, so its
      * waiting callbacks receive a fresh evaluation rather than the superseded
-     * one; an in-flight [remoteConfigList] load completes with the evaluation
-     * it started with, and any subsequent call fetches fresh values.
+     * one (if the re-issued request fails, the superseded evaluation is
+     * delivered instead); an in-flight [remoteConfigList] load completes with
+     * the evaluation it started with, and any subsequent call fetches fresh
+     * values.
      *
      * Call it when the targeting inputs changed and you need the change
      * reflected immediately, for example:
      * - after setting a batch of user properties via [setUserProperty] or
      *   [setCustomUserProperty] that your remote config targeting depends on;
-     * - after network connectivity is restored, if a previous call could have
-     *   returned a locally bundled fallback config;
      * - on returning to the foreground in long-living sessions, if the
      *   targeting could have changed server-side.
      *
      * You do NOT need to call it after [identify] — the SDK invalidates the
-     * cache on identity changes automatically. The screens shown by No-Code
-     * products are not affected by this method.
+     * cache on identity changes automatically. You also do not need it to
+     * recover from a locally bundled fallback config — fallbacks are never
+     * cached, so the next call retries the network automatically. The screens
+     * shown by No-Code products are not affected by this method.
      *
-     * The method is thread-safe and can be called from any thread.
+     * Call it from the same thread you use for the other Qonversion calls
+     * (typically the main thread).
      *
      * @see remoteConfig
      * @see remoteConfigList
@@ -361,19 +364,23 @@ interface Qonversion {
      * Sets Qonversion reserved user properties, like email or user id.
      * Note that using [QUserPropertyKey.Custom] here will do nothing.
      * To set custom user property, use [setCustomUserProperty] method instead.
+     * If your remote config targeting depends on this property and you need
+     * the updated evaluation immediately, call [invalidateRemoteConfigsCache]
+     * after setting the properties.
      * @param key defined enum key that will be transformed to string
      * @param value property value
-     * @see invalidateRemoteConfigsCache if your remote config targeting depends
-     *      on this property and you need the updated evaluation immediately
+     * @see invalidateRemoteConfigsCache
      */
     fun setUserProperty(key: QUserPropertyKey, value: String)
 
     /**
-     * Sets custom user property
+     * Sets custom user property.
+     * If your remote config targeting depends on this property and you need
+     * the updated evaluation immediately, call [invalidateRemoteConfigsCache]
+     * after setting the properties.
      * @param key custom user property key
      * @param value property value
-     * @see invalidateRemoteConfigsCache if your remote config targeting depends
-     *      on this property and you need the updated evaluation immediately
+     * @see invalidateRemoteConfigsCache
      */
     fun setCustomUserProperty(key: String, value: String)
 

--- a/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/Qonversion.kt
@@ -223,13 +223,36 @@ interface Qonversion {
     fun remoteConfigList(callback: QonversionRemoteConfigListCallback)
 
     /**
-     * Drops the cached remote configs so the next [remoteConfig] or
-     * [remoteConfigList] call fetches a fresh targeting evaluation from the
-     * server instead of returning the in-memory copy.
-     * Call it after changing user properties that participate in remote config
-     * targeting when you need the updated evaluation immediately.
+     * Invalidates the in-memory cache of remote configs so the next
+     * [remoteConfig] or [remoteConfigList] call fetches a fresh targeting
+     * evaluation from the server instead of returning the cached copy.
+     *
+     * This method performs no network request itself and has no callback —
+     * it only marks the cached values as stale. A [remoteConfig] load that is
+     * already in flight when this method is called is re-issued once, so its
+     * waiting callbacks receive a fresh evaluation rather than the superseded
+     * one; an in-flight [remoteConfigList] load completes with the evaluation
+     * it started with, and any subsequent call fetches fresh values.
+     *
+     * Call it when the targeting inputs changed and you need the change
+     * reflected immediately, for example:
+     * - after setting a batch of user properties via [setUserProperty] or
+     *   [setCustomUserProperty] that your remote config targeting depends on;
+     * - after network connectivity is restored, if a previous call could have
+     *   returned a locally bundled fallback config;
+     * - on returning to the foreground in long-living sessions, if the
+     *   targeting could have changed server-side.
+     *
+     * You do NOT need to call it after [identify] — the SDK invalidates the
+     * cache on identity changes automatically. The screens shown by No-Code
+     * products are not affected by this method.
+     *
+     * The method is thread-safe and can be called from any thread.
+     *
+     * @see remoteConfig
+     * @see remoteConfigList
      */
-    fun refreshRemoteConfigs()
+    fun invalidateRemoteConfigsCache()
 
     /**
      * This function should be used for the test purposes only. Do not forget to delete the usage of this function before the release.
@@ -340,6 +363,8 @@ interface Qonversion {
      * To set custom user property, use [setCustomUserProperty] method instead.
      * @param key defined enum key that will be transformed to string
      * @param value property value
+     * @see invalidateRemoteConfigsCache if your remote config targeting depends
+     *      on this property and you need the updated evaluation immediately
      */
     fun setUserProperty(key: QUserPropertyKey, value: String)
 
@@ -347,6 +372,8 @@ interface Qonversion {
      * Sets custom user property
      * @param key custom user property key
      * @param value property value
+     * @see invalidateRemoteConfigsCache if your remote config targeting depends
+     *      on this property and you need the updated evaluation immediately
      */
     fun setCustomUserProperty(key: String, value: String)
 

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QProductCenterManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QProductCenterManager.kt
@@ -234,7 +234,10 @@ internal class QProductCenterManager internal constructor(
                     // targeting evaluation. Drop them (non-destructively) so the
                     // next remoteConfig() call refetches; pending requests
                     // re-issued below fetch fresh as well (DEV-1236 B4).
-                    remoteConfigManager.refreshRemoteConfigs()
+                    // Invalidate BEFORE handlePendingRequests: the replay must
+                    // miss the cache, or queued completions would be served the
+                    // pre-identify evaluation.
+                    remoteConfigManager.invalidateRemoteConfigsCache()
                     handlePendingRequests()
                     fireIdentitySuccess(identityId)
                 } else {

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QProductCenterManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QProductCenterManager.kt
@@ -228,6 +228,13 @@ internal class QProductCenterManager internal constructor(
                 processingPartnersIdentityId = null
 
                 if (currentUserId == qonversionUid) {
+                    // The uid did not change, but the identity did — user
+                    // properties and the external identity are now attached, so
+                    // cached configs may no longer reflect the server-side
+                    // targeting evaluation. Drop them (non-destructively) so the
+                    // next remoteConfig() call refetches; pending requests
+                    // re-issued below fetch fresh as well (DEV-1236 B4).
+                    remoteConfigManager.refreshRemoteConfigs()
                     handlePendingRequests()
                     fireIdentitySuccess(identityId)
                 } else {

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -135,6 +135,10 @@ internal class QRemoteConfigManager @Inject constructor(
                 // before this call must still reach the server (parity with
                 // iOS) - a cache hit must not swallow the flush.
                 userPropertiesManager.forceSendProperties()
+                // A retry resolved by a warm cache consumes its stashed
+                // baseline - a leftover stash must not resurface on a later,
+                // unrelated failure.
+                loadingStates[contextKey]?.retryBaseline = null
                 // Queued waiters can be stranded on a warm state: a list load
                 // may cache into a state whose own load never fires them (it
                 // completed elsewhere or was superseded). Serving only the

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -79,6 +79,14 @@ internal class QRemoteConfigManager @Inject constructor(
         }
     }
 
+    // Public refresh seam (DEV-1236 B4): drops every cached config so the next
+    // load fetches a fresh evaluation. Non-destructive — loading states and
+    // pending callbacks survive, and the generation bump stops in-flight loads
+    // from re-caching a pre-refresh response.
+    fun refreshRemoteConfigs() = postToMainThread {
+        invalidateLoadedConfigs()
+    }
+
     fun onUserUpdate() = postToMainThread {
         invalidationGeneration++
         loadingStates = mutableMapOf()

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -94,20 +94,16 @@ internal class QRemoteConfigManager @Inject constructor(
     // Public cache invalidation seam (DEV-1236 B4): marks every cached config
     // stale so the next load fetches a fresh evaluation. Non-destructive —
     // loading states and pending callbacks survive, and the generation bump
-    // stops in-flight loads from re-caching a superseded response. The bump
-    // happens synchronously on the caller thread: a load issued right after
-    // this call — from any thread — must already see the cache as stale
-    // (the atomic gives the happens-before the main-thread hop cannot).
-    fun invalidateRemoteConfigsCache() {
+    // stops in-flight loads from re-caching a superseded response.
+    fun invalidateRemoteConfigsCache() = invalidateOnAnyThread {}
+
+    fun onUserUpdate() {
+        // Bump synchronously (see invalidateOnAnyThread) — the destructive
+        // map replacement still happens on main.
         invalidationGeneration.incrementAndGet()
         postToMainThread {
-            clearLoadedConfigs()
+            loadingStates = mutableMapOf()
         }
-    }
-
-    fun onUserUpdate() = postToMainThread {
-        invalidationGeneration.incrementAndGet()
-        loadingStates = mutableMapOf()
     }
 
     // The explicit Unit is required: the re-issue path recurses into this
@@ -117,8 +113,19 @@ internal class QRemoteConfigManager @Inject constructor(
             ?.takeIf { it.generation == invalidationGeneration.get() }
             ?.loadedConfig
             ?.takeIf { userStateProvider.isUserStable }
-            ?.let {
-                callback?.onSuccess(it)
+            ?.let { cached ->
+                // The cached config is served as is, but properties set right
+                // before this call must still reach the server (parity with
+                // iOS) - a cache hit must not swallow the flush.
+                userPropertiesManager.forceSendProperties()
+                callback?.onSuccess(cached)
+                // Queued waiters can be stranded on a warm state: a list load
+                // may cache into a state whose own load never fires them (it
+                // completed elsewhere or was superseded). Serving only the
+                // direct callback would leave them queued forever.
+                if (loadingStates[contextKey]?.callbacks?.isNotEmpty() == true) {
+                    fireToCallbacks(contextKey) { onSuccess(cached) }
+                }
                 return@postToMainThread
             }
 
@@ -153,15 +160,35 @@ internal class QRemoteConfigManager @Inject constructor(
                         // flight, so this evaluation is already superseded.
                         // Re-issue the load once per generation so the waiting
                         // callbacks receive a fresh evaluation instead of the
-                        // stale one; if this generation already got its retry,
-                        // deliver as-is — an invalidation storm must not turn
-                        // into a request loop.
-                        if (loadingState.callbacks.isNotEmpty() &&
+                        // stale one. The state must still be live: a user
+                        // switch replaces the map, and an orphaned state must
+                        // not fire a request nobody awaits. The waiters are
+                        // snapshotted and carried through the retry with the
+                        // superseded (but valid) evaluation as a baseline — a
+                        // failed retry degrades to the baseline instead of
+                        // surfacing an error where the caller previously got
+                        // a success. The generation cap is defense-in-depth:
+                        // the retry is bounded primarily by the per-key
+                        // isInProgress serialisation (one load, hence one
+                        // superseded response, per generation).
+                        if (loadingStates[contextKey] === loadingState &&
+                            loadingState.callbacks.isNotEmpty() &&
                             loadingState.reissuedForGeneration != currentGeneration
                         ) {
                             loadingState.reissuedForGeneration = currentGeneration
                             loadingState.isInProgress = false
-                            loadRemoteConfig(contextKey, null)
+                            val waiters = loadingState.callbacks.toList()
+                            loadingState.callbacks.clear()
+                            val baseline = remoteConfig
+                            loadRemoteConfig(contextKey, object : QonversionRemoteConfigCallback {
+                                override fun onSuccess(remoteConfig: QRemoteConfig) {
+                                    waiters.forEach { it.onSuccess(remoteConfig) }
+                                }
+
+                                override fun onError(error: QonversionError) {
+                                    waiters.forEach { it.onSuccess(baseline) }
+                                }
+                            })
                             return
                         }
                         fireToCallbacks(contextKey) { onSuccess(remoteConfig) }
@@ -208,6 +235,12 @@ internal class QRemoteConfigManager @Inject constructor(
             loadingStates[key]?.takeIf { it.generation == currentGeneration }?.loadedConfig
         }
         if (cachedConfigs.all { it != null }) {
+            // Same as the single-key cache hit: flush pending properties so a
+            // hit does not swallow them. Gated on stability (parity with iOS)
+            // so the flush cannot POST mid-identify to a switching uid.
+            if (userStateProvider.isUserStable) {
+                userPropertiesManager.forceSendProperties()
+            }
             callback.onSuccess(QRemoteConfigList(cachedConfigs.filterNotNull()))
             return@postToMainThread
         }
@@ -241,43 +274,45 @@ internal class QRemoteConfigManager @Inject constructor(
         })
     }
 
-    fun attachUserToExperiment(experimentId: String, groupId: String, callback: QonversionExperimentAttachCallback) = postToMainThread {
-        invalidateLoadedConfigs()
-        remoteConfigService.attachUserToExperiment(experimentId, groupId, callback)
-    }
+    // An attach/detach is addressed by experiment/configuration id, and the SDK does not
+    // know which context key that entity serves — drop every cached config, not just the
+    // empty-key one, or configs under named context keys stay stale until process restart.
+    // The generation bump also stops in-flight loads from re-caching a pre-attach response.
+    fun attachUserToExperiment(experimentId: String, groupId: String, callback: QonversionExperimentAttachCallback) =
+        invalidateOnAnyThread {
+            remoteConfigService.attachUserToExperiment(experimentId, groupId, callback)
+        }
 
-    fun detachUserFromExperiment(experimentId: String, callback: QonversionExperimentAttachCallback) = postToMainThread {
-        invalidateLoadedConfigs()
-        remoteConfigService.detachUserFromExperiment(experimentId, callback)
-    }
+    fun detachUserFromExperiment(experimentId: String, callback: QonversionExperimentAttachCallback) =
+        invalidateOnAnyThread {
+            remoteConfigService.detachUserFromExperiment(experimentId, callback)
+        }
 
     fun attachUserToRemoteConfiguration(
         remoteConfigurationId: String,
         callback: QonversionRemoteConfigurationAttachCallback
-    ) = postToMainThread {
-        invalidateLoadedConfigs()
+    ) = invalidateOnAnyThread {
         remoteConfigService.attachUserToRemoteConfiguration(remoteConfigurationId, callback)
     }
 
     fun detachUserFromRemoteConfiguration(
         remoteConfigurationId: String,
         callback: QonversionRemoteConfigurationAttachCallback
-    ) = postToMainThread {
-        invalidateLoadedConfigs()
+    ) = invalidateOnAnyThread {
         remoteConfigService.detachUserFromRemoteConfiguration(remoteConfigurationId, callback)
     }
 
-    // An attach/detach is addressed by experiment/configuration id, and the SDK does not
-    // know which context key that entity serves — drop every cached config, not just the
-    // empty-key one, or configs under named context keys stay stale until process restart.
-    // The generation bump also stops in-flight loads from re-caching a pre-attach response.
-    private fun invalidateLoadedConfigs() {
+    // Shared invalidation shape for every seam: the generation is bumped
+    // SYNCHRONOUSLY on the caller thread — a load issued right after any
+    // invalidation, from any thread, must already see the cache as stale
+    // (the atomic gives the happens-before the main-thread hop cannot) —
+    // then the cached values are cleared and the action runs on main.
+    private fun invalidateOnAnyThread(action: () -> Unit) {
         invalidationGeneration.incrementAndGet()
-        clearLoadedConfigs()
-    }
-
-    private fun clearLoadedConfigs() {
-        loadingStates.values.forEach { it.loadedConfig = null }
+        postToMainThread {
+            loadingStates.values.forEach { it.loadedConfig = null }
+            action()
+        }
     }
 
     private fun getRemoteConfigListCallbackWrapper(

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -14,6 +14,7 @@ import com.qonversion.android.sdk.listeners.QonversionExperimentAttachCallback
 import com.qonversion.android.sdk.listeners.QonversionRemoteConfigCallback
 import com.qonversion.android.sdk.listeners.QonversionRemoteConfigListCallback
 import com.qonversion.android.sdk.listeners.QonversionRemoteConfigurationAttachCallback
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
 private val EmptyContextKey: String? = null
@@ -29,7 +30,15 @@ internal class QRemoteConfigManager @Inject constructor(
     internal class LoadingState(
         var loadedConfig: QRemoteConfig? = null,
         val callbacks: MutableList<QonversionRemoteConfigCallback> = mutableListOf(),
-        var isInProgress: Boolean = false
+        var isInProgress: Boolean = false,
+        // Generation the loadedConfig was cached at — the cached fast paths
+        // serve it only while it matches the current invalidation generation,
+        // so an invalidation makes the cache stale before the posted
+        // main-thread cleanup has run.
+        var generation: Int = 0,
+        // Last generation a superseded in-flight load was re-issued for —
+        // caps the retry at one per invalidation.
+        var reissuedForGeneration: Int? = null
     )
 
     internal class ListRequestData(
@@ -44,11 +53,14 @@ internal class QRemoteConfigManager @Inject constructor(
     lateinit var userPropertiesManager: QUserPropertiesManager
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    // Bumped on every cache invalidation (attach/detach, user change). Loads
-    // capture it when they start and skip the cache write if it moved — an
-    // in-flight response evaluated before the invalidating event must not be
-    // re-cached as fresh. Main-thread confined like the rest of the state.
-    private var invalidationGeneration = 0
+    // Bumped on every cache invalidation (attach/detach, user change, explicit
+    // invalidateRemoteConfigsCache). Loads capture it when they start and skip
+    // the cache write if it moved — an in-flight response evaluated before the
+    // invalidating event must not be re-cached as fresh. Atomic rather than
+    // main-confined: the explicit invalidation bumps it synchronously on the
+    // caller thread, so the cached fast paths reject stale values immediately
+    // instead of waiting for the posted main-thread hop to drain.
+    private val invalidationGeneration = AtomicInteger(0)
 
     fun handlePendingRequests() = postToMainThread {
         loadingStates.filter { it.value.callbacks.isNotEmpty() }
@@ -79,21 +91,30 @@ internal class QRemoteConfigManager @Inject constructor(
         }
     }
 
-    // Public refresh seam (DEV-1236 B4): drops every cached config so the next
-    // load fetches a fresh evaluation. Non-destructive — loading states and
-    // pending callbacks survive, and the generation bump stops in-flight loads
-    // from re-caching a pre-refresh response.
-    fun refreshRemoteConfigs() = postToMainThread {
-        invalidateLoadedConfigs()
+    // Public cache invalidation seam (DEV-1236 B4): marks every cached config
+    // stale so the next load fetches a fresh evaluation. Non-destructive —
+    // loading states and pending callbacks survive, and the generation bump
+    // stops in-flight loads from re-caching a superseded response. The bump
+    // happens synchronously on the caller thread: a load issued right after
+    // this call — from any thread — must already see the cache as stale
+    // (the atomic gives the happens-before the main-thread hop cannot).
+    fun invalidateRemoteConfigsCache() {
+        invalidationGeneration.incrementAndGet()
+        postToMainThread {
+            clearLoadedConfigs()
+        }
     }
 
     fun onUserUpdate() = postToMainThread {
-        invalidationGeneration++
+        invalidationGeneration.incrementAndGet()
         loadingStates = mutableMapOf()
     }
 
-    fun loadRemoteConfig(contextKey: String?, callback: QonversionRemoteConfigCallback?) = postToMainThread {
+    // The explicit Unit is required: the re-issue path recurses into this
+    // function, and an inferred expression-body type would depend on itself.
+    fun loadRemoteConfig(contextKey: String?, callback: QonversionRemoteConfigCallback?): Unit = postToMainThread {
         loadingStates[contextKey]
+            ?.takeIf { it.generation == invalidationGeneration.get() }
             ?.loadedConfig
             ?.takeIf { userStateProvider.isUserStable }
             ?.let {
@@ -114,14 +135,34 @@ internal class QRemoteConfigManager @Inject constructor(
 
         loadingState.isInProgress = true
         loadingState.loadedConfig = null
-        val generationAtStart = invalidationGeneration
+        val generationAtStart = invalidationGeneration.get()
 
         userPropertiesManager.forceSendProperties(object : QonversionEmptyCallback {
             override fun onComplete() {
                 remoteConfigService.loadRemoteConfig(contextKey, object : QonversionRemoteConfigCallback {
                     override fun onSuccess(remoteConfig: QRemoteConfig) {
-                        if (invalidationGeneration == generationAtStart) {
+                        val currentGeneration = invalidationGeneration.get()
+                        if (currentGeneration == generationAtStart) {
                             loadingState.loadedConfig = remoteConfig
+                            loadingState.generation = generationAtStart
+                            fireToCallbacks(contextKey) { onSuccess(remoteConfig) }
+                            return
+                        }
+
+                        // The cache was invalidated while this load was in
+                        // flight, so this evaluation is already superseded.
+                        // Re-issue the load once per generation so the waiting
+                        // callbacks receive a fresh evaluation instead of the
+                        // stale one; if this generation already got its retry,
+                        // deliver as-is — an invalidation storm must not turn
+                        // into a request loop.
+                        if (loadingState.callbacks.isNotEmpty() &&
+                            loadingState.reissuedForGeneration != currentGeneration
+                        ) {
+                            loadingState.reissuedForGeneration = currentGeneration
+                            loadingState.isInProgress = false
+                            loadRemoteConfig(contextKey, null)
+                            return
                         }
                         fireToCallbacks(contextKey) { onSuccess(remoteConfig) }
                     }
@@ -143,8 +184,12 @@ internal class QRemoteConfigManager @Inject constructor(
                             baseRemoteConfigList.remoteConfigForContextKey(contextKey)
                         }
 
-                        remoteConfig?.let {
-                            onSuccess(it)
+                        // The fallback is a bundled last-resort payload, not a
+                        // fresh targeting evaluation — deliver it without
+                        // caching so the next call retries the network instead
+                        // of pinning the fallback until the next invalidation.
+                        remoteConfig?.let { fallbackConfig ->
+                            fireToCallbacks(contextKey) { onSuccess(fallbackConfig) }
                         } ?: fireToCallbacks(contextKey) { onError(error) }
                     }
                 })
@@ -158,9 +203,12 @@ internal class QRemoteConfigManager @Inject constructor(
         callback: QonversionRemoteConfigListCallback
     ) = postToMainThread {
         val allKeys = if (includeEmptyContextKey) contextKeys + EmptyContextKey else contextKeys
-        if (allKeys.all { loadingStates[it]?.loadedConfig != null }) {
-            val configs = allKeys.mapNotNull { loadingStates[it]?.loadedConfig }
-            callback.onSuccess(QRemoteConfigList(configs))
+        val currentGeneration = invalidationGeneration.get()
+        val cachedConfigs = allKeys.map { key ->
+            loadingStates[key]?.takeIf { it.generation == currentGeneration }?.loadedConfig
+        }
+        if (cachedConfigs.all { it != null }) {
+            callback.onSuccess(QRemoteConfigList(cachedConfigs.filterNotNull()))
             return@postToMainThread
         }
 
@@ -224,7 +272,11 @@ internal class QRemoteConfigManager @Inject constructor(
     // empty-key one, or configs under named context keys stay stale until process restart.
     // The generation bump also stops in-flight loads from re-caching a pre-attach response.
     private fun invalidateLoadedConfigs() {
-        invalidationGeneration++
+        invalidationGeneration.incrementAndGet()
+        clearLoadedConfigs()
+    }
+
+    private fun clearLoadedConfigs() {
         loadingStates.values.forEach { it.loadedConfig = null }
     }
 
@@ -236,14 +288,15 @@ internal class QRemoteConfigManager @Inject constructor(
         // Remembering loading states for the case of user change -
         // if it happens, we won't store remote configs for different user.
         val localLoadingStates = loadingStates
-        val generationAtStart = invalidationGeneration
+        val generationAtStart = invalidationGeneration.get()
         return object : QonversionRemoteConfigListCallback {
             override fun onSuccess(remoteConfigList: QRemoteConfigList) {
-                if (invalidationGeneration == generationAtStart) {
+                if (invalidationGeneration.get() == generationAtStart) {
                     remoteConfigList.remoteConfigs.forEach { remoteConfig ->
                         val contextKey = remoteConfig.source.contextKey
                         val loadingState = localLoadingStates[contextKey] ?: LoadingState()
                         loadingState.loadedConfig = remoteConfig
+                        loadingState.generation = generationAtStart
                         localLoadingStates[contextKey] = loadingState
                     }
                 }
@@ -274,7 +327,10 @@ internal class QRemoteConfigManager @Inject constructor(
                     QRemoteConfigList(remoteConfigs.toList())
                 }
 
-                onSuccess(remoteConfigList)
+                // Bundled fallback, not a fresh targeting evaluation — deliver
+                // without caching (see the single-key path), so the next call
+                // retries the network.
+                callback.onSuccess(remoteConfigList)
             }
         }
     }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -103,8 +103,12 @@ internal class QRemoteConfigManager @Inject constructor(
         // and registers that key in loadingStates. Iterating a copy keeps that re-entrant
         // structural add from mutating the map mid-iteration. Main-thread confinement does
         // not help here - the reentrancy is within a single thread.
-        loadingStates.keys.toList().forEach {
-            fireToCallbacks(it) { onError(error) }
+        loadingStates.keys.toList().forEach { key ->
+            // The only drain that bypasses the response handlers — consume
+            // the retry stash here too, or a leftover masks a later
+            // unrelated failure as a stale success.
+            loadingStates[key]?.retryBaseline = null
+            fireToCallbacks(key) { onError(error) }
         }
     }
 
@@ -154,7 +158,9 @@ internal class QRemoteConfigManager @Inject constructor(
                     snapshot
                 }.orEmpty()
                 queued.forEach { it.onSuccess(cached) }
-                if (callback != null && callback !in queued) {
+                // Identity, not equals: a host listener with value semantics
+                // (data class) must not suppress a distinct caller.
+                if (callback != null && queued.none { it === callback }) {
                     callback.onSuccess(cached)
                 }
                 return@postToMainThread

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QRemoteConfigManager.kt
@@ -6,6 +6,7 @@ import com.qonversion.android.sdk.dto.QFallbackObject
 import com.qonversion.android.sdk.dto.QRemoteConfig
 import com.qonversion.android.sdk.dto.QRemoteConfigList
 import com.qonversion.android.sdk.dto.QonversionError
+import com.qonversion.android.sdk.dto.QonversionErrorCode
 import com.qonversion.android.sdk.internal.provider.UserStateProvider
 import com.qonversion.android.sdk.internal.services.QFallbacksService
 import com.qonversion.android.sdk.internal.services.QRemoteConfigService
@@ -18,6 +19,15 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
 private val EmptyContextKey: String? = null
+
+// Rate-limit tolerance is scoped to remote configs deliberately: the other
+// shouldFireFallback consumer (the entitlements path) keeps surfacing
+// ApiRateLimitExceeded unchanged. A locally short-circuited RC request is
+// exactly the case the bundled payload exists for — and since fallbacks are
+// no longer cached, offline repeat calls hit the limiter instead of the old
+// cached-fallback fast path.
+private val QonversionError.shouldFireRemoteConfigFallback
+    get(): Boolean = shouldFireFallback || code == QonversionErrorCode.ApiRateLimitExceeded
 
 internal class QRemoteConfigManager @Inject constructor(
     private val remoteConfigService: QRemoteConfigService,
@@ -37,8 +47,15 @@ internal class QRemoteConfigManager @Inject constructor(
         // main-thread cleanup has run.
         var generation: Int = 0,
         // Last generation a superseded in-flight load was re-issued for —
-        // caps the retry at one per invalidation.
-        var reissuedForGeneration: Int? = null
+        // defense-in-depth against a concurrent re-entry; the retry count is
+        // bounded structurally by the per-key isInProgress serialisation.
+        var reissuedForGeneration: Int? = null,
+        // The superseded (but valid) evaluation held while its re-issued
+        // retry is in flight. A failed retry degrades to it — for everyone,
+        // including callers who join during the retry window — and it
+        // outranks the static bundled fallback: a real user-specific
+        // evaluation seconds old beats shipped-in-binary defaults.
+        var retryBaseline: QRemoteConfig? = null
     )
 
     internal class ListRequestData(
@@ -118,13 +135,23 @@ internal class QRemoteConfigManager @Inject constructor(
                 // before this call must still reach the server (parity with
                 // iOS) - a cache hit must not swallow the flush.
                 userPropertiesManager.forceSendProperties()
-                callback?.onSuccess(cached)
                 // Queued waiters can be stranded on a warm state: a list load
                 // may cache into a state whose own load never fires them (it
                 // completed elsewhere or was superseded). Serving only the
-                // direct callback would leave them queued forever.
-                if (loadingStates[contextKey]?.callbacks?.isNotEmpty() == true) {
-                    fireToCallbacks(contextKey) { onSuccess(cached) }
+                // direct callback would leave them queued forever. Drained
+                // inline, NOT via fireToCallbacks: resolving waiters must not
+                // mark a still-outstanding load as finished (isInProgress
+                // belongs to that load). Dedup: a listener instance queued
+                // earlier and passed again as the direct callback must
+                // receive exactly one onSuccess per delivery.
+                val queued = loadingStates[contextKey]?.callbacks?.let { callbacks ->
+                    val snapshot = callbacks.toList()
+                    callbacks.clear()
+                    snapshot
+                }.orEmpty()
+                queued.forEach { it.onSuccess(cached) }
+                if (callback != null && callback !in queued) {
+                    callback.onSuccess(cached)
                 }
                 return@postToMainThread
             }
@@ -148,6 +175,9 @@ internal class QRemoteConfigManager @Inject constructor(
             override fun onComplete() {
                 remoteConfigService.loadRemoteConfig(contextKey, object : QonversionRemoteConfigCallback {
                     override fun onSuccess(remoteConfig: QRemoteConfig) {
+                        // A successful (or delivered-as-is) response always
+                        // supersedes any baseline stashed by an earlier retry.
+                        loadingState.retryBaseline = null
                         val currentGeneration = invalidationGeneration.get()
                         if (currentGeneration == generationAtStart) {
                             loadingState.loadedConfig = remoteConfig
@@ -177,6 +207,11 @@ internal class QRemoteConfigManager @Inject constructor(
                         ) {
                             loadingState.reissuedForGeneration = currentGeneration
                             loadingState.isInProgress = false
+                            // The stash makes the never-worse guarantee
+                            // uniform: the retry's failure handlers prefer it
+                            // over both the error and the bundled fallback,
+                            // reaching late joiners queued during the retry.
+                            loadingState.retryBaseline = remoteConfig
                             val waiters = loadingState.callbacks.toList()
                             loadingState.callbacks.clear()
                             val baseline = remoteConfig
@@ -186,6 +221,9 @@ internal class QRemoteConfigManager @Inject constructor(
                                 }
 
                                 override fun onError(error: QonversionError) {
+                                    // Safety net only: with the stash in place
+                                    // the retry resolves via onSuccess; this
+                                    // branch survives for exotic interleavings.
                                     waiters.forEach { it.onSuccess(baseline) }
                                 }
                             })
@@ -195,28 +233,32 @@ internal class QRemoteConfigManager @Inject constructor(
                     }
 
                     override fun onError(error: QonversionError) {
-                        if (!error.shouldFireFallback) {
-                            fireToCallbacks(contextKey) { onError(error) }
-                            return
-                        }
-
-                        val baseRemoteConfigList = fallbackData?.remoteConfigList ?: run {
-                            fireToCallbacks(contextKey) { onError(error) }
-                            return@onError
-                        }
-
-                        val remoteConfig = if (contextKey == null) {
-                            baseRemoteConfigList.remoteConfigForEmptyContextKey
-                        } else {
-                            baseRemoteConfigList.remoteConfigForContextKey(contextKey)
-                        }
-
+                        val baseline = loadingState.retryBaseline
+                        loadingState.retryBaseline = null
                         // The fallback is a bundled last-resort payload, not a
                         // fresh targeting evaluation — deliver it without
                         // caching so the next call retries the network instead
                         // of pinning the fallback until the next invalidation.
-                        remoteConfig?.let { fallbackConfig ->
-                            fireToCallbacks(contextKey) { onSuccess(fallbackConfig) }
+                        val bundledConfig = if (error.shouldFireRemoteConfigFallback) {
+                            fallbackData?.remoteConfigList?.let { list ->
+                                if (contextKey == null) {
+                                    list.remoteConfigForEmptyContextKey
+                                } else {
+                                    list.remoteConfigForContextKey(contextKey)
+                                }
+                            }
+                        } else {
+                            null
+                        }
+
+                        // A failed retry of a superseded load degrades to the
+                        // baseline — a real user-specific evaluation seconds
+                        // old — for everyone, including callers who joined
+                        // during the retry window. It outranks both the error
+                        // and the static bundled payload.
+                        val result = baseline ?: bundledConfig
+                        result?.let { config ->
+                            fireToCallbacks(contextKey) { onSuccess(config) }
                         } ?: fireToCallbacks(contextKey) { onError(error) }
                     }
                 })
@@ -340,7 +382,7 @@ internal class QRemoteConfigManager @Inject constructor(
             }
 
             override fun onError(error: QonversionError) {
-                if (!error.shouldFireFallback) {
+                if (!error.shouldFireRemoteConfigFallback) {
                     callback.onError(error)
                     return
                 }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -307,6 +307,10 @@ internal class QonversionInternal(
         })
     }
 
+    override fun refreshRemoteConfigs() {
+        remoteConfigManager.refreshRemoteConfigs()
+    }
+
     override fun attachUserToExperiment(
         experimentId: String,
         groupId: String,

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/QonversionInternal.kt
@@ -307,8 +307,8 @@ internal class QonversionInternal(
         })
     }
 
-    override fun refreshRemoteConfigs() {
-        remoteConfigManager.refreshRemoteConfigs()
+    override fun invalidateRemoteConfigsCache() {
+        remoteConfigManager.invalidateRemoteConfigsCache()
     }
 
     override fun attachUserToExperiment(

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/utils.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/utils.kt
@@ -10,10 +10,4 @@ internal val Int.daysToMs get() = daysToSeconds * 1000
 internal val QonversionError.shouldFireFallback
     get(): Boolean =
         this.code == QonversionErrorCode.NetworkConnectionFailed ||
-                // A locally short-circuited request (rate limiter) is exactly the
-                // case the bundled payload exists for: no network attempt was
-                // made, so serving the fallback beats surfacing a hard error.
-                // Matters since fallbacks are no longer cached - offline apps
-                // hit the limiter instead of the old cached-fallback fast path.
-                this.code == QonversionErrorCode.ApiRateLimitExceeded ||
                 this.httpCode?.isInternalServerError() == true

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/utils.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/utils.kt
@@ -10,4 +10,10 @@ internal val Int.daysToMs get() = daysToSeconds * 1000
 internal val QonversionError.shouldFireFallback
     get(): Boolean =
         this.code == QonversionErrorCode.NetworkConnectionFailed ||
+                // A locally short-circuited request (rate limiter) is exactly the
+                // case the bundled payload exists for: no network attempt was
+                // made, so serving the fallback beats surfacing a hard error.
+                // Matters since fallbacks are no longer cached - offline apps
+                // hit the limiter instead of the old cached-fallback fast path.
+                this.code == QonversionErrorCode.ApiRateLimitExceeded ||
                 this.httpCode?.isInternalServerError() == true

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerIdentifyContractTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerIdentifyContractTest.kt
@@ -152,7 +152,7 @@ internal class QProductCenterManagerIdentifyContractTest {
      * always-launch.
      */
     @Test
-    fun `identify with same uid does NOT clear cache or re-launch, but refreshes remote configs`() {
+    fun `identify with same uid does NOT clear cache or re-launch, but invalidates remote configs cache`() {
         val newIdentity = "user@example.com"
         val sameUid = "uid_initial"
 
@@ -171,8 +171,37 @@ internal class QProductCenterManagerIdentifyContractTest {
         }
         // DEV-1236 B4: the identity attached without a uid change — cached
         // configs may no longer reflect server-side targeting, so they are
-        // dropped (non-destructively) for a refetch on the next call.
-        verify(exactly = 1) { mockRemoteConfigManager.refreshRemoteConfigs() }
+        // dropped (non-destructively) for a refetch on the next call. The
+        // ORDER is load-bearing: the pending-request replay must run after
+        // the invalidation, or queued RC completions would be served the
+        // pre-identify evaluation straight from the cache.
+        verifyOrder {
+            mockRemoteConfigManager.invalidateRemoteConfigsCache()
+            mockRemoteConfigManager.handlePendingRequests()
+        }
+        verify(exactly = 1) { mockRemoteConfigManager.invalidateRemoteConfigsCache() }
+        // ...and the destructive user-switch path must NOT fire on same-uid
+        verify(exactly = 0) { mockRemoteConfigManager.onUserUpdate() }
+    }
+
+    /**
+     * Repeat identify with an identity that is ALREADY current returns early:
+     * nothing changed server-side, so no cache invalidation and no identity
+     * request. Pins the early-return so re-identifying in a hot loop stays
+     * free; the explicit escape hatch for "same identity, changed targeting"
+     * is the public invalidateRemoteConfigsCache().
+     */
+    @Test
+    fun `repeat identify with the current identity returns early without touching remote configs`() {
+        val identity = "user@example.com"
+
+        every { mockIdentityManager.currentPartnersIdentityId } returns identity
+
+        pcm.identify(identity)
+
+        verify(exactly = 0) { mockIdentityManager.identify(any(), any()) }
+        verify(exactly = 0) { mockRemoteConfigManager.invalidateRemoteConfigsCache() }
+        verify(exactly = 0) { mockRemoteConfigManager.onUserUpdate() }
     }
 
     /**

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerIdentifyContractTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QProductCenterManagerIdentifyContractTest.kt
@@ -152,7 +152,7 @@ internal class QProductCenterManagerIdentifyContractTest {
      * always-launch.
      */
     @Test
-    fun `identify with same uid does NOT clear cache or re-launch`() {
+    fun `identify with same uid does NOT clear cache or re-launch, but refreshes remote configs`() {
         val newIdentity = "user@example.com"
         val sameUid = "uid_initial"
 
@@ -169,6 +169,10 @@ internal class QProductCenterManagerIdentifyContractTest {
         verify(exactly = 0) {
             mockRepository.init(match { it.requestTrigger == RequestTrigger.Identify })
         }
+        // DEV-1236 B4: the identity attached without a uid change — cached
+        // configs may no longer reflect server-side targeting, so they are
+        // dropped (non-destructively) for a refetch on the next call.
+        verify(exactly = 1) { mockRemoteConfigManager.refreshRemoteConfigs() }
     }
 
     /**

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -350,6 +350,37 @@ internal class QRemoteConfigManagerTest {
         assertEquals(null, loadingStates()["ctx"]?.loadedConfig)
     }
 
+    @Test
+    fun `refreshRemoteConfigs drops caches non-destructively and guards in-flight loads`() {
+        // given - cached configs with a pending callback, plus a load in flight
+        userStateProvider.stable = true
+        val pendingCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        loadingStates()[null] = QRemoteConfigManager.LoadingState(loadedConfig = mockk<QRemoteConfig>(relaxed = true))
+        loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(
+            loadedConfig = mockk<QRemoteConfig>(relaxed = true),
+            callbacks = mutableListOf(pendingCallback),
+        )
+        val serviceCallback = slot<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("in-flight", capture(serviceCallback)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("in-flight", null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when
+        manager.refreshRemoteConfigs()
+        shadowOf(Looper.getMainLooper()).idle()
+        serviceCallback.captured.onSuccess(mockk<QRemoteConfig>(relaxed = true))
+
+        // then - every cached config dropped, callbacks preserved, and the
+        // pre-refresh in-flight response is not re-cached (generation guard)
+        assertEquals(null, loadingStates()[null]?.loadedConfig)
+        assertEquals(null, loadingStates()["ctx"]?.loadedConfig)
+        assertEquals(1, loadingStates()["ctx"]?.callbacks?.size)
+        assertEquals(null, loadingStates()["in-flight"]?.loadedConfig)
+    }
+
     private fun listRequests() =
         manager.getPrivateField<List<*>>("listRequests")
 

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -2,6 +2,7 @@ package com.qonversion.android.sdk.internal
 
 import android.os.Build
 import android.os.Looper
+import com.qonversion.android.sdk.dto.QFallbackObject
 import com.qonversion.android.sdk.dto.QRemoteConfig
 import com.qonversion.android.sdk.dto.QRemoteConfigList
 import com.qonversion.android.sdk.dto.QonversionError
@@ -22,6 +23,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -262,15 +264,17 @@ internal class QRemoteConfigManagerTest {
     }
 
     @Test
-    fun `every attach and detach entry point invalidates named-key cached configs`() {
-        // given - all four entry points are addressed by entity id only, so the
-        // SDK cannot know which context key is served and must drop every cache
+    fun `every invalidation entry point drops named-key cached configs non-destructively`() {
+        // given - attach/detach are addressed by entity id only, so the SDK
+        // cannot know which context key is served and must drop every cache;
+        // the public invalidateRemoteConfigsCache shares the same semantics
         userStateProvider.stable = true
         val entryPoints = listOf<Pair<String, (QRemoteConfigManager) -> Unit>>(
             "attachUserToRemoteConfiguration" to { it.attachUserToRemoteConfiguration("config_id", mockk(relaxed = true)) },
             "detachUserFromRemoteConfiguration" to { it.detachUserFromRemoteConfiguration("config_id", mockk(relaxed = true)) },
             "attachUserToExperiment" to { it.attachUserToExperiment("experiment_id", "group_id", mockk(relaxed = true)) },
             "detachUserFromExperiment" to { it.detachUserFromExperiment("experiment_id", mockk(relaxed = true)) },
+            "invalidateRemoteConfigsCache" to { it.invalidateRemoteConfigsCache() },
         )
 
         entryPoints.forEach { (name, entryPoint) ->
@@ -288,20 +292,27 @@ internal class QRemoteConfigManagerTest {
             shadowOf(Looper.getMainLooper()).idle()
 
             // then - every cached config is dropped, but loading states and
-            // their pending callbacks are preserved (non-destructive invalidation)
-            assertEquals("$name must drop the empty-key config", null, loadingStates()[null]?.loadedConfig)
-            assertEquals("$name must drop the named-key config", null, loadingStates()["ctx"]?.loadedConfig)
-            assertEquals("$name must preserve pending callbacks", 1, loadingStates()["ctx"]?.callbacks?.size)
+            // their pending callbacks are preserved (non-destructive invalidation).
+            // Assert on the states themselves first: a `?.` chain against a
+            // missing key would make the null comparisons pass vacuously.
+            val emptyKeyState = loadingStates()[null]
+            val namedKeyState = loadingStates()["ctx"]
+            assertNotNull("$name must preserve the empty-key loading state", emptyKeyState)
+            assertNotNull("$name must preserve the named-key loading state", namedKeyState)
+            assertEquals("$name must drop the empty-key config", null, emptyKeyState?.loadedConfig)
+            assertEquals("$name must drop the named-key config", null, namedKeyState?.loadedConfig)
+            assertEquals("$name must preserve pending callbacks", 1, namedKeyState?.callbacks?.size)
         }
     }
 
     @Test
-    fun `attach invalidation prevents an in-flight load from re-caching a stale config`() {
-        // given - a load is in flight when the attach lands
+    fun `invalidation mid-flight re-issues the load instead of delivering the stale response`() {
+        // given - a load with a waiting callback is in flight when the
+        // invalidation lands
         userStateProvider.stable = true
         val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
-        val serviceCallback = slot<QonversionRemoteConfigCallback>()
-        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallback)) } just runs
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
         every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
             firstArg<QonversionEmptyCallback?>()?.onComplete()
         }
@@ -309,18 +320,79 @@ internal class QRemoteConfigManagerTest {
         manager.loadRemoteConfig("ctx", loadCallback)
         shadowOf(Looper.getMainLooper()).idle()
 
-        // when - the attach invalidates mid-flight, then the pre-attach response lands
+        // when - the cache is invalidated mid-flight, then the superseded
+        // response lands
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        val staleConfig = mockk<QRemoteConfig>(relaxed = true)
+        serviceCallbacks.first().onSuccess(staleConfig)
+
+        // then - the stale evaluation is neither cached nor delivered; the
+        // load is re-issued exactly once for the waiting callback
+        verify(exactly = 0) { loadCallback.onSuccess(any()) }
+        verify(exactly = 2) { mockRemoteConfigService.loadRemoteConfig("ctx", any()) }
+
+        // and the fresh response is delivered, cached, and the state settled
+        val freshConfig = mockk<QRemoteConfig>(relaxed = true)
+        serviceCallbacks.last().onSuccess(freshConfig)
+        verify(exactly = 1) { loadCallback.onSuccess(freshConfig) }
+        verify(exactly = 0) { loadCallback.onSuccess(staleConfig) }
+        val state = loadingStates()["ctx"]
+        assertNotNull(state)
+        assertEquals(freshConfig, state?.loadedConfig)
+        assertEquals(false, state?.isInProgress)
+    }
+
+    @Test
+    fun `attach invalidation mid-flight also re-issues an awaited load`() {
+        // given - a load with a waiting callback is in flight when the attach
+        // lands (attach shares the invalidation seam with the public API)
+        userStateProvider.stable = true
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+
         manager.attachUserToRemoteConfiguration("config_id", mockk(relaxed = true))
         shadowOf(Looper.getMainLooper()).idle()
         val staleConfig = mockk<QRemoteConfig>(relaxed = true)
-        serviceCallback.captured.onSuccess(staleConfig)
+        serviceCallbacks.first().onSuccess(staleConfig)
 
-        // then - the stale (pre-attach) evaluation must not be re-cached, but
-        // the response is still DELIVERED to the waiting caller and the state
-        // is left refetchable (the guard skips only the cache write)
-        assertEquals(null, loadingStates()["ctx"]?.loadedConfig)
-        verify(exactly = 1) { loadCallback.onSuccess(staleConfig) }
-        assertEquals(false, loadingStates()["ctx"]?.isInProgress)
+        // then - the pre-attach evaluation is dropped and the load re-issued
+        verify(exactly = 0) { loadCallback.onSuccess(any()) }
+        verify(exactly = 2) { mockRemoteConfigService.loadRemoteConfig("ctx", any()) }
+    }
+
+    @Test
+    fun `invalidation mid-flight does not re-issue a load nobody awaits`() {
+        // given - a load with NO waiting callback is in flight
+        userStateProvider.stable = true
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+
+        manager.loadRemoteConfig("ctx", null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - the cache is invalidated mid-flight, then the response lands
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        serviceCallbacks.first().onSuccess(mockk<QRemoteConfig>(relaxed = true))
+
+        // then - no waiter means no retry; the superseded response is simply
+        // not cached and the state is left refetchable
+        verify(exactly = 1) { mockRemoteConfigService.loadRemoteConfig("ctx", any()) }
+        val state = loadingStates()["ctx"]
+        assertNotNull(state)
+        assertEquals(null, state?.loadedConfig)
+        assertEquals(false, state?.isInProgress)
     }
 
     @Test
@@ -346,39 +418,135 @@ internal class QRemoteConfigManagerTest {
         every { staleConfig.source.contextKey } returns "ctx"
         listServiceCallback.captured.onSuccess(QRemoteConfigList(listOf(staleConfig)))
 
-        // then - nothing from the stale list is cached
-        assertEquals(null, loadingStates()["ctx"]?.loadedConfig)
+        // then - nothing from the stale list is cached: the wrapper would have
+        // created a loading state for the key had it cached the config
+        assertEquals(false, loadingStates().containsKey("ctx"))
     }
 
     @Test
-    fun `refreshRemoteConfigs drops caches non-destructively and guards in-flight loads`() {
-        // given - cached configs with a pending callback, plus a load in flight
+    fun `invalidateRemoteConfigsCache from a background thread defers the map mutation but makes the cache immediately stale`() {
+        // given - cached configs for a stable user
         userStateProvider.stable = true
-        val pendingCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
-        loadingStates()[null] = QRemoteConfigManager.LoadingState(loadedConfig = mockk<QRemoteConfig>(relaxed = true))
-        loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(
-            loadedConfig = mockk<QRemoteConfig>(relaxed = true),
-            callbacks = mutableListOf(pendingCallback),
+        val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
+        val otherConfig = mockk<QRemoteConfig>(relaxed = true)
+        loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(loadedConfig = cachedConfig)
+        loadingStates()["other"] = QRemoteConfigManager.LoadingState(loadedConfig = otherConfig)
+
+        // when - invalidated from a non-main thread
+        val backgroundThread = Thread { manager.invalidateRemoteConfigsCache() }
+        backgroundThread.start()
+        backgroundThread.join()
+
+        // then - the map mutation was posted to the main looper, not applied on
+        // the background thread (main-thread confinement, SUP3-188 class)...
+        assertEquals(cachedConfig, loadingStates()["ctx"]?.loadedConfig)
+
+        // ...but the generation bump is synchronous, so the cached fast path
+        // is already stale: a load issued before the posted cleanup drains
+        // must not be served the pre-invalidation config
+        val callback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        manager.loadRemoteConfig("ctx", callback)
+        verify(exactly = 0) { callback.onSuccess(any()) }
+
+        // and the posted cleanup still lands on the main thread
+        shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(null, loadingStates()["other"]?.loadedConfig)
+    }
+
+    @Test
+    fun `concurrent invalidateRemoteConfigsCache and loadRemoteConfig do not throw`() {
+        // Same SUP3-188 class as the tests above: the public invalidation can be
+        // called from any thread while the main thread mutates loadingStates.
+        userStateProvider.stable = false
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val iterations = 1_000
+
+        val invalidator = Thread {
+            try {
+                repeat(iterations) { manager.invalidateRemoteConfigsCache() }
+            } catch (t: Throwable) {
+                errors.add(t)
+            }
+        }
+
+        val mainLooper = shadowOf(Looper.getMainLooper())
+        invalidator.start()
+        try {
+            repeat(iterations) { i ->
+                manager.loadRemoteConfig("ctx_$i", null)
+                mainLooper.idle()
+            }
+        } catch (t: Throwable) {
+            errors.add(t)
+        }
+        invalidator.join()
+        mainLooper.idle()
+
+        assertTrue("Concurrent access threw: $errors", errors.isEmpty())
+    }
+
+    @Test
+    fun `fallback config is delivered without being cached`() {
+        // given - a bundled fallback exists and a load is in flight
+        userStateProvider.stable = true
+        val fallbackConfig = mockk<QRemoteConfig>(relaxed = true)
+        every { fallbackConfig.source.contextKey } returns "ctx"
+        every { mockFallbacksService.obtainFallbackData() } returns QFallbackObject(
+            offerings = null,
+            productPermissions = null,
+            remoteConfigList = QRemoteConfigList(listOf(fallbackConfig)),
         )
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
         val serviceCallback = slot<QonversionRemoteConfigCallback>()
-        every { mockRemoteConfigService.loadRemoteConfig("in-flight", capture(serviceCallback)) } just runs
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallback)) } just runs
         every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
             firstArg<QonversionEmptyCallback?>()?.onComplete()
         }
-        manager.loadRemoteConfig("in-flight", null)
+        manager.loadRemoteConfig("ctx", loadCallback)
         shadowOf(Looper.getMainLooper()).idle()
 
-        // when
-        manager.refreshRemoteConfigs()
-        shadowOf(Looper.getMainLooper()).idle()
-        serviceCallback.captured.onSuccess(mockk<QRemoteConfig>(relaxed = true))
+        // when - the network fails in a fallback-eligible way
+        serviceCallback.captured.onError(QonversionError(QonversionErrorCode.NetworkConnectionFailed))
 
-        // then - every cached config dropped, callbacks preserved, and the
-        // pre-refresh in-flight response is not re-cached (generation guard)
-        assertEquals(null, loadingStates()[null]?.loadedConfig)
-        assertEquals(null, loadingStates()["ctx"]?.loadedConfig)
-        assertEquals(1, loadingStates()["ctx"]?.callbacks?.size)
-        assertEquals(null, loadingStates()["in-flight"]?.loadedConfig)
+        // then - the fallback is delivered but NOT pinned into the cache, so
+        // the next call retries the network instead of serving the fallback
+        // until the next invalidation
+        verify(exactly = 1) { loadCallback.onSuccess(fallbackConfig) }
+        val state = loadingStates()["ctx"]
+        assertNotNull(state)
+        assertEquals(null, state?.loadedConfig)
+        assertEquals(false, state?.isInProgress)
+    }
+
+    @Test
+    fun `fallback list configs are delivered without being cached`() {
+        // given - a bundled fallback exists and a list load is in flight
+        userStateProvider.stable = true
+        val fallbackConfig = mockk<QRemoteConfig>(relaxed = true)
+        every { fallbackConfig.source.contextKey } returns "ctx"
+        every { mockFallbacksService.obtainFallbackData() } returns QFallbackObject(
+            offerings = null,
+            productPermissions = null,
+            remoteConfigList = QRemoteConfigList(listOf(fallbackConfig)),
+        )
+        val listCallback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
+        val listServiceCallback = slot<QonversionRemoteConfigListCallback>()
+        every {
+            mockRemoteConfigService.loadRemoteConfigs(listOf("ctx"), false, capture(listServiceCallback))
+        } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfigList(listOf("ctx"), false, listCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - the network fails in a fallback-eligible way
+        listServiceCallback.captured.onError(QonversionError(QonversionErrorCode.NetworkConnectionFailed))
+
+        // then - the fallback list is delivered but nothing is cached (the
+        // wrapper would have created a loading state had it cached anything)
+        verify(exactly = 1) { listCallback.onSuccess(match { it.remoteConfigs == listOf(fallbackConfig) }) }
+        assertEquals(false, loadingStates().containsKey("ctx"))
     }
 
     private fun listRequests() =

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -549,6 +549,110 @@ internal class QRemoteConfigManagerTest {
     }
 
     @Test
+    fun `a stash consumed by a successful retry cannot resurface on a later failure`() {
+        // given - a full re-issue cycle that ends with a SUCCESSFUL retry
+        userStateProvider.stable = true
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        serviceCallbacks.first().onSuccess(mockk<QRemoteConfig>(relaxed = true))
+        serviceCallbacks.last().onSuccess(mockk<QRemoteConfig>(relaxed = true))
+
+        // when - a later, unrelated load for the same key fails
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        val lateCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        manager.loadRemoteConfig("ctx", lateCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+        serviceCallbacks.last().onError(QonversionError(QonversionErrorCode.BackendError))
+
+        // then - the error surfaces; a leftover stash must not deliver a
+        // long-superseded evaluation as a success
+        verify(exactly = 1) { lateCallback.onError(any()) }
+        verify(exactly = 0) { lateCallback.onSuccess(any()) }
+    }
+
+    @Test
+    fun `a stash consumed by a warm-cache resolution cannot resurface on a later failure`() {
+        // given - the re-issue resolves through a warm cache (a list load
+        // cached the key at the new generation)
+        userStateProvider.stable = true
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        val listServiceCallback = slot<QonversionRemoteConfigListCallback>()
+        every {
+            mockRemoteConfigService.loadRemoteConfigs(listOf("ctx"), false, capture(listServiceCallback))
+        } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        manager.loadRemoteConfigList(listOf("ctx"), false, mockk(relaxed = true))
+        shadowOf(Looper.getMainLooper()).idle()
+        val warmConfig = mockk<QRemoteConfig>(relaxed = true)
+        every { warmConfig.source.contextKey } returns "ctx"
+        listServiceCallback.captured.onSuccess(QRemoteConfigList(listOf(warmConfig)))
+        serviceCallbacks.first().onSuccess(mockk<QRemoteConfig>(relaxed = true))
+        verify(exactly = 1) { loadCallback.onSuccess(warmConfig) }
+
+        // when - a later, unrelated load for the same key fails
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        val lateCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        manager.loadRemoteConfig("ctx", lateCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+        serviceCallbacks.last().onError(QonversionError(QonversionErrorCode.BackendError))
+
+        // then - the error surfaces, not the stashed baseline
+        verify(exactly = 1) { lateCallback.onError(any()) }
+        verify(exactly = 0) { lateCallback.onSuccess(any()) }
+    }
+
+    @Test
+    fun `a stash left by a user-change failure cannot resurface on a later failure`() {
+        // given - the superseded response arrives while the user is unstable,
+        // so the re-issue can only queue, and the identity change then fails -
+        // the one drain path that bypasses the response handlers
+        userStateProvider.stable = true
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        userStateProvider.stable = false
+        serviceCallbacks.first().onSuccess(mockk<QRemoteConfig>(relaxed = true))
+        manager.userChangingRequestFailedWithError(QonversionError(QonversionErrorCode.BackendError))
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - the user stabilises and a later load for the same key fails
+        userStateProvider.stable = true
+        val lateCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        manager.loadRemoteConfig("ctx", lateCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+        serviceCallbacks.last().onError(QonversionError(QonversionErrorCode.BackendError))
+
+        // then - the error surfaces, not the stashed baseline
+        verify(exactly = 1) { lateCallback.onError(any()) }
+        verify(exactly = 0) { lateCallback.onSuccess(any()) }
+    }
+
+    @Test
     fun `a reused callback instance is delivered exactly once on a cache hit`() {
         // given - a warm state whose queue already holds the same listener
         // instance the caller passes again (singleton-callback integrations)

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -283,9 +283,29 @@ internal class QRemoteConfigManagerTest {
         // when - called on the test (main) thread, with no looper draining in between
         manager.loadRemoteConfigList(listOf("ctx"), false, callback)
 
-        // then - the cached list is delivered synchronously, without hitting the service
+        // then - the cached list is delivered synchronously, without hitting
+        // the service, and pending properties are still flushed (a cache hit
+        // must not swallow the flush - parity with iOS)
         verify(exactly = 1) { callback.onSuccess(any()) }
         verify { mockRemoteConfigService wasNot Called }
+        verify(exactly = 1) { mockUserPropertiesManager.forceSendProperties(any()) }
+    }
+
+    @Test
+    fun `loadRemoteConfigList cache hit does not flush properties while the user is unstable`() {
+        // given - cached configs, but the user is mid-identify. The stability
+        // gate exists so the flush cannot POST to a switching uid.
+        userStateProvider.stable = false
+        val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
+        loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(loadedConfig = cachedConfig)
+        val callback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
+
+        // when
+        manager.loadRemoteConfigList(listOf("ctx"), false, callback)
+
+        // then - the cached list is still served, but nothing is flushed
+        verify(exactly = 1) { callback.onSuccess(any()) }
+        verify(exactly = 0) { mockUserPropertiesManager.forceSendProperties(any()) }
     }
 
     @Test
@@ -458,6 +478,93 @@ internal class QRemoteConfigManagerTest {
         verify(exactly = 1) { loadCallback.onSuccess(supersededConfig) }
         verify(exactly = 0) { loadCallback.onError(any()) }
         assertEquals(null, loadingStates()["ctx"]?.loadedConfig)
+    }
+
+    @Test
+    fun `a failed re-issue prefers the baseline over the bundled fallback`() {
+        // given - a bundled fallback EXISTS for the key, and a load with a
+        // waiter is in flight
+        userStateProvider.stable = true
+        val bundledConfig = mockk<QRemoteConfig>(relaxed = true)
+        every { bundledConfig.source.contextKey } returns "ctx"
+        every { mockFallbacksService.obtainFallbackData() } returns QFallbackObject(
+            offerings = null,
+            productPermissions = null,
+            remoteConfigList = QRemoteConfigList(listOf(bundledConfig)),
+        )
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - invalidation mid-flight, the superseded (valid) response
+        // triggers a re-issue, and the retry fails in a FALLBACK-ELIGIBLE way
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        val supersededConfig = mockk<QRemoteConfig>(relaxed = true)
+        serviceCallbacks.first().onSuccess(supersededConfig)
+        serviceCallbacks.last().onError(QonversionError(QonversionErrorCode.NetworkConnectionFailed))
+
+        // then - the real user-specific evaluation seconds old outranks the
+        // static bundled payload: the waiter gets the baseline, not the bundle
+        verify(exactly = 1) { loadCallback.onSuccess(supersededConfig) }
+        verify(exactly = 0) { loadCallback.onSuccess(bundledConfig) }
+        verify(exactly = 0) { loadCallback.onError(any()) }
+    }
+
+    @Test
+    fun `a late joiner during the retry window also receives the baseline`() {
+        // given - a load with a waiter is in flight
+        userStateProvider.stable = true
+        val callbackA = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", callbackA)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - invalidation mid-flight, the superseded response triggers a
+        // re-issue, a SECOND caller joins while the retry is flying, and the
+        // retry fails without a fallback
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        val supersededConfig = mockk<QRemoteConfig>(relaxed = true)
+        serviceCallbacks.first().onSuccess(supersededConfig)
+        val callbackB = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        manager.loadRemoteConfig("ctx", callbackB)
+        serviceCallbacks.last().onError(QonversionError(QonversionErrorCode.BackendError))
+
+        // then - the never-worse guarantee is uniform: the late joiner gets
+        // the baseline too, not the retry error
+        verify(exactly = 1) { callbackA.onSuccess(supersededConfig) }
+        verify(exactly = 1) { callbackB.onSuccess(supersededConfig) }
+        verify(exactly = 0) { callbackA.onError(any()) }
+        verify(exactly = 0) { callbackB.onError(any()) }
+    }
+
+    @Test
+    fun `a reused callback instance is delivered exactly once on a cache hit`() {
+        // given - a warm state whose queue already holds the same listener
+        // instance the caller passes again (singleton-callback integrations)
+        userStateProvider.stable = true
+        val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
+        val callback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(
+            loadedConfig = cachedConfig,
+            callbacks = mutableListOf(callback),
+        )
+
+        // when
+        manager.loadRemoteConfig("ctx", callback)
+
+        // then - one delivery, not two
+        verify(exactly = 1) { callback.onSuccess(cachedConfig) }
     }
 
     @Test

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/QRemoteConfigManagerTest.kt
@@ -242,9 +242,34 @@ internal class QRemoteConfigManagerTest {
         // when - called on the test (main) thread, with no looper draining in between
         manager.loadRemoteConfig(null, callback)
 
-        // then - the cached config is delivered synchronously, without hitting the service
+        // then - the cached config is delivered synchronously, without hitting
+        // the service, and pending properties are still flushed (a cache hit
+        // must not swallow the flush - parity with iOS)
         verify(exactly = 1) { callback.onSuccess(cachedConfig) }
         verify { mockRemoteConfigService wasNot Called }
+        verify(exactly = 1) { mockUserPropertiesManager.forceSendProperties(any()) }
+    }
+
+    @Test
+    fun `a cache hit drains queued waiters instead of serving only the direct callback`() {
+        // given - a warm state that still carries queued callbacks (e.g. a
+        // list load cached into a state whose own load never fired them)
+        userStateProvider.stable = true
+        val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
+        val queuedCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(
+            loadedConfig = cachedConfig,
+            callbacks = mutableListOf(queuedCallback),
+        )
+        val directCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+
+        // when
+        manager.loadRemoteConfig("ctx", directCallback)
+
+        // then - both the direct caller and the stranded waiter are served
+        verify(exactly = 1) { directCallback.onSuccess(cachedConfig) }
+        verify(exactly = 1) { queuedCallback.onSuccess(cachedConfig) }
+        assertEquals(0, loadingStates()["ctx"]?.callbacks?.size)
     }
 
     @Test
@@ -369,6 +394,150 @@ internal class QRemoteConfigManagerTest {
     }
 
     @Test
+    fun `a list load warming a superseded single-key state does not strand its waiters`() {
+        // given - a single-key load with a waiter is in flight
+        userStateProvider.stable = true
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        val listServiceCallback = slot<QonversionRemoteConfigListCallback>()
+        every {
+            mockRemoteConfigService.loadRemoteConfigs(listOf("ctx"), false, capture(listServiceCallback))
+        } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - an invalidation lands, then a list load started AFTER it
+        // caches the same key, and only then the superseded single-key
+        // response arrives, so its re-issue hits the warm cache
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        manager.loadRemoteConfigList(listOf("ctx"), false, mockk(relaxed = true))
+        shadowOf(Looper.getMainLooper()).idle()
+        val warmConfig = mockk<QRemoteConfig>(relaxed = true)
+        every { warmConfig.source.contextKey } returns "ctx"
+        listServiceCallback.captured.onSuccess(QRemoteConfigList(listOf(warmConfig)))
+        serviceCallbacks.first().onSuccess(mockk<QRemoteConfig>(relaxed = true))
+
+        // then - the waiter is served exactly once with the warm (current
+        // generation) config instead of hanging forever, and no second
+        // single-key request was needed
+        verify(exactly = 1) { loadCallback.onSuccess(warmConfig) }
+        verify(exactly = 0) { loadCallback.onError(any()) }
+        verify(exactly = 1) { mockRemoteConfigService.loadRemoteConfig("ctx", any()) }
+        assertEquals(0, loadingStates()["ctx"]?.callbacks?.size)
+    }
+
+    @Test
+    fun `a failed re-issue delivers the superseded evaluation instead of an error`() {
+        // given - a load with a waiter is in flight
+        userStateProvider.stable = true
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - invalidation mid-flight, the superseded (valid) response
+        // triggers a re-issue, and the retry fails without a fallback
+        manager.invalidateRemoteConfigsCache()
+        shadowOf(Looper.getMainLooper()).idle()
+        val supersededConfig = mockk<QRemoteConfig>(relaxed = true)
+        serviceCallbacks.first().onSuccess(supersededConfig)
+        serviceCallbacks.last().onError(QonversionError(QonversionErrorCode.BackendError))
+
+        // then - never worse than before: the superseded evaluation is
+        // delivered as a success instead of surfacing the retry error, and
+        // nothing is cached
+        verify(exactly = 1) { loadCallback.onSuccess(supersededConfig) }
+        verify(exactly = 0) { loadCallback.onError(any()) }
+        assertEquals(null, loadingStates()["ctx"]?.loadedConfig)
+    }
+
+    @Test
+    fun `a user switch mid-flight does not trigger an unrequested re-issue`() {
+        // given - a load with a waiter is in flight
+        userStateProvider.stable = true
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallbacks = mutableListOf<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallbacks)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - the user switches (map replaced), then the response lands on
+        // the now-orphaned state
+        manager.onUserUpdate()
+        shadowOf(Looper.getMainLooper()).idle()
+        serviceCallbacks.first().onSuccess(mockk<QRemoteConfig>(relaxed = true))
+
+        // then - the orphaned state must not fire a request nobody awaits
+        verify(exactly = 1) { mockRemoteConfigService.loadRemoteConfig("ctx", any()) }
+    }
+
+    @Test
+    fun `attach from a background thread makes the cache immediately stale`() {
+        // given - a cached config for a stable user
+        userStateProvider.stable = true
+        val cachedConfig = mockk<QRemoteConfig>(relaxed = true)
+        loadingStates()["ctx"] = QRemoteConfigManager.LoadingState(loadedConfig = cachedConfig)
+
+        // when - an attach lands from a non-main thread
+        val backgroundThread = Thread {
+            manager.attachUserToRemoteConfiguration("config_id", mockk(relaxed = true))
+        }
+        backgroundThread.start()
+        backgroundThread.join()
+
+        // then - before the posted cleanup drains, the fast path must already
+        // reject the pre-attach config (the bump is synchronous on the caller
+        // thread for every invalidation seam, not only the public API)
+        val callback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        manager.loadRemoteConfig("ctx", callback)
+        verify(exactly = 0) { callback.onSuccess(any()) }
+    }
+
+    @Test
+    fun `rate-limited load delivers the bundled fallback`() {
+        // given - a bundled fallback exists and a load is in flight
+        userStateProvider.stable = true
+        val fallbackConfig = mockk<QRemoteConfig>(relaxed = true)
+        every { fallbackConfig.source.contextKey } returns "ctx"
+        every { mockFallbacksService.obtainFallbackData() } returns QFallbackObject(
+            offerings = null,
+            productPermissions = null,
+            remoteConfigList = QRemoteConfigList(listOf(fallbackConfig)),
+        )
+        val loadCallback = mockk<QonversionRemoteConfigCallback>(relaxed = true)
+        val serviceCallback = slot<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig("ctx", capture(serviceCallback)) } just runs
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        manager.loadRemoteConfig("ctx", loadCallback)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // when - the request is short-circuited by the local rate limiter
+        serviceCallback.captured.onError(QonversionError(QonversionErrorCode.ApiRateLimitExceeded))
+
+        // then - the bundled payload is served instead of a hard error; since
+        // fallbacks are no longer cached, offline repeat calls hit the limiter
+        // instead of the old cached-fallback fast path, and must still get
+        // the config
+        verify(exactly = 1) { loadCallback.onSuccess(fallbackConfig) }
+        verify(exactly = 0) { loadCallback.onError(any()) }
+        assertEquals(null, loadingStates()["ctx"]?.loadedConfig)
+    }
+
+    @Test
     fun `invalidation mid-flight does not re-issue a load nobody awaits`() {
         // given - a load with NO waiting callback is in flight
         userStateProvider.stable = true
@@ -408,7 +577,8 @@ internal class QRemoteConfigManagerTest {
             firstArg<QonversionEmptyCallback?>()?.onComplete()
         }
 
-        manager.loadRemoteConfigList(listOf("ctx"), false, mockk(relaxed = true))
+        val listCallback = mockk<QonversionRemoteConfigListCallback>(relaxed = true)
+        manager.loadRemoteConfigList(listOf("ctx"), false, listCallback)
         shadowOf(Looper.getMainLooper()).idle()
 
         // when - the attach invalidates mid-flight, then the pre-attach list lands
@@ -418,9 +588,13 @@ internal class QRemoteConfigManagerTest {
         every { staleConfig.source.contextKey } returns "ctx"
         listServiceCallback.captured.onSuccess(QRemoteConfigList(listOf(staleConfig)))
 
-        // then - nothing from the stale list is cached: the wrapper would have
-        // created a loading state for the key had it cached the config
+        // then - nothing from the stale list is cached (the wrapper would have
+        // created a loading state for the key had it cached the config), but
+        // the caller still receives the evaluation the load started with —
+        // this pins the documented list contract, whose failure mode is a
+        // callback that never fires
         assertEquals(false, loadingStates().containsKey("ctx"))
+        verify(exactly = 1) { listCallback.onSuccess(any()) }
     }
 
     @Test
@@ -483,6 +657,67 @@ internal class QRemoteConfigManagerTest {
         mainLooper.idle()
 
         assertTrue("Concurrent access threw: $errors", errors.isEmpty())
+    }
+
+    @Test
+    fun `concurrent invalidation with live loads keeps only current-generation configs cached`() {
+        // Unlike the CME stress test above, the user is STABLE here, so every
+        // load runs the full generation-capture / cache-write path while a
+        // background thread keeps bumping the generation.
+        userStateProvider.stable = true
+        every { mockUserPropertiesManager.forceSendProperties(any()) } answers {
+            firstArg<QonversionEmptyCallback?>()?.onComplete()
+        }
+        val pendingResponses = ArrayDeque<QonversionRemoteConfigCallback>()
+        every { mockRemoteConfigService.loadRemoteConfig(any(), any()) } answers {
+            pendingResponses.add(secondArg())
+        }
+        val config = mockk<QRemoteConfig>(relaxed = true)
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val iterations = 300
+
+        val invalidator = Thread {
+            try {
+                repeat(iterations) { manager.invalidateRemoteConfigsCache() }
+            } catch (t: Throwable) {
+                errors.add(t)
+            }
+        }
+
+        val mainLooper = shadowOf(Looper.getMainLooper())
+        invalidator.start()
+        try {
+            repeat(iterations) { i ->
+                manager.loadRemoteConfig("ctx_${i % 8}", null)
+                mainLooper.idle()
+                while (pendingResponses.isNotEmpty()) {
+                    pendingResponses.removeFirst().onSuccess(config)
+                    mainLooper.idle()
+                }
+            }
+        } catch (t: Throwable) {
+            errors.add(t)
+        }
+        invalidator.join()
+        mainLooper.idle()
+        while (pendingResponses.isNotEmpty()) {
+            pendingResponses.removeFirst().onSuccess(config)
+            mainLooper.idle()
+        }
+
+        assertTrue("Concurrent access threw: $errors", errors.isEmpty())
+        // The stamp-guard invariant: once everything settles, any config still
+        // cached must carry the final generation - the write guard must never
+        // have let a superseded response in, and every older write must have
+        // been swept by a later posted cleanup.
+        val finalGeneration = manager
+            .getPrivateField<java.util.concurrent.atomic.AtomicInteger>("invalidationGeneration")
+            .get()
+        loadingStates().values.forEach { state ->
+            if (state.loadedConfig != null) {
+                assertEquals(finalGeneration, state.generation)
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
B4 from the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)). Linear: [DEV-1236](https://linear.app/qonversion/issue/DEV-1236). Prerequisite of arming server-side dynamic targeting re-evaluation (B2a) in production: re-evaluation is invisible while the SDK serves configs from its process-lifetime in-memory cache.

## What changed

1. **`identify()` resolving to the SAME uid now drops the cached remote configs.** The first identify does not change the uid (`UPDATE client SET external_identity`), so the cache was never invalidated on login and the user stayed on the pre-login targeting evaluation until process restart. The drop is non-destructive: loading states, pending callbacks and the in-flight generation guard survive; the pending-request replay runs strictly after the invalidation, so queued completions fetch a fresh evaluation with the attached identity and user properties. No permissions-cache clear, no re-launch — pinned by the updated identify contract tests (including the order and the repeat-identify early return).
2. **New public API `Qonversion.invalidateRemoteConfigsCache()`** — marks the cached configs stale on demand. The name says exactly what it does: no network request, no callback; the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. Use cases in the KDoc: property batches the targeting depends on, long-session foreground returns; the doc also states you need it neither after identify (automatic) nor to recover from a bundled fallback (fallbacks are never cached). Not needed after `identify()` — that path is automatic.
3. **Happens-before for any-thread callers.** The invalidation generation is an `AtomicInteger` bumped synchronously on the caller thread, and every cached config carries a generation stamp — the cached fast paths serve it only while the stamp matches, so a load issued right after the invalidation never serves the stale copy even before the posted main-thread cleanup drains.
4. **Superseded in-flight loads are re-issued, never worse than before.** If the generation moves while a `remoteConfig` request is flying and callbacks await it, the load is re-issued instead of delivering the stale evaluation. The waiters are snapshotted and carried through the retry with the superseded (but valid) evaluation as a baseline — a failed retry delivers the baseline as a success instead of an error. The re-issue is gated on the loading state still being live (a user switch must not fire a request nobody awaits). An in-flight `remoteConfigList` completes with the evaluation it started with (documented; re-issuing a list would multiply the retry cost across N keys for a one-shot completion — recorded so nobody "fixes" the asymmetry); nothing from it is cached. Cache hits drain queued waiters (a warm state must never strand them) and flush pending user properties (parity with iOS).
5. **Fallback configs are no longer cached** (single-key and list paths): a bundled fallback delivered on network failure previously pinned itself into the cache until the next invalidation; now the next call retries the network. `ApiRateLimitExceeded` became fallback-eligible **scoped to remote configs only** (a local `shouldFireRemoteConfigFallback` predicate; the shared `shouldFireFallback` and the entitlements path are untouched), so offline repeat calls that hit the local limiter still receive the bundled payload instead of a hard error. A failed retry of a superseded load prefers the stashed baseline over both the error and the bundled payload — a real user-specific evaluation seconds old outranks shipped-in-binary defaults — and the guarantee is uniform: late joiners during the retry window get the baseline too.
6. **Every invalidation seam bumps synchronously** — the caller-thread generation bump covers attach/detach and `onUserUpdate`, not only the public API, so an attach from a background thread makes the cache immediately stale for main-thread readers.

## Behavior changes for existing integrations (release notes)

- A `remoteConfig()` request in flight when `identify()` completes is re-issued, so its callback resolves after two round trips instead of one (correct-data-for-latency trade; a failed retry falls back to the first response, so reliability is not reduced).
- Fallback configs are no longer cached: offline apps issue one fast-failing request per read instead of one per session, recover automatically when connectivity returns, and receive the bundled payload even when the local rate limiter short-circuits the request (remote configs only — rate-limited entitlement checks are unchanged).
- A warm `remoteConfig()` / `remoteConfigList()` cache hit now flushes pending user properties (parity with iOS) — a previously purely-local read can issue a properties POST when properties are pending.
- New abstract member on the public `Qonversion` interface → minor version bump; anyone with a custom implementation of the interface must add `invalidateRemoteConfigsCache()`.

## Tests

`QRemoteConfigManagerTest`: invalidation folded into the shared entry-point loop (5 entry points, non-destructive semantics); focused re-issue tests (awaited / non-awaited / attach path); background-thread confinement test asserting immediate staleness via the generation stamp; concurrent invalidate-vs-load stress test; fallback non-caching tests. `QProductCenterManagerIdentifyContractTest`: same-uid pins `verifyOrder(invalidate → handlePendingRequests)` plus `onUserUpdate` exclusion; repeat-identify early return pinned. `testDebugUnitTest` (32+4 green), `detektAll`, `:sample` compile green.

Sample: an "Invalidate Remote Configs Cache" button on the Remote Configs screen.

Facade delegation (`QonversionInternal`) is a 1-line pass-through; the repo has no facade-level tests, consistent with the existing precedent.

iOS mirror and cross-platform wrappers follow in the same Linear issue. Release note: ships together with the A6 fixes (#852) in one release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9
