### PR TITLE
feat: expose frozen remote config assignments

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/dto/QRemoteConfigurationAssignmentType.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/dto/QRemoteConfigurationAssignmentType.kt
@@ -3,13 +3,16 @@ package com.qonversion.android.sdk.dto
 enum class QRemoteConfigurationAssignmentType(val type: String) {
     Auto("auto"),
     Manual("manual"),
-    Unknown("unknown");
+    Unknown("unknown"),
+    // Appended to preserve the ordinals of the existing public enum values.
+    Frozen("frozen");
 
     companion object {
         fun fromType(type: String): QRemoteConfigurationAssignmentType {
             return when (type) {
                 "auto" -> Auto
                 "manual" -> Manual
+                "frozen" -> Frozen
                 else -> Unknown
             }
         }

--- a/sdk/src/test/java/com/qonversion/android/sdk/dto/QRemoteConfigurationAssignmentTypeTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/dto/QRemoteConfigurationAssignmentTypeTest.kt
@@ -1,0 +1,25 @@
+package com.qonversion.android.sdk.dto
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QRemoteConfigurationAssignmentTypeTest {
+    @Test
+    fun `frozen wire value preserves assignment provenance`() {
+        assertEquals(
+            QRemoteConfigurationAssignmentType.Frozen,
+            QRemoteConfigurationAssignmentType.fromType("frozen")
+        )
+    }
+
+    @Test
+    fun `existing enum ordinals and unknown fallback remain compatible`() {
+        assertEquals(0, QRemoteConfigurationAssignmentType.Auto.ordinal)
+        assertEquals(1, QRemoteConfigurationAssignmentType.Manual.ordinal)
+        assertEquals(2, QRemoteConfigurationAssignmentType.Unknown.ordinal)
+        assertEquals(
+            QRemoteConfigurationAssignmentType.Unknown,
+            QRemoteConfigurationAssignmentType.fromType("future")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add Frozen without changing existing assignment enum values
- decode wire value frozen and preserve unknown fallback
- cover parser and mapping behavior with tests

## Release dependency

Publish as Android SDK 9.8.0 before the frozen-aware Sandwich bridge release.

## Verification

- full Gradle test suite passed locally