### PR TITLE
fix: restore API TLS verification

### DIFF
--- a/nocodes/build.gradle
+++ b/nocodes/build.gradle
@@ -67,6 +67,8 @@ dependencies {
     
     api project(':sdk')
 
+    testImplementation 'junit:junit:4.13.2'
+
     androidTestImplementation 'androidx.test:core:1.5.0'
     androidTestImplementation "androidx.test:runner:1.5.2"
     androidTestImplementation "androidx.test:rules:1.5.0"

--- a/nocodes/src/main/java/io/qonversion/nocodes/internal/networkLayer/networkClient/NetworkClientImpl.kt
+++ b/nocodes/src/main/java/io/qonversion/nocodes/internal/networkLayer/networkClient/NetworkClientImpl.kt
@@ -20,12 +20,6 @@ import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
-import javax.net.ssl.HttpsURLConnection
-import javax.net.ssl.SSLContext
-import javax.net.ssl.TrustManager
-import javax.net.ssl.X509TrustManager
 
 private const val NETWORK_ENCODING = "utf-8"
 
@@ -65,19 +59,6 @@ internal class NetworkClientImpl(
     internal fun connect(url: URL): HttpURLConnection {
         return try {
             val connection = url.openConnection() as HttpURLConnection
-
-            // Trust all certificates for staging
-            if (connection is HttpsURLConnection) {
-                val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
-                    override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
-                    override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
-                    override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
-                })
-                val sslContext = SSLContext.getInstance("TLS")
-                sslContext.init(null, trustAllCerts, SecureRandom())
-                connection.sslSocketFactory = sslContext.socketFactory
-                connection.setHostnameVerifier { _, _ -> true }
-            }
 
             // Set smart timeout based on fallback availability
             val timeout = if (isFallbackAvailable) {

--- a/nocodes/src/test/java/io/qonversion/nocodes/internal/networkLayer/networkClient/NetworkClientImplTest.kt
+++ b/nocodes/src/test/java/io/qonversion/nocodes/internal/networkLayer/networkClient/NetworkClientImplTest.kt
@@ -1,0 +1,47 @@
+package io.qonversion.nocodes.internal.networkLayer.networkClient
+
+import io.qonversion.nocodes.internal.common.serializers.Serializer
+import org.junit.Assert.assertSame
+import org.junit.Test
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+import java.security.Principal
+import java.security.cert.Certificate
+import javax.net.ssl.HttpsURLConnection
+
+internal class NetworkClientImplTest {
+    @Test
+    fun `https connections retain platform TLS verification`() {
+        lateinit var platformConnection: TestHttpsURLConnection
+        val url = URL(null, "https://api.qonversion.io", object : URLStreamHandler() {
+            override fun openConnection(url: URL): URLConnection {
+                return TestHttpsURLConnection(url).also { platformConnection = it }
+            }
+        })
+        val platformSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory()
+        val platformHostnameVerifier = HttpsURLConnection.getDefaultHostnameVerifier()
+
+        val connection = NetworkClientImpl(UnusedSerializer()).connect(url) as HttpsURLConnection
+
+        assertSame(platformConnection, connection)
+        assertSame(platformSocketFactory, connection.sslSocketFactory)
+        assertSame(platformHostnameVerifier, connection.hostnameVerifier)
+    }
+
+    private class UnusedSerializer : Serializer {
+        override fun serialize(data: Map<String, Any?>): String = error("not used")
+        override fun deserialize(payload: String): Any = error("not used")
+    }
+
+    private class TestHttpsURLConnection(url: URL) : HttpsURLConnection(url) {
+        override fun connect() = Unit
+        override fun disconnect() = Unit
+        override fun usingProxy(): Boolean = false
+        override fun getCipherSuite(): String = ""
+        override fun getLocalCertificates(): Array<Certificate>? = null
+        override fun getServerCertificates(): Array<Certificate> = emptyArray()
+        override fun getPeerPrincipal(): Principal? = null
+        override fun getLocalPrincipal(): Principal? = null
+    }
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/di/module/NetworkModule.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/di/module/NetworkModule.kt
@@ -32,12 +32,7 @@ import okhttp3.Cache
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
-import javax.net.ssl.SSLContext
-import javax.net.ssl.TrustManager
-import javax.net.ssl.X509TrustManager
 
 @Module
 internal class NetworkModule {
@@ -86,21 +81,11 @@ internal class NetworkModule {
         context: Application,
         interceptor: NetworkInterceptor
     ): OkHttpClient {
-        val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
-            override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
-            override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
-            override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
-        })
-        val sslContext = SSLContext.getInstance("TLS")
-        sslContext.init(null, trustAllCerts, SecureRandom())
-
         return OkHttpClient.Builder()
             .cache(Cache(context.cacheDir, CACHE_SIZE))
             .readTimeout(TIMEOUT, TimeUnit.SECONDS)
             .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
             .addInterceptor(interceptor)
-            .sslSocketFactory(sslContext.socketFactory, trustAllCerts[0] as X509TrustManager)
-            .hostnameVerifier { _, _ -> true }
             .build()
     }
 

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/di/module/NetworkModuleTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/di/module/NetworkModuleTest.kt
@@ -20,6 +20,6 @@ internal class NetworkModuleTest {
 
         val client = NetworkModule().provideOkHttpClient(application, interceptor)
 
-        assertFalse(client.hostnameVerifier.verify("attacker.invalid", sslSession))
+        assertFalse(client.hostnameVerifier().verify("attacker.invalid", sslSession))
     }
 }

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/di/module/NetworkModuleTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/di/module/NetworkModuleTest.kt
@@ -1,0 +1,25 @@
+package com.qonversion.android.sdk.internal.di.module
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.qonversion.android.sdk.internal.api.NetworkInterceptor
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import javax.net.ssl.SSLSession
+
+@RunWith(RobolectricTestRunner::class)
+internal class NetworkModuleTest {
+    @Test
+    fun `api client rejects a hostname that does not match the certificate`() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val interceptor = mockk<NetworkInterceptor>(relaxed = true)
+        val sslSession = mockk<SSLSession>(relaxed = true)
+
+        val client = NetworkModule().provideOkHttpClient(application, interceptor)
+
+        assertFalse(client.hostnameVerifier.verify("attacker.invalid", sslSession))
+    }
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/di/module/NetworkModuleTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/di/module/NetworkModuleTest.kt
@@ -8,6 +8,8 @@ import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.lang.reflect.Proxy
+import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLSession
 
 @RunWith(RobolectricTestRunner::class)
@@ -16,7 +18,15 @@ internal class NetworkModuleTest {
     fun `api client rejects a hostname that does not match the certificate`() {
         val application = ApplicationProvider.getApplicationContext<Application>()
         val interceptor = mockk<NetworkInterceptor>(relaxed = true)
-        val sslSession = mockk<SSLSession>(relaxed = true)
+        val sslSession = Proxy.newProxyInstance(
+            NetworkModuleTest::class.java.classLoader,
+            arrayOf(SSLSession::class.java),
+        ) { _, method, _ ->
+            if (method.name == "getPeerCertificates") {
+                throw SSLPeerUnverifiedException("no certificate for mismatched host")
+            }
+            null
+        } as SSLSession
 
         val client = NetworkModule().provideOkHttpClient(application, interceptor)
 


### PR DESCRIPTION
## Outcome

Restores the platform trust chain and hostname verification for every Android SDK API request. The previous client installed a trust-all X509 manager and an always-true hostname verifier.

## Changes

- remove the custom trust-all socket factory
- remove the permissive hostname verifier
- rely on OkHttp platform TLS defaults, including for HTTPS proxy URLs
- add a regression test proving a mismatched hostname is rejected

## Verification

- git diff --check
- focused Gradle test is included; local execution is unavailable because this workspace has no Java runtime, so CI is the executable evidence

This is independent from the Remote Config targeting rollout and should be released as a security prerequisite.