### PR TITLE
Qonversion Release 9.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 buildscript {
     ext {
         sdk = [
-                versionName: "9.6.0",
+                versionName: "9.7.0",
                 versionCode: 1
         ]
         nocodes = [

--- a/fastlane/report.xml
+++ b/fastlane/report.xml
@@ -5,7 +5,7 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000257535">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000281295">
         
       </testcase>
     


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## New

* New public API `Qonversion.shared.invalidateRemoteConfigsCache()` — invalidates the in-memory cache of remote configs so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. No network request itself; call it after changing user properties your targeting depends on. Not needed after `identify` — see below (#853).

## Improvements & fixes

* `identify()` resolving to the same Qonversion user now invalidates the remote configs cache automatically, so the first login no longer serves the pre-login targeting evaluation for the rest of the process lifetime (#853).
* A remote config load in flight during an invalidation is re-issued so its callbacks receive a fresh evaluation; if the retry fails, the superseded evaluation is delivered instead of an error (#853).
* Bundled fallback configs are no longer cached: offline apps recover automatically when connectivity returns, and a request short-circuited by the local rate limiter still receives the bundled payload (remote configs only) (#853).
* Fixed `forceSendProperties` losing the send-scheduled flag after a forced flush, and user property batches now reliably reach the server before a remote config evaluation (#852).
* Remote config cache hits now flush pending user properties, so a cache hit cannot swallow a property batch (#853).

## Behavior changes

* A `remoteConfig()` request in flight when `identify()` completes resolves after two round trips instead of one (fresh-data-for-latency trade; reliability is not reduced).
* `invalidateRemoteConfigsCache()` is a new member of the public `Qonversion` interface — custom implementations of the interface must add it.
<!-- release-notes:end -->
