### PR TITLE
feat: add durable Remote Config snapshot core

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshot.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshot.kt
@@ -1,0 +1,325 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.services.BUNDLED_REMOTE_CONFIG_DEFAULT_VALUE_MAX_BYTES
+import com.qonversion.android.sdk.internal.services.BundledRemoteConfigDefaultsDocument
+import com.qonversion.android.sdk.internal.services.isPortableRemoteConfigJson
+import java.util.Collections
+
+private const val REMOTE_CONFIG_METADATA_MAX_BYTES = 4 * 1024
+private const val REMOTE_CONFIG_MAX_KEYS = 1_000
+private const val REMOTE_CONFIG_MAX_RELEASE_BYTES = 4 * 1024 * 1024
+private const val REMOTE_CONFIG_LOGICAL_KEY_MAX_BYTES = 256
+private const val REMOTE_CONFIG_SCOPE_IDENTIFIER_MAX_BYTES = 256
+private const val REMOTE_CONFIG_ENVIRONMENT_MAX_CODE_POINTS = 36
+private const val REMOTE_CONFIG_UID_MAX_CODE_POINTS = 36
+private const val PORTABLE_JSON_MAX_INTEGER = 9_007_199_254_740_991L
+private val LOWERCASE_SHA256_PATTERN = Regex("^[0-9a-f]{64}$")
+
+internal enum class RemoteConfigSnapshotApplyPolicy {
+    OnNextActivate,
+    Immediate,
+}
+
+internal enum class RemoteConfigSnapshotValueSource {
+    Server,
+    Cache,
+    Fallback,
+}
+
+internal data class RemoteConfigSnapshotScope(
+    val projectKey: String,
+    val environment: String,
+    val canonicalUserId: String,
+) {
+    init {
+        require(
+            projectKey.isNotEmpty() && projectKey.hasValidSurrogatePairs() &&
+                projectKey.toByteArray(Charsets.UTF_8).size <= REMOTE_CONFIG_SCOPE_IDENTIFIER_MAX_BYTES,
+        )
+        require(
+            environment.isNotEmpty() && environment.hasValidSurrogatePairs() &&
+                environment.codePointCount(0, environment.length) <= REMOTE_CONFIG_ENVIRONMENT_MAX_CODE_POINTS,
+        )
+        require(
+            canonicalUserId.isNotEmpty() && canonicalUserId.hasValidSurrogatePairs() &&
+                canonicalUserId.toByteArray(Charsets.UTF_8).size <= REMOTE_CONFIG_SCOPE_IDENTIFIER_MAX_BYTES,
+        )
+    }
+}
+
+internal class RemoteConfigSnapshotEntry private constructor(
+    val key: String,
+    rawValue: ByteArray?,
+    val variationUid: String?,
+    val applyPolicy: RemoteConfigSnapshotApplyPolicy,
+    metadata: ByteArray?,
+) {
+    private val storedRawValue = rawValue?.clone()
+    private val storedMetadata = metadata?.clone()
+
+    val isTombstone: Boolean get() = storedRawValue == null
+    val rawValueBytes: ByteArray? get() = storedRawValue?.clone()
+    val metadataBytes: ByteArray? get() = storedMetadata?.clone()
+    internal val budgetBytes: Long
+        get() = key.toByteArray().size.toLong() +
+            (variationUid?.toByteArray()?.size ?: 0) +
+            (storedRawValue?.size ?: 0) +
+            (storedMetadata?.size ?: 0)
+
+    init {
+        require(
+            key.isNotEmpty() && key.hasValidSurrogatePairs() &&
+                key.toByteArray().size <= REMOTE_CONFIG_LOGICAL_KEY_MAX_BYTES,
+        )
+        if (storedRawValue == null) {
+            require(variationUid == null)
+            require(storedMetadata == null)
+        } else {
+            require(
+                !variationUid.isNullOrEmpty() && variationUid.hasValidUidLength() &&
+                    variationUid.hasValidSurrogatePairs(),
+            )
+            require(storedRawValue.size <= BUNDLED_REMOTE_CONFIG_DEFAULT_VALUE_MAX_BYTES)
+            require(isPortableRemoteConfigJson(storedRawValue))
+            require(storedMetadata == null || (
+                storedMetadata.size <= REMOTE_CONFIG_METADATA_MAX_BYTES &&
+                    isPortableRemoteConfigJson(storedMetadata)
+                ))
+        }
+    }
+
+    internal fun contentEquals(other: RemoteConfigSnapshotEntry?): Boolean =
+        other != null &&
+            key == other.key &&
+            storedRawValue.contentEqualsNullable(other.storedRawValue) &&
+            variationUid == other.variationUid &&
+            applyPolicy == other.applyPolicy &&
+            storedMetadata.contentEqualsNullable(other.storedMetadata)
+
+    companion object {
+        fun value(
+            key: String,
+            rawValue: ByteArray,
+            variationUid: String,
+            applyPolicy: RemoteConfigSnapshotApplyPolicy,
+            metadata: ByteArray?,
+        ) = RemoteConfigSnapshotEntry(key, rawValue, variationUid, applyPolicy, metadata)
+
+        fun tombstone(key: String) = RemoteConfigSnapshotEntry(
+            key = key,
+            rawValue = null,
+            variationUid = null,
+            applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+            metadata = null,
+        )
+    }
+}
+
+internal class RemoteConfigSnapshotRelease(
+    val releaseUid: String,
+    val releaseNumber: Long,
+    val manifestContentHash: String,
+    entries: Collection<RemoteConfigSnapshotEntry>,
+) {
+    private val entriesByKey: Map<String, RemoteConfigSnapshotEntry>
+
+    val entries: Map<String, RemoteConfigSnapshotEntry> get() = entriesByKey
+    val containsImmediateEntry: Boolean
+        get() = entriesByKey.values.any { it.applyPolicy == RemoteConfigSnapshotApplyPolicy.Immediate }
+
+    init {
+        require(releaseUid.isNotEmpty() && releaseUid.hasValidUidLength() && releaseUid.hasValidSurrogatePairs())
+        require(releaseNumber in 1..PORTABLE_JSON_MAX_INTEGER)
+        require(LOWERCASE_SHA256_PATTERN.matches(manifestContentHash))
+        require(entries.size <= REMOTE_CONFIG_MAX_KEYS)
+        require(entries.map { it.key }.distinct().size == entries.size)
+        val aggregateBytes = releaseUid.toByteArray().size.toLong() + manifestContentHash.length +
+            entries.sumOf(RemoteConfigSnapshotEntry::budgetBytes)
+        require(aggregateBytes <= REMOTE_CONFIG_MAX_RELEASE_BYTES)
+        entriesByKey = Collections.unmodifiableMap(entries.associateBy { it.key })
+    }
+
+    fun entry(key: String): RemoteConfigSnapshotEntry? = entriesByKey[key]
+
+    internal fun contentEquals(other: RemoteConfigSnapshotRelease?): Boolean =
+        other != null && releaseUid == other.releaseUid && releaseNumber == other.releaseNumber &&
+            manifestContentHash == other.manifestContentHash && entriesByKey.size == other.entriesByKey.size &&
+            entriesByKey.all { (key, entry) -> entry.contentEquals(other.entriesByKey[key]) }
+}
+
+internal class RemoteConfigScopedBundledRelease(
+    val projectKey: String,
+    val environment: String,
+    val release: RemoteConfigSnapshotRelease,
+) {
+    init {
+        RemoteConfigSnapshotScope(projectKey, environment, "bundle-scope-validation")
+    }
+
+    fun releaseFor(scope: RemoteConfigSnapshotScope?): RemoteConfigSnapshotRelease? = when {
+        scope == null -> release
+        scope.projectKey == projectKey && scope.environment == environment -> release
+        else -> null
+    }
+}
+
+internal data class RemoteConfigSnapshotState(
+    val candidate: RemoteConfigSnapshotRelease? = null,
+    val active: RemoteConfigSnapshotRelease? = null,
+    val previous: RemoteConfigSnapshotRelease? = null,
+    val didActivate: Boolean = false,
+) {
+    init {
+        require(active != null || previous == null)
+        require(didActivate || (active == null && previous == null))
+        require(candidate == null || active == null || candidate.releaseNumber >= active.releaseNumber)
+        require(
+            candidate == null || active == null || candidate.releaseNumber != active.releaseNumber ||
+                candidate.contentEquals(active),
+        )
+        require(previous == null || active == null || previous.releaseNumber < active.releaseNumber)
+    }
+}
+
+internal class RemoteConfigResolvedValue<T>(
+    val value: T,
+    val source: RemoteConfigSnapshotValueSource,
+    val variationUid: String,
+    val applyPolicy: RemoteConfigSnapshotApplyPolicy,
+    metadata: ByteArray?,
+) {
+    private val storedMetadata = metadata?.clone()
+    val metadataBytes: ByteArray? get() = storedMetadata?.clone()
+}
+
+internal class RemoteConfigSnapshot(
+    private val primaryRelease: RemoteConfigSnapshotRelease?,
+    private val previousRelease: RemoteConfigSnapshotRelease?,
+    private val bundledRelease: RemoteConfigSnapshotRelease?,
+) {
+    val releaseUid: String get() = primaryRelease?.releaseUid.orEmpty()
+    val releaseNumber: Long get() = primaryRelease?.releaseNumber ?: 0
+    val manifestContentHash: String get() = primaryRelease?.manifestContentHash.orEmpty()
+    val allKeys: Set<String> = Collections.unmodifiableSet(
+        buildSet {
+            primaryRelease?.entries?.keys?.let(::addAll)
+            bundledRelease?.entries?.keys?.let(::addAll)
+        },
+    )
+
+    @Suppress("ReturnCount")
+    fun rawValue(key: String): RemoteConfigResolvedValue<ByteArray>? {
+        val candidate = primaryRelease?.entry(key)?.takeUnless { it.isTombstone }
+            ?.let { it to RemoteConfigSnapshotValueSource.Server }
+            ?: bundledRelease?.entry(key)?.takeUnless { it.isTombstone }
+                ?.let { it to RemoteConfigSnapshotValueSource.Fallback }
+            ?: return null
+        val raw = candidate.first.rawValueBytes ?: return null
+        return candidate.first.resolve(raw, candidate.second)
+    }
+
+    @Suppress("ReturnCount")
+    fun <T> value(key: String, decoder: (ByteArray) -> T?): RemoteConfigResolvedValue<T>? {
+        val primary = primaryRelease?.entry(key)
+        if (primary != null && !primary.isTombstone) {
+            primary.decode(decoder, RemoteConfigSnapshotValueSource.Server)?.let { return it }
+            previousRelease?.entry(key)
+                ?.takeUnless { it.isTombstone }
+                ?.decode(decoder, RemoteConfigSnapshotValueSource.Cache)
+                ?.let { return it }
+        }
+        return bundledRelease?.entry(key)
+            ?.takeUnless { it.isTombstone }
+            ?.decode(decoder, RemoteConfigSnapshotValueSource.Fallback)
+    }
+
+    fun metadataForKey(key: String): ByteArray? {
+        val entry = primaryRelease?.entry(key)?.takeUnless { it.isTombstone }
+            ?: bundledRelease?.entry(key)?.takeUnless { it.isTombstone }
+        return entry?.metadataBytes
+    }
+
+    internal fun effectiveEntry(key: String): RemoteConfigSnapshotEntry? =
+        primaryRelease?.entry(key)?.takeUnless { it.isTombstone }
+            ?: bundledRelease?.entry(key)?.takeUnless { it.isTombstone }
+
+    private fun <T> RemoteConfigSnapshotEntry.decode(
+        decoder: (ByteArray) -> T?,
+        source: RemoteConfigSnapshotValueSource,
+    ): RemoteConfigResolvedValue<T>? {
+        val decoded = try {
+            rawValueBytes?.let(decoder)
+        } catch (_: Exception) {
+            null
+        } ?: return null
+        return resolve(decoded, source)
+    }
+
+    private fun <T> RemoteConfigSnapshotEntry.resolve(
+        value: T,
+        source: RemoteConfigSnapshotValueSource,
+    ) = RemoteConfigResolvedValue(
+        value = value,
+        source = source,
+        variationUid = requireNotNull(variationUid),
+        applyPolicy = applyPolicy,
+        metadata = metadataBytes,
+    )
+}
+
+internal class RemoteConfigSnapshotUpdate(
+    val snapshot: RemoteConfigSnapshot,
+    changedKeys: Set<String>,
+    metadataByKey: Map<String, ByteArray>,
+) {
+    val changedKeys: Set<String> = Collections.unmodifiableSet(changedKeys.toSet())
+    private val storedMetadata = metadataByKey.mapValues { (_, value) -> value.clone() }
+
+    fun metadataForKey(key: String): ByteArray? = storedMetadata[key]?.clone()
+}
+
+internal fun BundledRemoteConfigDefaultsDocument.toScopedRemoteConfigSnapshotRelease(projectKey: String) =
+    RemoteConfigScopedBundledRelease(
+        projectKey = projectKey,
+        environment = environmentUid,
+        release = RemoteConfigSnapshotRelease(
+            releaseUid = releaseUid,
+            releaseNumber = releaseNumber,
+            manifestContentHash = manifestContentHash,
+            entries = allDefaults().map { value ->
+                RemoteConfigSnapshotEntry.value(
+                    key = value.key,
+                    rawValue = value.rawJsonBytes,
+                    variationUid = value.variationUid,
+                    applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+                    metadata = null,
+                )
+            },
+        ),
+    )
+
+private fun String.hasValidUidLength(): Boolean =
+    codePointCount(0, length) <= REMOTE_CONFIG_UID_MAX_CODE_POINTS
+
+@Suppress("ReturnCount")
+private fun String.hasValidSurrogatePairs(): Boolean {
+    var index = 0
+    while (index < length) {
+        val character = this[index]
+        when {
+            character.isHighSurrogate() -> {
+                if (index + 1 >= length || !this[index + 1].isLowSurrogate()) return false
+                index += 2
+            }
+            character.isLowSurrogate() -> return false
+            else -> index += 1
+        }
+    }
+    return true
+}
+
+private fun ByteArray?.contentEqualsNullable(other: ByteArray?): Boolean = when {
+    this == null -> other == null
+    other == null -> false
+    else -> contentEquals(other)
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCore.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCore.kt
@@ -1,0 +1,290 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadResult
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadStatus
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotStore
+import java.util.ArrayDeque
+
+internal enum class RemoteConfigSnapshotTransitionStatus {
+    Accepted,
+    Activated,
+    Ignored,
+    PersistenceFailed,
+    Unchanged,
+}
+
+internal data class RemoteConfigSnapshotTransitionResult(
+    val status: RemoteConfigSnapshotTransitionStatus,
+    val changed: Boolean = false,
+    val update: RemoteConfigSnapshotUpdate? = null,
+)
+
+internal class RemoteConfigSnapshotCore(
+    private val store: RemoteConfigSnapshotStore,
+    private val bundledRelease: RemoteConfigScopedBundledRelease?,
+) {
+    private val lock = Any()
+    private val deliveryLock = Any()
+    private var currentScope: RemoteConfigSnapshotScope? = null
+    private var state = RemoteConfigSnapshotState()
+    private var scopeLoadFailed = false
+    private var scopeGeneration = 0L
+    private var nextObserverToken = 0L
+    private val observers = linkedMapOf<Long, (RemoteConfigSnapshotUpdate) -> Unit>()
+    private val pendingDeliveries = ArrayDeque<TransitionDelivery>()
+    private var isDrainingDeliveries = false
+
+    fun setScope(scope: RemoteConfigSnapshotScope?) {
+        synchronized(deliveryLock) {
+            synchronized(lock) {
+                if (currentScope == scope && !(scope != null && scopeLoadFailed)) return
+                if (currentScope != scope) {
+                    currentScope = scope
+                    state = RemoteConfigSnapshotState()
+                    scopeLoadFailed = false
+                    scopeGeneration++
+                }
+                scope?.let(::loadScopeState)
+            }
+        }
+    }
+
+    fun currentSnapshot(): RemoteConfigSnapshot = synchronized(lock) {
+        snapshotFor(state.active, state.previous)
+    }
+
+    fun lastFetchedSnapshot(): RemoteConfigSnapshot? = synchronized(lock) {
+        state.candidate?.let { candidate ->
+            val previous = if (candidate.isSameRelease(state.active)) state.previous else state.active
+            snapshotFor(candidate, previous)
+        }
+    }
+
+    fun addUpdateObserver(observer: (RemoteConfigSnapshotUpdate) -> Unit): Long = synchronized(lock) {
+        val token = ++nextObserverToken
+        observers[token] = observer
+        token
+    }
+
+    fun removeUpdateObserver(token: Long) {
+        synchronized(lock) { observers.remove(token) }
+    }
+
+    fun acceptCandidate(
+        scope: RemoteConfigSnapshotScope,
+        release: RemoteConfigSnapshotRelease,
+    ): RemoteConfigSnapshotTransitionResult {
+        val delivery = synchronized(lock) {
+            if (scope != currentScope) return@synchronized TransitionDelivery.ignored()
+            if (!ensureCurrentScopeLoaded()) return@synchronized TransitionDelivery.persistenceFailed()
+            val latestNumber = maxOf(
+                state.candidate?.releaseNumber ?: 0,
+                state.active?.releaseNumber ?: 0,
+            )
+            if (release.releaseNumber <= latestNumber) return@synchronized TransitionDelivery.ignored()
+
+            val oldSnapshot = snapshotFor(state.active, state.previous)
+            val nextState = if (release.containsImmediateEntry) {
+                RemoteConfigSnapshotState(
+                    candidate = release,
+                    active = release,
+                    previous = state.active,
+                    didActivate = true,
+                )
+            } else {
+                state.copy(candidate = release)
+            }
+            if (!saveCurrentScope(nextState)) return@synchronized TransitionDelivery.persistenceFailed()
+            state = nextState
+            if (release.containsImmediateEntry) {
+                val update = buildUpdate(oldSnapshot, snapshotFor(nextState.active, nextState.previous))
+                TransitionDelivery(
+                    result = RemoteConfigSnapshotTransitionResult(
+                        status = RemoteConfigSnapshotTransitionStatus.Activated,
+                        changed = update.changedKeys.isNotEmpty(),
+                        update = update,
+                    ),
+                    update = update,
+                    observers = observers.values.toList(),
+                    scopeGeneration = scopeGeneration,
+                ).also(::enqueueDeliveryLocked)
+            } else {
+                TransitionDelivery(
+                    RemoteConfigSnapshotTransitionResult(RemoteConfigSnapshotTransitionStatus.Accepted),
+                )
+            }
+        }
+        drainDeliveries()
+        return delivery.result
+    }
+
+    fun activate(): RemoteConfigSnapshotTransitionResult {
+        val delivery = synchronized(lock) {
+            if (currentScope == null) return@synchronized TransitionDelivery.ignored()
+            if (!ensureCurrentScopeLoaded()) return@synchronized TransitionDelivery.persistenceFailed()
+            val candidate = state.candidate
+            if (candidate == null) {
+                if (state.didActivate) return@synchronized TransitionDelivery.unchanged()
+                val nextState = state.copy(didActivate = true)
+                if (!saveCurrentScope(nextState)) return@synchronized TransitionDelivery.persistenceFailed()
+                val oldSnapshot = snapshotFor(state.active, state.previous)
+                state = nextState
+                val update = buildUpdate(oldSnapshot = null, newSnapshot = oldSnapshot)
+                return@synchronized TransitionDelivery
+                    .activated(update, observers.values.toList(), scopeGeneration)
+                    .also(::enqueueDeliveryLocked)
+            }
+            if (state.didActivate && candidate.isSameRelease(state.active)) {
+                return@synchronized TransitionDelivery.unchanged()
+            }
+
+            val oldSnapshot = snapshotFor(state.active, state.previous)
+            val nextState = RemoteConfigSnapshotState(
+                candidate = candidate,
+                active = candidate,
+                previous = state.active,
+                didActivate = true,
+            )
+            if (!saveCurrentScope(nextState)) return@synchronized TransitionDelivery.persistenceFailed()
+            state = nextState
+            val update = buildUpdate(oldSnapshot, snapshotFor(nextState.active, nextState.previous))
+            TransitionDelivery
+                .activated(update, observers.values.toList(), scopeGeneration)
+                .also(::enqueueDeliveryLocked)
+        }
+        drainDeliveries()
+        return delivery.result
+    }
+
+    private fun ensureCurrentScopeLoaded(): Boolean {
+        val scope = currentScope
+        if (scope != null && scopeLoadFailed) loadScopeState(scope)
+        return scope != null && !scopeLoadFailed
+    }
+
+    private fun loadScopeState(scope: RemoteConfigSnapshotScope) {
+        val result = try {
+            store.load(scope)
+        } catch (_: Exception) {
+            RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Failed)
+        }
+        when (result.status) {
+            RemoteConfigSnapshotLoadStatus.Found -> {
+                state = requireNotNull(result.state)
+                scopeLoadFailed = false
+            }
+            RemoteConfigSnapshotLoadStatus.Missing -> {
+                state = RemoteConfigSnapshotState()
+                scopeLoadFailed = false
+            }
+            RemoteConfigSnapshotLoadStatus.Failed -> {
+                scopeLoadFailed = true
+            }
+        }
+    }
+
+    private fun saveCurrentScope(nextState: RemoteConfigSnapshotState): Boolean {
+        val scope = currentScope ?: return false
+        return try {
+            store.save(scope, nextState)
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun snapshotFor(
+        primary: RemoteConfigSnapshotRelease?,
+        previous: RemoteConfigSnapshotRelease?,
+    ) = RemoteConfigSnapshot(primary, previous, bundledRelease?.releaseFor(currentScope))
+
+    private fun buildUpdate(
+        oldSnapshot: RemoteConfigSnapshot?,
+        newSnapshot: RemoteConfigSnapshot,
+    ): RemoteConfigSnapshotUpdate {
+        val allKeys = oldSnapshot?.allKeys.orEmpty() + newSnapshot.allKeys
+        val changedKeys = allKeys.filterTo(mutableSetOf()) { key ->
+            val oldEntry = oldSnapshot?.effectiveEntry(key)
+            val newEntry = newSnapshot.effectiveEntry(key)
+            when {
+                oldEntry == null -> newEntry != null
+                else -> !oldEntry.contentEquals(newEntry)
+            }
+        }
+        val metadata = changedKeys.mapNotNull { key ->
+            newSnapshot.metadataForKey(key)?.let { key to it }
+        }.toMap()
+        return RemoteConfigSnapshotUpdate(newSnapshot, changedKeys, metadata)
+    }
+
+    private fun enqueueDeliveryLocked(delivery: TransitionDelivery) {
+        if (delivery.update?.changedKeys?.isNotEmpty() == true) pendingDeliveries.addLast(delivery)
+    }
+
+    private fun drainDeliveries() {
+        synchronized(deliveryLock) {
+            if (isDrainingDeliveries) return
+            isDrainingDeliveries = true
+            try {
+                while (true) {
+                    val delivery = synchronized(lock) { pendingDeliveries.pollFirst() } ?: break
+                    deliverIfCurrent(delivery)
+                }
+            } finally {
+                isDrainingDeliveries = false
+            }
+        }
+    }
+
+    private fun deliverIfCurrent(delivery: TransitionDelivery) {
+        val update = requireNotNull(delivery.update)
+        val generation = requireNotNull(delivery.scopeGeneration)
+        for (observer in delivery.observers) {
+            val isCurrent = synchronized(lock) { generation == scopeGeneration }
+            if (!isCurrent) break
+            try {
+                observer(update)
+            } catch (_: Exception) {
+                // A committed transition remains successful and other observers still run.
+            }
+        }
+    }
+
+    private fun RemoteConfigSnapshotRelease.isSameRelease(other: RemoteConfigSnapshotRelease?): Boolean =
+        contentEquals(other)
+
+    private data class TransitionDelivery(
+        val result: RemoteConfigSnapshotTransitionResult,
+        val update: RemoteConfigSnapshotUpdate? = null,
+        val observers: List<(RemoteConfigSnapshotUpdate) -> Unit> = emptyList(),
+        val scopeGeneration: Long? = null,
+    ) {
+        companion object {
+            fun ignored() = TransitionDelivery(
+                RemoteConfigSnapshotTransitionResult(RemoteConfigSnapshotTransitionStatus.Ignored),
+            )
+
+            fun persistenceFailed() = TransitionDelivery(
+                RemoteConfigSnapshotTransitionResult(RemoteConfigSnapshotTransitionStatus.PersistenceFailed),
+            )
+
+            fun unchanged() = TransitionDelivery(
+                RemoteConfigSnapshotTransitionResult(RemoteConfigSnapshotTransitionStatus.Unchanged),
+            )
+
+            fun activated(
+                update: RemoteConfigSnapshotUpdate,
+                observers: List<(RemoteConfigSnapshotUpdate) -> Unit>,
+                scopeGeneration: Long,
+            ) = TransitionDelivery(
+                result = RemoteConfigSnapshotTransitionResult(
+                    status = RemoteConfigSnapshotTransitionStatus.Activated,
+                    changed = update.changedKeys.isNotEmpty(),
+                    update = update,
+                ),
+                update = update,
+                observers = observers,
+                scopeGeneration = scopeGeneration,
+            )
+        }
+    }
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/services/BundledRemoteConfigDefaults.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/services/BundledRemoteConfigDefaults.kt
@@ -224,6 +224,7 @@ internal class BundledRemoteConfigDefaultsDocument(
     private val defaultsByKey = Collections.unmodifiableMap(orderedDefaults.associateBy { it.key })
 
     fun defaultFor(key: String): BundledRemoteConfigDefault? = defaultsByKey[key]
+    internal fun allDefaults(): List<BundledRemoteConfigDefault> = orderedDefaults
 
     internal fun canonicalJson(): String = buildString {
         append("{\"schemaVersion\":1,\"projectId\":").append(projectId)
@@ -268,6 +269,8 @@ private fun parsePortableJson(bytes: ByteArray): ParsedJson? = try {
 } catch (_: Exception) {
     null
 }
+
+internal fun isPortableRemoteConfigJson(bytes: ByteArray): Boolean = parsePortableJson(bytes) != null
 
 @Suppress("ComplexMethod")
 private fun JsonReader.readPortableJsonValue(depth: Int): Any? = when (peek()) {

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/storage/PersistentRemoteConfigSnapshotStore.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/storage/PersistentRemoteConfigSnapshotStore.kt
@@ -1,0 +1,515 @@
+package com.qonversion.android.sdk.internal.storage
+
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotApplyPolicy
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotEntry
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotRelease
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotScope
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotState
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import okio.ByteString.Companion.decodeBase64
+import okio.ByteString.Companion.toByteString
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+
+internal const val REMOTE_CONFIG_SNAPSHOT_INDEX_KEY = "qonversion_remote_config_v2_snapshot_index"
+
+private const val REMOTE_CONFIG_SNAPSHOT_STORAGE_PREFIX = "qonversion_remote_config_v2_snapshot_"
+private const val REMOTE_CONFIG_SNAPSHOT_ENVELOPE_VERSION = 1
+private const val REMOTE_CONFIG_SNAPSHOT_INDEX_VERSION = 1
+private const val DEFAULT_REMOTE_CONFIG_SNAPSHOT_MAX_SCOPES = 16
+private const val DEFAULT_REMOTE_CONFIG_SNAPSHOT_MAX_STATE_BYTES = 20 * 1024 * 1024
+private const val DEFAULT_REMOTE_CONFIG_SNAPSHOT_MAX_TOTAL_BYTES = 32 * 1024 * 1024
+private const val REMOTE_CONFIG_SNAPSHOT_MAX_INDEX_BYTES = 64 * 1024
+private const val BYTE_MASK = 0xff
+private const val LOW_NIBBLE_MASK = 0x0f
+private const val NIBBLE_SHIFT = 4
+private const val HEX = "0123456789abcdef"
+private val REMOTE_CONFIG_SNAPSHOT_STORAGE_KEY_PATTERN =
+    Regex("^${Regex.escape(REMOTE_CONFIG_SNAPSHOT_STORAGE_PREFIX)}[0-9a-f]{64}$")
+
+internal enum class RemoteConfigSnapshotLoadStatus {
+    Found,
+    Missing,
+    Failed,
+}
+
+internal data class RemoteConfigSnapshotLoadResult(
+    val status: RemoteConfigSnapshotLoadStatus,
+    val state: RemoteConfigSnapshotState? = null,
+) {
+    init {
+        require((status == RemoteConfigSnapshotLoadStatus.Found) == (state != null))
+    }
+}
+
+internal interface RemoteConfigSnapshotStore {
+    fun load(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotLoadResult
+    fun save(scope: RemoteConfigSnapshotScope, state: RemoteConfigSnapshotState): Boolean
+}
+
+internal class PersistentRemoteConfigSnapshotStore(
+    private val cache: Cache,
+    moshi: Moshi,
+    private val maxScopes: Int = DEFAULT_REMOTE_CONFIG_SNAPSHOT_MAX_SCOPES,
+    private val maxStateBytes: Int = DEFAULT_REMOTE_CONFIG_SNAPSHOT_MAX_STATE_BYTES,
+    private val maxTotalBytes: Int = DEFAULT_REMOTE_CONFIG_SNAPSHOT_MAX_TOTAL_BYTES,
+) : RemoteConfigSnapshotStore {
+    private val envelopeAdapter = moshi.adapter(PersistedRemoteConfigSnapshotEnvelope::class.java).failOnUnknown()
+    private val indexAdapter = moshi.adapter(PersistedRemoteConfigSnapshotIndex::class.java).failOnUnknown()
+
+    init {
+        require(maxScopes > 0)
+        require(maxStateBytes > 0)
+        require(maxTotalBytes > 0)
+    }
+
+    @Synchronized
+    @Suppress("ReturnCount")
+    override fun load(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotLoadResult = try {
+        loadTrusted(scope)?.let { state ->
+            RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Found, state)
+        } ?: RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Missing)
+    } catch (_: Exception) {
+        RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Failed)
+    }
+
+    @Suppress("ReturnCount")
+    private fun loadTrusted(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotState? {
+        val storageKey = remoteConfigSnapshotStorageKey(scope)
+        val index = loadIndex(clearInvalid = true)
+        val rawEnvelope = cache.getString(storageKey, null)
+        val envelopeBytes = rawEnvelope?.toByteArray(Charsets.UTF_8)?.size
+        val envelope = rawEnvelope
+            ?.takeIf {
+                requireNotNull(envelopeBytes) <= maxStateBytes && envelopeBytes <= maxTotalBytes
+            }
+            ?.let(::decodeEnvelope)
+        val decoded = envelope
+            ?.takeIf { it.matches(scope, storageKey) }
+            ?.state
+            ?.toDecodedModel()
+        if (decoded != null) {
+            val rewritten = decoded.requiresRewrite && save(scope, decoded.state)
+            if (!rewritten) {
+                if (storageKey in index.storageKeys) {
+                    promoteAfterRead(storageKey, index)
+                } else {
+                    admitRecoveredAfterRead(storageKey, requireNotNull(envelopeBytes), index)
+                }
+            }
+            return decoded.state
+        }
+        removeInvalidEnvelope(storageKey, index)
+        return null
+    }
+
+    @Synchronized
+    @Suppress("ReturnCount")
+    override fun save(scope: RemoteConfigSnapshotScope, state: RemoteConfigSnapshotState): Boolean {
+        val storageKey = remoteConfigSnapshotStorageKey(scope)
+        val envelope = PersistedRemoteConfigSnapshotEnvelope(
+            version = REMOTE_CONFIG_SNAPSHOT_ENVELOPE_VERSION,
+            projectKey = scope.projectKey,
+            environment = scope.environment,
+            canonicalUserId = scope.canonicalUserId,
+            state = state.toPersisted(),
+        )
+        val stateJson = try {
+            envelopeAdapter.toJson(envelope)
+        } catch (_: Exception) {
+            return false
+        }
+        val stateBytes = stateJson.toByteArray(Charsets.UTF_8).size
+        if (stateBytes > maxStateBytes || stateBytes > maxTotalBytes) return false
+
+        val existing = try {
+            loadIndex(clearInvalid = false).storageKeys
+        } catch (_: Exception) {
+            return false
+        }
+        val admitted = try {
+            existing.filter { it != storageKey }.mapNotNull { key ->
+                admittedEnvelopeSize(key)?.let { bytes -> StoredEnvelope(key, bytes) }
+            }
+        } catch (_: Exception) {
+            return false
+        }
+        val retained = boundedNewest(admitted + StoredEnvelope(storageKey, stateBytes))
+        val retainedKeys = retained.map(StoredEnvelope::storageKey)
+        val evicted = (existing.toSet() - retainedKeys.toSet()) - storageKey
+        val indexJson = try {
+            indexAdapter.toJson(
+                PersistedRemoteConfigSnapshotIndex(
+                    version = REMOTE_CONFIG_SNAPSHOT_INDEX_VERSION,
+                    storageKeys = retainedKeys,
+                ),
+            )
+        } catch (_: Exception) {
+            return false
+        }
+        if (indexJson.toByteArray(Charsets.UTF_8).size > REMOTE_CONFIG_SNAPSHOT_MAX_INDEX_BYTES) return false
+
+        return try {
+            cache.updateStringsDurably(
+                values = mapOf(
+                    storageKey to stateJson,
+                    REMOTE_CONFIG_SNAPSHOT_INDEX_KEY to indexJson,
+                ),
+                removedKeys = evicted,
+            )
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun loadIndex(clearInvalid: Boolean): PersistedRemoteConfigSnapshotIndex {
+        val raw = cache.getString(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY, null) ?: return emptyIndex()
+        val decoded = try {
+            raw.takeIf { it.toByteArray(Charsets.UTF_8).size <= REMOTE_CONFIG_SNAPSHOT_MAX_INDEX_BYTES }
+                ?.let(indexAdapter::fromJson)
+                ?.takeIf { it.isValid() }
+        } catch (_: Exception) {
+            null
+        }
+        if (decoded != null) return decoded
+        if (clearInvalid) clearInvalidIndex()
+        return emptyIndex()
+    }
+
+    private fun PersistedRemoteConfigSnapshotIndex.isValid(): Boolean =
+        version == REMOTE_CONFIG_SNAPSHOT_INDEX_VERSION &&
+            storageKeys.size <= maxScopes &&
+            storageKeys.size == storageKeys.distinct().size &&
+            storageKeys.all(REMOTE_CONFIG_SNAPSHOT_STORAGE_KEY_PATTERN::matches)
+
+    private fun PersistedRemoteConfigSnapshotEnvelope.matches(
+        scope: RemoteConfigSnapshotScope,
+        storageKey: String,
+    ): Boolean = version == REMOTE_CONFIG_SNAPSHOT_ENVELOPE_VERSION &&
+        projectKey == scope.projectKey && environment == scope.environment &&
+        canonicalUserId == scope.canonicalUserId &&
+        remoteConfigSnapshotStorageKey(scope) == storageKey
+
+    private fun decodeEnvelope(raw: String): PersistedRemoteConfigSnapshotEnvelope? = try {
+        envelopeAdapter.fromJson(raw)
+    } catch (_: Exception) {
+        null
+    }
+
+    @Suppress("ReturnCount")
+    private fun admittedEnvelopeSize(storageKey: String): Int? {
+        val raw = cache.getString(storageKey, null) ?: return null
+        val rawBytes = raw.toByteArray(Charsets.UTF_8).size
+        if (rawBytes > maxStateBytes || rawBytes > maxTotalBytes) return null
+        val envelope = decodeEnvelope(raw) ?: return null
+        val scope = try {
+            RemoteConfigSnapshotScope(
+                projectKey = envelope.projectKey,
+                environment = envelope.environment,
+                canonicalUserId = envelope.canonicalUserId,
+            )
+        } catch (_: IllegalArgumentException) {
+            return null
+        }
+        if (!envelope.matches(scope, storageKey)) return null
+        val decoded = envelope.state.toDecodedModel()
+        if (decoded.requiresRewrite && decoded.state == RemoteConfigSnapshotState()) return null
+        return rawBytes
+    }
+
+    private fun boundedNewest(envelopes: List<StoredEnvelope>): List<StoredEnvelope> {
+        val retained = envelopes.takeLast(maxScopes).toMutableList()
+        var totalBytes = retained.sumOf { envelope -> envelope.bytes.toLong() }
+        while (totalBytes > maxTotalBytes && retained.size > 1) {
+            totalBytes -= retained.removeAt(0).bytes
+        }
+        return retained
+    }
+
+    private fun removeInvalidEnvelope(
+        storageKey: String,
+        index: PersistedRemoteConfigSnapshotIndex,
+    ) {
+        val remaining = index.storageKeys - storageKey
+        val values = if (remaining.isEmpty()) {
+            emptyMap()
+        } else {
+            mapOf(
+                REMOTE_CONFIG_SNAPSHOT_INDEX_KEY to indexAdapter.toJson(
+                    PersistedRemoteConfigSnapshotIndex(REMOTE_CONFIG_SNAPSHOT_INDEX_VERSION, remaining),
+                ),
+            )
+        }
+        val removed = buildSet {
+            add(storageKey)
+            if (remaining.isEmpty()) add(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY)
+        }
+        try {
+            cache.updateStringsDurably(values, removed)
+        } catch (_: Exception) {
+            // Reads stay fail-closed if corruption cleanup cannot be committed.
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun admitRecoveredAfterRead(
+        storageKey: String,
+        storageBytes: Int,
+        index: PersistedRemoteConfigSnapshotIndex,
+    ) {
+        val admitted = try {
+            index.storageKeys.mapNotNull { key ->
+                admittedEnvelopeSize(key)?.let { bytes -> StoredEnvelope(key, bytes) }
+            }
+        } catch (_: Exception) {
+            return
+        }
+        val retained = boundedNewest(admitted + StoredEnvelope(storageKey, storageBytes))
+        val retainedKeys = retained.map(StoredEnvelope::storageKey)
+        val removed = index.storageKeys.toSet() - retainedKeys.toSet()
+        val indexJson = try {
+            indexAdapter.toJson(
+                PersistedRemoteConfigSnapshotIndex(
+                    version = REMOTE_CONFIG_SNAPSHOT_INDEX_VERSION,
+                    storageKeys = retainedKeys,
+                ),
+            )
+        } catch (_: Exception) {
+            return
+        }
+        if (indexJson.toByteArray(Charsets.UTF_8).size > REMOTE_CONFIG_SNAPSHOT_MAX_INDEX_BYTES) return
+        try {
+            cache.updateStringsDurably(
+                values = mapOf(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY to indexJson),
+                removedKeys = removed,
+            )
+        } catch (_: Exception) {
+            // An exact valid envelope remains safe to serve even if its index cannot be repaired.
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun promoteAfterRead(
+        storageKey: String,
+        index: PersistedRemoteConfigSnapshotIndex,
+    ) {
+        if (index.storageKeys.lastOrNull() == storageKey) return
+        val promoted = PersistedRemoteConfigSnapshotIndex(
+            version = REMOTE_CONFIG_SNAPSHOT_INDEX_VERSION,
+            storageKeys = (index.storageKeys - storageKey) + storageKey,
+        )
+        val indexJson = try {
+            indexAdapter.toJson(promoted)
+        } catch (_: Exception) {
+            return
+        }
+        if (indexJson.toByteArray(Charsets.UTF_8).size > REMOTE_CONFIG_SNAPSHOT_MAX_INDEX_BYTES) return
+        try {
+            cache.updateStringsDurably(
+                values = mapOf(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY to indexJson),
+                removedKeys = emptySet(),
+            )
+        } catch (_: Exception) {
+            // A failed recency hint must never make an otherwise valid snapshot unavailable.
+        }
+    }
+
+    private fun clearInvalidIndex() {
+        try {
+            cache.updateStringsDurably(emptyMap(), setOf(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY))
+        } catch (_: Exception) {
+            // The invalid index remains unusable and no scope is trusted from it.
+        }
+    }
+
+    private fun emptyIndex() = PersistedRemoteConfigSnapshotIndex(
+        version = REMOTE_CONFIG_SNAPSHOT_INDEX_VERSION,
+        storageKeys = emptyList(),
+    )
+
+    private data class StoredEnvelope(
+        val storageKey: String,
+        val bytes: Int,
+    )
+}
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigSnapshotIndex(
+    val version: Int,
+    val storageKeys: List<String>,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigSnapshotEnvelope(
+    val version: Int,
+    val projectKey: String,
+    val environment: String,
+    val canonicalUserId: String,
+    val state: PersistedRemoteConfigSnapshotState,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigSnapshotState(
+    val candidate: PersistedRemoteConfigSnapshotRelease?,
+    val active: PersistedRemoteConfigSnapshotRelease?,
+    val previous: PersistedRemoteConfigSnapshotRelease?,
+    val didActivate: Boolean,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigSnapshotRelease(
+    val releaseUid: String,
+    val releaseNumber: Long,
+    val manifestContentHash: String,
+    val entries: List<PersistedRemoteConfigSnapshotEntry>,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigSnapshotEntry(
+    val key: String,
+    val rawBase64: String?,
+    val variationUid: String?,
+    val applyPolicy: Int,
+    val metadataBase64: String?,
+)
+
+private data class DecodedRemoteConfigSnapshotState(
+    val state: RemoteConfigSnapshotState,
+    val requiresRewrite: Boolean,
+)
+
+@Suppress("ComplexMethod")
+private fun PersistedRemoteConfigSnapshotState.toDecodedModel(): DecodedRemoteConfigSnapshotState {
+    var candidateModel = candidate?.toModel()
+    var activeModel = active?.toModel()
+    var previousModel = previous?.toModel()
+    var requiresRewrite =
+        (candidate != null && candidateModel == null) ||
+            (active != null && activeModel == null) ||
+            (previous != null && previousModel == null)
+
+    if (!didActivate && activeModel != null) {
+        activeModel = null
+        previousModel = null
+        requiresRewrite = true
+    }
+    if (activeModel == null && previousModel != null) {
+        previousModel = null
+        requiresRewrite = true
+    }
+    if (candidateModel != null && activeModel != null &&
+        candidateModel.releaseNumber < activeModel.releaseNumber
+    ) {
+        candidateModel = null
+        requiresRewrite = true
+    }
+    if (candidateModel != null && activeModel != null &&
+        candidateModel.releaseNumber == activeModel.releaseNumber
+    ) {
+        if (candidateModel.contentEquals(activeModel)) {
+            candidateModel = activeModel
+        } else {
+            candidateModel = null
+            requiresRewrite = true
+        }
+    }
+    if (previousModel != null && activeModel != null &&
+        previousModel.releaseNumber >= activeModel.releaseNumber
+    ) {
+        previousModel = null
+        requiresRewrite = true
+    }
+    return DecodedRemoteConfigSnapshotState(
+        state = RemoteConfigSnapshotState(
+            candidate = candidateModel,
+            active = activeModel,
+            previous = previousModel,
+            didActivate = didActivate,
+        ),
+        requiresRewrite = requiresRewrite,
+    )
+}
+
+@Suppress("ReturnCount")
+private fun PersistedRemoteConfigSnapshotRelease.toModel(): RemoteConfigSnapshotRelease? {
+    return try {
+        RemoteConfigSnapshotRelease(
+            releaseUid = releaseUid,
+            releaseNumber = releaseNumber,
+            manifestContentHash = manifestContentHash,
+            entries = entries.map { it.toModel() ?: return null },
+        )
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}
+
+@Suppress("ReturnCount")
+private fun PersistedRemoteConfigSnapshotEntry.toModel(): RemoteConfigSnapshotEntry? {
+    return try {
+        val policy = when (applyPolicy) {
+            1 -> RemoteConfigSnapshotApplyPolicy.OnNextActivate
+            2 -> RemoteConfigSnapshotApplyPolicy.Immediate
+            else -> return null
+        }
+        val raw = rawBase64.decodeCanonicalBase64()
+        val metadata = metadataBase64.decodeCanonicalBase64()
+        when {
+            rawBase64 == null && metadataBase64 == null && variationUid == null ->
+                RemoteConfigSnapshotEntry.tombstone(key)
+            raw == null || variationUid == null || (metadataBase64 != null && metadata == null) -> null
+            else -> RemoteConfigSnapshotEntry.value(key, raw, variationUid, policy, metadata)
+        }
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}
+
+@Suppress("ReturnCount")
+private fun String?.decodeCanonicalBase64(): ByteArray? {
+    if (this == null) return null
+    val decoded = decodeBase64() ?: return null
+    return decoded.takeIf { it.base64() == this }?.toByteArray()
+}
+
+private fun RemoteConfigSnapshotState.toPersisted() = PersistedRemoteConfigSnapshotState(
+    candidate = candidate?.toPersisted(),
+    active = active?.toPersisted(),
+    previous = previous?.toPersisted(),
+    didActivate = didActivate,
+)
+
+private fun RemoteConfigSnapshotRelease.toPersisted() = PersistedRemoteConfigSnapshotRelease(
+    releaseUid = releaseUid,
+    releaseNumber = releaseNumber,
+    manifestContentHash = manifestContentHash,
+    entries = entries.values.sortedBy { it.key }.map { entry ->
+        PersistedRemoteConfigSnapshotEntry(
+            key = entry.key,
+            rawBase64 = entry.rawValueBytes?.toByteString()?.base64(),
+            variationUid = entry.variationUid,
+            applyPolicy = when (entry.applyPolicy) {
+                RemoteConfigSnapshotApplyPolicy.OnNextActivate -> 1
+                RemoteConfigSnapshotApplyPolicy.Immediate -> 2
+            },
+            metadataBase64 = entry.metadataBytes?.toByteString()?.base64(),
+        )
+    },
+)
+
+internal fun remoteConfigSnapshotStorageKey(scope: RemoteConfigSnapshotScope): String {
+    val messageDigest = MessageDigest.getInstance("SHA-256")
+    listOf(scope.projectKey, scope.environment, scope.canonicalUserId).forEach { component ->
+        val bytes = component.toByteArray(Charsets.UTF_8)
+        messageDigest.update(ByteBuffer.allocate(Int.SIZE_BYTES).putInt(bytes.size).array())
+        messageDigest.update(bytes)
+    }
+    val digest = messageDigest.digest()
+        .joinToString(separator = "") { byte ->
+            val value = byte.toInt() and BYTE_MASK
+            "${HEX[value ushr NIBBLE_SHIFT]}${HEX[value and LOW_NIBBLE_MASK]}"
+        }
+    return "$REMOTE_CONFIG_SNAPSHOT_STORAGE_PREFIX$digest"
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCoreTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCoreTest.kt
@@ -1,0 +1,430 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotStore
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadResult
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadStatus
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class RemoteConfigSnapshotCoreTest {
+    private val scopeA = RemoteConfigSnapshotScope("project", "production", "canonical-user-a")
+    private val scopeB = RemoteConfigSnapshotScope("project", "production", "canonical-user-b")
+    private val bundled = RemoteConfigScopedBundledRelease(
+        projectKey = "project",
+        environment = "production",
+        release = release("bundle", 1, mapOf("a" to "0", "b" to "0")),
+    )
+    private val store = RecordingSnapshotStore()
+    private val core = RemoteConfigSnapshotCore(store, bundled)
+
+    @Test
+    fun `candidate waits for activation and held snapshots never mutate`() {
+        core.setScope(scopeA)
+        assertEquals(
+            RemoteConfigSnapshotTransitionStatus.Accepted,
+            core.acceptCandidate(scopeA, release("one", 1, mapOf("a" to "1"))).status,
+        )
+        assertEquals("0", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+        assertEquals("one", core.lastFetchedSnapshot()?.releaseUid)
+
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Activated, core.activate().status)
+        val held = core.currentSnapshot()
+        assertEquals("1", held.rawValue("a")?.value?.decodeToString())
+
+        core.acceptCandidate(scopeA, release("two", 2, mapOf("a" to "2")))
+        core.activate()
+
+        assertEquals("2", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+        assertEquals("1", held.rawValue("a")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `one immediate entry activates the entire release and emits one atomic update`() {
+        core.setScope(scopeA)
+        core.activate()
+        val observed = mutableListOf<RemoteConfigSnapshotUpdate>()
+        core.addUpdateObserver(observed::add)
+        val immediate = release(
+            uid = "immediate",
+            number = 2,
+            values = mapOf("a" to "1", "b" to "2"),
+            immediateKey = "a",
+        )
+
+        val result = core.acceptCandidate(scopeA, immediate)
+
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Activated, result.status)
+        assertEquals("1", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+        assertEquals("2", core.currentSnapshot().rawValue("b")?.value?.decodeToString())
+        assertEquals(1, observed.size)
+        assertEquals(setOf("a", "b"), observed.single().changedKeys)
+        assertEquals("immediate", observed.single().snapshot.releaseUid)
+        assertEquals("immediate", store.states.getValue(scopeA).active?.releaseUid)
+    }
+
+    @Test
+    fun `logout and identity switch are a hard privacy boundary and late responses are ignored`() {
+        core.setScope(scopeA)
+        core.acceptCandidate(scopeA, release("private-a", 1, mapOf("a" to "\"private-a\"")))
+        core.activate()
+
+        core.setScope(null)
+        assertEquals("0", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+        assertNull(core.lastFetchedSnapshot())
+
+        core.setScope(scopeB)
+        val late = core.acceptCandidate(
+            scopeA,
+            release("late-a", 2, mapOf("a" to "\"must-not-leak\""), immediateKey = "a"),
+        )
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Ignored, late.status)
+        assertEquals("0", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+
+        core.setScope(scopeA)
+        assertEquals("\"private-a\"", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `candidate commit failure preserves admitted state and emits no update`() {
+        core.setScope(scopeA)
+        core.acceptCandidate(scopeA, release("one", 1, mapOf("a" to "1")))
+        core.activate()
+        val observed = mutableListOf<RemoteConfigSnapshotUpdate>()
+        core.addUpdateObserver(observed::add)
+        store.failNextSave = true
+
+        val result = core.acceptCandidate(
+            scopeA,
+            release("two", 2, mapOf("a" to "2"), immediateKey = "a"),
+        )
+
+        assertEquals(RemoteConfigSnapshotTransitionStatus.PersistenceFailed, result.status)
+        assertEquals("one", core.currentSnapshot().releaseUid)
+        assertEquals("one", core.lastFetchedSnapshot()?.releaseUid)
+        assertTrue(observed.isEmpty())
+    }
+
+    @Test
+    fun `activation commit failure preserves active candidate and previous without success`() {
+        core.setScope(scopeA)
+        core.acceptCandidate(scopeA, release("one", 1, mapOf("a" to "1")))
+        core.activate()
+        core.acceptCandidate(scopeA, release("two", 2, mapOf("a" to "2")))
+        val before = core.currentSnapshot()
+        val observed = mutableListOf<RemoteConfigSnapshotUpdate>()
+        core.addUpdateObserver(observed::add)
+        store.failNextSave = true
+
+        val result = core.activate()
+
+        assertEquals(RemoteConfigSnapshotTransitionStatus.PersistenceFailed, result.status)
+        assertFalse(result.changed)
+        assertEquals("one", core.currentSnapshot().releaseUid)
+        assertEquals("two", core.lastFetchedSnapshot()?.releaseUid)
+        assertArrayEquals(before.rawValue("a")?.value, core.currentSnapshot().rawValue("a")?.value)
+        assertTrue(observed.isEmpty())
+    }
+
+    @Test
+    fun `older equal and conflicting replays cannot replace freshest candidate`() {
+        core.setScope(scopeA)
+        core.acceptCandidate(scopeA, release("newest", 3, mapOf("a" to "3")))
+
+        for (stale in listOf(
+            release("older", 2, mapOf("a" to "2"), immediateKey = "a"),
+            release("conflict", 3, mapOf("a" to "\"conflict\""), immediateKey = "a"),
+        )) {
+            assertEquals(
+                RemoteConfigSnapshotTransitionStatus.Ignored,
+                core.acceptCandidate(scopeA, stale).status,
+            )
+        }
+        assertEquals("newest", core.lastFetchedSnapshot()?.releaseUid)
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Activated, core.activate().status)
+        assertEquals("3", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `last fetched snapshot after activation retains the actual previous decode tier`() {
+        core.setScope(scopeA)
+        core.acceptCandidate(scopeA, release("one", 1, mapOf("a" to "{\"value\":1}")))
+        core.activate()
+        core.acceptCandidate(scopeA, release("two", 2, mapOf("a" to "\"wrong-shape\"")))
+        core.activate()
+
+        val resolved = core.lastFetchedSnapshot()?.value("a") { raw ->
+            raw.decodeToString().takeIf { it.startsWith("{") }
+        }
+
+        assertEquals(RemoteConfigSnapshotValueSource.Cache, resolved?.source)
+        assertEquals("{\"value\":1}", resolved?.value)
+    }
+
+    @Test
+    fun `one failing observer cannot block committed result or other observers`() {
+        core.setScope(scopeA)
+        val observed = mutableListOf<String>()
+        core.addUpdateObserver { error("observer failure") }
+        core.addUpdateObserver { update -> observed += update.snapshot.releaseUid }
+
+        val result = core.acceptCandidate(
+            scopeA,
+            release("immediate", 1, mapOf("a" to "1"), immediateKey = "a"),
+        )
+
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Activated, result.status)
+        assertEquals("immediate", core.currentSnapshot().releaseUid)
+        assertEquals(listOf("immediate"), observed)
+    }
+
+    @Test
+    fun `scope change waits for in flight delivery so no private callback arrives after logout`() {
+        core.setScope(scopeA)
+        val firstObserverStarted = CountDownLatch(1)
+        val releaseFirstObserver = CountDownLatch(1)
+        val scopeChangeFinished = CountDownLatch(1)
+        val callbackAfterLogout = AtomicBoolean(false)
+        core.addUpdateObserver {
+            firstObserverStarted.countDown()
+            releaseFirstObserver.await(2, TimeUnit.SECONDS)
+        }
+        core.addUpdateObserver {
+            if (scopeChangeFinished.count == 0L) callbackAfterLogout.set(true)
+        }
+        val acceptThread = Thread {
+            core.acceptCandidate(
+                scopeA,
+                release("private", 1, mapOf("a" to "\"private\""), immediateKey = "a"),
+            )
+        }
+        acceptThread.start()
+        assertTrue(firstObserverStarted.await(2, TimeUnit.SECONDS))
+        val logoutThread = Thread {
+            core.setScope(null)
+            scopeChangeFinished.countDown()
+        }
+        logoutThread.start()
+
+        val logoutFinishedBeforeDelivery = scopeChangeFinished.await(250, TimeUnit.MILLISECONDS)
+        releaseFirstObserver.countDown()
+        acceptThread.join(2_000)
+        logoutThread.join(2_000)
+
+        assertFalse(logoutFinishedBeforeDelivery)
+        assertFalse(callbackAfterLogout.get())
+        assertEquals("0", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `transient scope load failure cannot overwrite durable state and same scope retries`() {
+        store.states[scopeA] = RemoteConfigSnapshotState(
+            candidate = release("private", 1, mapOf("a" to "\"private\"")),
+            active = release("private", 1, mapOf("a" to "\"private\"")),
+            didActivate = true,
+        )
+        store.failNextLoads = 2
+
+        core.setScope(scopeA)
+        assertEquals("0", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+
+        val activation = core.activate()
+        assertEquals(RemoteConfigSnapshotTransitionStatus.PersistenceFailed, activation.status)
+        assertTrue(store.savedStates.isEmpty())
+
+        core.setScope(scopeA)
+        assertEquals("private", core.currentSnapshot().releaseUid)
+        assertEquals("\"private\"", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `activation reports unchanged when a new release has no effective diff`() {
+        core.setScope(scopeA)
+        val observed = mutableListOf<RemoteConfigSnapshotUpdate>()
+        core.addUpdateObserver(observed::add)
+        val emptyRelease = RemoteConfigSnapshotRelease(
+            releaseUid = "empty",
+            releaseNumber = 1,
+            manifestContentHash = hash(1),
+            entries = emptyList(),
+        )
+        core.acceptCandidate(scopeA, emptyRelease)
+
+        val result = core.activate()
+
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Activated, result.status)
+        assertFalse(result.changed)
+        assertTrue(result.update?.changedKeys?.isEmpty() == true)
+        assertTrue(observed.isEmpty())
+    }
+
+    @Test
+    fun `bundled fallback is available only in its project and environment scope`() {
+        core.setScope(RemoteConfigSnapshotScope("project", "sandbox", "canonical-user"))
+        assertNull(core.currentSnapshot().rawValue("a"))
+
+        core.setScope(RemoteConfigSnapshotScope("other-project", "production", "canonical-user"))
+        assertNull(core.currentSnapshot().rawValue("a"))
+
+        core.setScope(scopeA)
+        assertEquals("0", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `slow observer never blocks snapshot reads on the state lock`() {
+        core.setScope(scopeA)
+        val observerStarted = CountDownLatch(1)
+        val releaseObserver = CountDownLatch(1)
+        val snapshotRead = CountDownLatch(1)
+        core.addUpdateObserver {
+            observerStarted.countDown()
+            releaseObserver.await(2, TimeUnit.SECONDS)
+        }
+        val acceptThread = Thread {
+            core.acceptCandidate(
+                scopeA,
+                release("private", 1, mapOf("a" to "\"private\""), immediateKey = "a"),
+            )
+        }
+        acceptThread.start()
+        assertTrue(observerStarted.await(2, TimeUnit.SECONDS))
+        val readerThread = Thread {
+            core.currentSnapshot()
+            snapshotRead.countDown()
+        }
+        readerThread.start()
+
+        val readCompletedWhileObserverWasBlocked = snapshotRead.await(250, TimeUnit.MILLISECONDS)
+        releaseObserver.countDown()
+        acceptThread.join(2_000)
+        readerThread.join(2_000)
+
+        assertTrue(readCompletedWhileObserverWasBlocked)
+    }
+
+    @Test
+    fun `reentrant activation callbacks preserve durable commit order for every observer`() {
+        core.setScope(scopeA)
+        val observedBySecond = mutableListOf<String>()
+        core.addUpdateObserver { update ->
+            if (update.snapshot.releaseUid == "one") {
+                core.acceptCandidate(
+                    scopeA,
+                    release("two", 2, mapOf("a" to "2"), immediateKey = "a"),
+                )
+            }
+        }
+        core.addUpdateObserver { update -> observedBySecond += update.snapshot.releaseUid }
+
+        core.acceptCandidate(
+            scopeA,
+            release("one", 1, mapOf("a" to "1"), immediateKey = "a"),
+        )
+
+        assertEquals(listOf("one", "two"), observedBySecond)
+        assertEquals("two", core.currentSnapshot().releaseUid)
+    }
+
+    @Test
+    fun `concurrent commit during slow delivery preserves FIFO observer order`() {
+        core.setScope(scopeA)
+        val firstDeliveryStarted = CountDownLatch(1)
+        val releaseFirstDelivery = CountDownLatch(1)
+        val secondCommitFinished = CountDownLatch(1)
+        val observedBySecond = mutableListOf<String>()
+        store.saveObserver = { savedState ->
+            if (savedState.active?.releaseUid == "two") secondCommitFinished.countDown()
+        }
+        core.addUpdateObserver { update ->
+            if (update.snapshot.releaseUid == "one") {
+                firstDeliveryStarted.countDown()
+                releaseFirstDelivery.await(2, TimeUnit.SECONDS)
+            }
+        }
+        core.addUpdateObserver { update -> observedBySecond += update.snapshot.releaseUid }
+        val firstThread = Thread {
+            core.acceptCandidate(
+                scopeA,
+                release("one", 1, mapOf("a" to "1"), immediateKey = "a"),
+            )
+        }
+        firstThread.start()
+        assertTrue(firstDeliveryStarted.await(2, TimeUnit.SECONDS))
+        val secondThread = Thread {
+            core.acceptCandidate(
+                scopeA,
+                release("two", 2, mapOf("a" to "2"), immediateKey = "a"),
+            )
+        }
+        secondThread.start()
+        assertTrue(secondCommitFinished.await(2, TimeUnit.SECONDS))
+
+        releaseFirstDelivery.countDown()
+        firstThread.join(2_000)
+        secondThread.join(2_000)
+
+        assertEquals(listOf("one", "two"), observedBySecond)
+        assertEquals("two", core.currentSnapshot().releaseUid)
+    }
+
+    private fun release(
+        uid: String,
+        number: Long,
+        values: Map<String, String>,
+        immediateKey: String? = null,
+    ) = RemoteConfigSnapshotRelease(
+        releaseUid = uid,
+        releaseNumber = number,
+        manifestContentHash = hash(number),
+        entries = values.map { (key, value) ->
+            RemoteConfigSnapshotEntry.value(
+                key = key,
+                rawValue = value.encodeToByteArray(),
+                variationUid = "$uid-$key",
+                applyPolicy = if (key == immediateKey) {
+                    RemoteConfigSnapshotApplyPolicy.Immediate
+                } else {
+                    RemoteConfigSnapshotApplyPolicy.OnNextActivate
+                },
+                metadata = "{\"release\":\"$uid\"}".encodeToByteArray(),
+            )
+        },
+    )
+
+    private fun hash(number: Long) = number.toString(16).padStart(64, '0')
+
+    private class RecordingSnapshotStore : RemoteConfigSnapshotStore {
+        val states = mutableMapOf<RemoteConfigSnapshotScope, RemoteConfigSnapshotState>()
+        val savedStates = mutableListOf<RemoteConfigSnapshotState>()
+        var failNextSave = false
+        var failNextLoads = 0
+        var saveObserver: ((RemoteConfigSnapshotState) -> Unit)? = null
+
+        override fun load(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotLoadResult {
+            if (failNextLoads > 0) {
+                failNextLoads--
+                return RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Failed)
+            }
+            return states[scope]?.let { state ->
+                RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Found, state)
+            } ?: RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Missing)
+        }
+
+        override fun save(scope: RemoteConfigSnapshotScope, state: RemoteConfigSnapshotState): Boolean {
+            if (failNextSave) {
+                failNextSave = false
+                return false
+            }
+            states[scope] = state
+            savedStates += state
+            saveObserver?.invoke(state)
+            return true
+        }
+    }
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotTest.kt
@@ -1,0 +1,271 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.services.BundledRemoteConfigDefault
+import com.qonversion.android.sdk.internal.services.BundledRemoteConfigDefaultsDocument
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.Assert.assertThrows
+
+internal class RemoteConfigSnapshotTest {
+    @Test
+    fun `typed resolution uses previous only when current raw cannot decode`() {
+        val current = release(
+            uid = "release-2",
+            number = 2,
+            values = mapOf(
+                "paywall" to "\"not-an-object\"",
+                "title" to "\"server-title\"",
+            ),
+        )
+        val previous = release(
+            uid = "release-1",
+            number = 1,
+            values = mapOf(
+                "paywall" to "{\"title\":\"cached\"}",
+                "title" to "\"cached-title\"",
+                "previous-only" to "\"must-not-leak\"",
+            ),
+        )
+        val bundled = release(
+            uid = "bundle",
+            number = 1,
+            values = mapOf(
+                "paywall" to "{\"title\":\"fallback\"}",
+                "bundle-only" to "true",
+            ),
+        )
+        val snapshot = RemoteConfigSnapshot(current, previous, bundled)
+
+        val typed = snapshot.value("paywall") { raw ->
+            raw.decodeToString().takeIf { it.startsWith("{") }
+        }
+        val raw = snapshot.rawValue("paywall")
+
+        assertEquals(RemoteConfigSnapshotValueSource.Cache, typed?.source)
+        assertEquals("{\"title\":\"cached\"}", typed?.value)
+        assertEquals(RemoteConfigSnapshotValueSource.Server, raw?.source)
+        assertArrayEquals("\"not-an-object\"".encodeToByteArray(), raw?.value)
+        assertNull(snapshot.rawValue("previous-only"))
+        assertEquals(RemoteConfigSnapshotValueSource.Fallback, snapshot.rawValue("bundle-only")?.source)
+    }
+
+    @Test
+    fun `missing and tombstone skip previous and resolve directly to bundle`() {
+        val current = RemoteConfigSnapshotRelease(
+            releaseUid = "release-2",
+            releaseNumber = 2,
+            manifestContentHash = "a".repeat(64),
+            entries = listOf(RemoteConfigSnapshotEntry.tombstone("removed")),
+        )
+        val previous = release(
+            uid = "release-1",
+            number = 1,
+            values = mapOf("removed" to "\"private-old\"", "missing" to "\"private-old\""),
+        )
+        val bundled = release(
+            uid = "bundle",
+            number = 1,
+            values = mapOf("removed" to "\"safe-default\"", "missing" to "\"safe-default\""),
+        )
+        val snapshot = RemoteConfigSnapshot(current, previous, bundled)
+
+        for (key in listOf("removed", "missing")) {
+            val raw = snapshot.rawValue(key)
+            val typed = snapshot.value(key) { it.decodeToString() }
+
+            assertEquals(RemoteConfigSnapshotValueSource.Fallback, raw?.source)
+            assertArrayEquals("\"safe-default\"".encodeToByteArray(), raw?.value)
+            assertEquals(RemoteConfigSnapshotValueSource.Fallback, typed?.source)
+            assertEquals("\"safe-default\"", typed?.value)
+        }
+    }
+
+    @Test
+    fun `held snapshot values metadata and updates are deeply immutable`() {
+        val raw = "{\"enabled\":true}".encodeToByteArray()
+        val metadata = "{\"reset\":true}".encodeToByteArray()
+        val entry = RemoteConfigSnapshotEntry.value(
+            key = "feature",
+            rawValue = raw,
+            variationUid = "variation",
+            applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+            metadata = metadata,
+        )
+        val snapshot = RemoteConfigSnapshot(
+            primaryRelease = RemoteConfigSnapshotRelease("release", 1, "a".repeat(64), listOf(entry)),
+            previousRelease = null,
+            bundledRelease = null,
+        )
+        val update = RemoteConfigSnapshotUpdate(
+            snapshot = snapshot,
+            changedKeys = setOf("feature"),
+            metadataByKey = mapOf("feature" to metadata),
+        )
+
+        raw.fill('x'.code.toByte())
+        metadata.fill('x'.code.toByte())
+        snapshot.rawValue("feature")?.value?.fill('y'.code.toByte())
+        update.metadataForKey("feature")?.fill('y'.code.toByte())
+
+        assertArrayEquals("{\"enabled\":true}".encodeToByteArray(), snapshot.rawValue("feature")?.value)
+        assertArrayEquals("{\"reset\":true}".encodeToByteArray(), snapshot.metadataForKey("feature"))
+        assertArrayEquals("{\"reset\":true}".encodeToByteArray(), update.metadataForKey("feature"))
+        assertEquals(setOf("feature"), update.changedKeys)
+    }
+
+    @Test
+    fun `bundled document integrates exact raw defaults without mutable aliases`() {
+        val raw = "{\"enabled\":true}".encodeToByteArray()
+        val document = BundledRemoteConfigDefaultsDocument(
+            projectId = 42,
+            environmentUid = "env-production",
+            releaseUid = "bundle-release",
+            releaseNumber = 7,
+            manifestContentHash = "a".repeat(64),
+            defaultsDigest = "b".repeat(64),
+            defaults = listOf(
+                BundledRemoteConfigDefault(
+                    key = "feature",
+                    variationUid = "bundle-variation",
+                    valueBase64 = "unused-by-adapter",
+                    rawJson = raw,
+                    parsedValue = emptyMap<String, Any>(),
+                ),
+            ),
+        )
+
+        val scopedRelease = document.toScopedRemoteConfigSnapshotRelease("sdk-project-key")
+        val release = scopedRelease.release
+        raw.fill('x'.code.toByte())
+
+        assertEquals("sdk-project-key", scopedRelease.projectKey)
+        assertEquals("env-production", scopedRelease.environment)
+        assertEquals("bundle-release", release.releaseUid)
+        assertEquals(7, release.releaseNumber)
+        assertTrue(release.entries.keys.contains("feature"))
+        assertArrayEquals("{\"enabled\":true}".encodeToByteArray(), release.entry("feature")?.rawValueBytes)
+    }
+
+    @Test
+    fun `release and entries enforce exact server resource and identifier bounds`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            RemoteConfigSnapshotEntry.value(
+                key = "key",
+                rawValue = ("\"" + "x".repeat(64 * 1024) + "\"").encodeToByteArray(),
+                variationUid = "variation",
+                applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+                metadata = null,
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            RemoteConfigSnapshotEntry.value(
+                key = "key",
+                rawValue = "true".encodeToByteArray(),
+                variationUid = "variation",
+                applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+                metadata = ("\"" + "x".repeat(4 * 1024) + "\"").encodeToByteArray(),
+            )
+        }
+        val entry = RemoteConfigSnapshotEntry.value(
+            key = "key",
+            rawValue = "true".encodeToByteArray(),
+            variationUid = "variation",
+            applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+            metadata = null,
+        )
+        for (invalidHash in listOf("hash", "A".repeat(64), "a".repeat(63))) {
+            assertThrows(IllegalArgumentException::class.java) {
+                RemoteConfigSnapshotRelease("release", 1, invalidHash, listOf(entry))
+            }
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            RemoteConfigSnapshotRelease("r".repeat(37), 1, "a".repeat(64), listOf(entry))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            RemoteConfigSnapshotRelease(
+                "release",
+                1,
+                "a".repeat(64),
+                List(1_001) { index -> RemoteConfigSnapshotEntry.tombstone("key-$index") },
+            )
+        }
+
+        val nearMaximumRaw = ("\"" + "x".repeat(64 * 1024 - 2) + "\"").encodeToByteArray()
+        assertThrows(IllegalArgumentException::class.java) {
+            RemoteConfigSnapshotRelease(
+                "release",
+                1,
+                "a".repeat(64),
+                List(65) { index ->
+                    RemoteConfigSnapshotEntry.value(
+                        key = "key-$index",
+                        rawValue = nearMaximumRaw,
+                        variationUid = "variation-$index",
+                        applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+                        metadata = null,
+                    )
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `scope enforces exact identity boundary limits`() {
+        val valid = RemoteConfigSnapshotScope(
+            projectKey = "é".repeat(128),
+            environment = "😀".repeat(36),
+            canonicalUserId = "u".repeat(256),
+        )
+
+        assertEquals(256, valid.projectKey.toByteArray().size)
+        assertEquals(36, valid.environment.codePointCount(0, valid.environment.length))
+        assertEquals(256, valid.canonicalUserId.toByteArray().size)
+
+        for (invalid in listOf(
+            Triple("", "production", "user"),
+            Triple("p".repeat(257), "production", "user"),
+            Triple("project", "", "user"),
+            Triple("project", "e".repeat(37), "user"),
+            Triple("project", "production", "u".repeat(257)),
+            Triple("project", "production", "\uD800"),
+        )) {
+            assertThrows(IllegalArgumentException::class.java) {
+                RemoteConfigSnapshotScope(invalid.first, invalid.second, invalid.third)
+            }
+        }
+    }
+
+    @Test
+    fun `scope storage identity remains unambiguous when values contain separators`() {
+        val first = RemoteConfigSnapshotScope("a\u0000b", "c", "d")
+        val second = RemoteConfigSnapshotScope("a", "b", "c\u0000d")
+
+        assertTrue(
+            com.qonversion.android.sdk.internal.storage.remoteConfigSnapshotStorageKey(first) !=
+                com.qonversion.android.sdk.internal.storage.remoteConfigSnapshotStorageKey(second),
+        )
+    }
+
+    private fun release(
+        uid: String,
+        number: Long,
+        values: Map<String, String>,
+        policy: RemoteConfigSnapshotApplyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+    ) = RemoteConfigSnapshotRelease(
+        releaseUid = uid,
+        releaseNumber = number,
+        manifestContentHash = "a".repeat(64),
+        entries = values.map { (key, value) ->
+            RemoteConfigSnapshotEntry.value(
+                key = key,
+                rawValue = value.encodeToByteArray(),
+                variationUid = "$uid-$key",
+                applyPolicy = policy,
+                metadata = null,
+            )
+        },
+    )
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/storage/PersistentRemoteConfigSnapshotStoreTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/storage/PersistentRemoteConfigSnapshotStoreTest.kt
@@ -1,0 +1,447 @@
+package com.qonversion.android.sdk.internal.storage
+
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotApplyPolicy
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotEntry
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotRelease
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotScope
+import com.qonversion.android.sdk.internal.remoteconfig.RemoteConfigSnapshotState
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class PersistentRemoteConfigSnapshotStoreTest {
+    private val cache = SnapshotInMemoryCache()
+    private val moshi = Moshi.Builder().build()
+    private val userA = RemoteConfigSnapshotScope("project", "production", "canonical-user-a")
+    private val userB = RemoteConfigSnapshotScope("project", "production", "canonical-user-b")
+
+    @Test
+    fun `candidate active and previous persist as one exact scoped versioned state`() {
+        val state = RemoteConfigSnapshotState(
+            candidate = release("three", 3, "candidate"),
+            active = release("two", 2, "active"),
+            previous = release("one", 1, "previous"),
+            didActivate = true,
+        )
+
+        assertTrue(store().save(userA, state))
+
+        assertEquals(1, cache.durableUpdates.size)
+        assertEquals(2, cache.durableUpdates.single().values.size)
+        assertTrue(cache.durableUpdates.single().values.containsKey(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY))
+        assertTrue(cache.durableUpdates.single().values.containsKey(remoteConfigSnapshotStorageKey(userA)))
+        val restarted = store().loadState(userA)
+        assertEquals("three", restarted?.candidate?.releaseUid)
+        assertEquals("two", restarted?.active?.releaseUid)
+        assertEquals("one", restarted?.previous?.releaseUid)
+        assertTrue(restarted?.didActivate == true)
+    }
+
+    @Test
+    fun `store isolates canonical users and never migrates or mutates legacy LKG`() {
+        cache.putString(LEGACY_LKG_KEY, "legacy-must-survive")
+        val store = store()
+
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+
+        assertNull(store.loadState(userB))
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+        assertEquals("legacy-must-survive", cache.getString(LEGACY_LKG_KEY, null))
+    }
+
+    @Test
+    fun `unknown or corrupt archive fails closed and clears only v2 storage`() {
+        cache.putString(LEGACY_LKG_KEY, "legacy-must-survive")
+        for (invalid in listOf(
+            "{not-json",
+            "{\"version\":999,\"records\":[]}",
+            "{\"version\":1,\"records\":[{\"unexpected\":true}]}",
+        )) {
+            val storageKey = remoteConfigSnapshotStorageKey(userA)
+            cache.putString(storageKey, invalid)
+            cache.putString(
+                REMOTE_CONFIG_SNAPSHOT_INDEX_KEY,
+                "{\"version\":1,\"storageKeys\":[\"$storageKey\"]}",
+            )
+
+            assertNull(store().loadState(userA))
+
+            assertNull(cache.getString(storageKey, null))
+            assertEquals("legacy-must-survive", cache.getString(LEGACY_LKG_KEY, null))
+        }
+    }
+
+    @Test
+    fun `failed durable save preserves prior whole state across restart`() {
+        val store = store()
+        val prior = RemoteConfigSnapshotState(
+            candidate = release("two", 2, "candidate"),
+            active = release("one", 1, "active"),
+            didActivate = true,
+        )
+        assertTrue(store.save(userA, prior))
+        cache.nextDurableUpdateResult = false
+
+        val replacement = RemoteConfigSnapshotState(
+            candidate = release("three", 3, "replacement"),
+            active = release("three", 3, "replacement"),
+            previous = release("one", 1, "active"),
+            didActivate = true,
+        )
+        assertFalse(store.save(userA, replacement))
+
+        val restarted = store().loadState(userA)
+        assertEquals("two", restarted?.candidate?.releaseUid)
+        assertEquals("one", restarted?.active?.releaseUid)
+        assertNull(restarted?.previous)
+    }
+
+    @Test
+    fun `oversized replacement is rejected before durable storage changes`() {
+        val store = PersistentRemoteConfigSnapshotStore(cache, moshi, maxStateBytes = 600)
+        val prior = RemoteConfigSnapshotState(candidate = release("one", 1, "small"))
+        assertTrue(store.save(userA, prior))
+        val writesBefore = cache.durableUpdates.size
+        val oversized = RemoteConfigSnapshotState(
+            candidate = release("two", 2, "x".repeat(2_000)),
+        )
+
+        assertFalse(store.save(userA, oversized))
+
+        assertEquals(writesBefore, cache.durableUpdates.size)
+        assertEquals("one", store().loadState(userA)?.candidate?.releaseUid)
+    }
+
+    @Test
+    fun `scope archive is bounded and evicts least recently used scope atomically`() {
+        val store = PersistentRemoteConfigSnapshotStore(cache, moshi, maxScopes = 2)
+        val userC = RemoteConfigSnapshotScope("project", "production", "canonical-user-c")
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "a"))))
+        assertTrue(store.save(userB, RemoteConfigSnapshotState(candidate = release("b", 1, "b"))))
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+        assertTrue(store.save(userC, RemoteConfigSnapshotState(candidate = release("c", 1, "c"))))
+
+        assertNull(store.loadState(userB))
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+        assertEquals("c", store.loadState(userC)?.candidate?.releaseUid)
+    }
+
+    @Test
+    fun `default scope archive retains exactly sixteen most recently used identities`() {
+        val store = store()
+        val users = List(17) { index ->
+            RemoteConfigSnapshotScope("project", "production", "canonical-user-$index")
+        }
+        users.take(16).forEachIndexed { index, scope ->
+            assertTrue(store.save(scope, RemoteConfigSnapshotState(candidate = release("r$index", 1, "$index"))))
+        }
+        assertEquals("r0", store.loadState(users.first())?.candidate?.releaseUid)
+
+        assertTrue(store.save(users.last(), RemoteConfigSnapshotState(candidate = release("r16", 1, "16"))))
+
+        assertNull(store.loadState(users[1]))
+        assertEquals("r0", store.loadState(users.first())?.candidate?.releaseUid)
+        assertEquals("r16", store.loadState(users.last())?.candidate?.releaseUid)
+    }
+
+    @Test
+    fun `saving another identity never rewrites the first identity payload`() {
+        val store = store()
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        cache.durableUpdates.clear()
+
+        assertTrue(store.save(userB, RemoteConfigSnapshotState(candidate = release("b", 1, "private-b"))))
+
+        val update = cache.durableUpdates.single()
+        assertFalse(update.values.containsKey(remoteConfigSnapshotStorageKey(userA)))
+        assertTrue(update.values.containsKey(remoteConfigSnapshotStorageKey(userB)))
+        assertTrue(update.values.containsKey(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY))
+    }
+
+    @Test
+    fun `untrusted index can never remove an unrelated preference`() {
+        val unrelatedKey = "customer_auth_token"
+        cache.putString(unrelatedKey, "must-survive")
+        cache.putString(
+            REMOTE_CONFIG_SNAPSHOT_INDEX_KEY,
+            "{\"version\":1,\"storageKeys\":[\"$unrelatedKey\"]}",
+        )
+
+        assertTrue(store().save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "a"))))
+
+        assertEquals("must-survive", cache.getString(unrelatedKey, null))
+        assertFalse(cache.durableUpdates.last().removedKeys.contains(unrelatedKey))
+    }
+
+    @Test
+    fun `envelope self declared scope cannot cross the requested privacy scope`() {
+        val store = store()
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        val userAKey = remoteConfigSnapshotStorageKey(userA)
+        cache.strings[userAKey] = requireNotNull(cache.strings[userAKey])
+            .replace("canonical-user-a", "canonical-user-b")
+
+        assertNull(store.loadState(userA))
+        assertNull(store.loadState(userB))
+    }
+
+    @Test
+    fun `oversized corrupt envelope cannot evict an admitted identity`() {
+        val userBKey = remoteConfigSnapshotStorageKey(userB)
+        val store = PersistentRemoteConfigSnapshotStore(cache, moshi, maxScopes = 2)
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        assertTrue(store.save(userB, RemoteConfigSnapshotState(candidate = release("b", 1, "private-b"))))
+        cache.strings[userBKey] = requireNotNull(cache.strings[userBKey])
+            .replace("canonical-user-b", "x".repeat(257))
+
+        assertNull(store.loadState(userB))
+
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+        assertNull(cache.getString(userBKey, null))
+    }
+
+    @Test
+    fun `saving a new identity evicts corrupt envelope before admitted identity`() {
+        val userC = RemoteConfigSnapshotScope("project", "production", "canonical-user-c")
+        val userBKey = remoteConfigSnapshotStorageKey(userB)
+        val store = PersistentRemoteConfigSnapshotStore(cache, moshi, maxScopes = 2)
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        assertTrue(store.save(userB, RemoteConfigSnapshotState(candidate = release("b", 1, "private-b"))))
+        cache.strings[userBKey] = requireNotNull(cache.strings[userBKey])
+            .replace("canonical-user-b", "x".repeat(257))
+
+        assertTrue(store.save(userC, RemoteConfigSnapshotState(candidate = release("c", 1, "private-c"))))
+
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+        assertNull(store.loadState(userB))
+        assertEquals("c", store.loadState(userC)?.candidate?.releaseUid)
+    }
+
+    @Test
+    fun `failed durable read promotion never blocks a valid snapshot`() {
+        val store = PersistentRemoteConfigSnapshotStore(cache, moshi, maxScopes = 2)
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        assertTrue(store.save(userB, RemoteConfigSnapshotState(candidate = release("b", 1, "private-b"))))
+        cache.nextDurableUpdateResult = false
+
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+        assertTrue(cache.nextDurableUpdateResult)
+    }
+
+    @Test
+    fun `transient index read failure never deletes admitted state`() {
+        val store = store()
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        cache.throwOnNextGet += REMOTE_CONFIG_SNAPSHOT_INDEX_KEY
+
+        val failedLoad = store.load(userA)
+        assertEquals(RemoteConfigSnapshotLoadStatus.Failed, failedLoad.status)
+        assertNull(failedLoad.state)
+
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+    }
+
+    @Test
+    fun `transient envelope read failure never deletes admitted state`() {
+        val store = store()
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        cache.throwOnNextGet += remoteConfigSnapshotStorageKey(userA)
+
+        val failedLoad = store.load(userA)
+        assertEquals(RemoteConfigSnapshotLoadStatus.Failed, failedLoad.status)
+        assertNull(failedLoad.state)
+
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+    }
+
+    @Test
+    fun `transient index read failure rejects save without orphaning admitted state`() {
+        val store = store()
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        cache.throwOnNextGet += REMOTE_CONFIG_SNAPSHOT_INDEX_KEY
+
+        assertFalse(store.save(userB, RemoteConfigSnapshotState(candidate = release("b", 1, "private-b"))))
+
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+        assertNull(store.loadState(userB))
+    }
+
+    @Test
+    fun `corrupt index is rebuilt from an exact valid envelope without losing state`() {
+        val store = store()
+        val storageKey = remoteConfigSnapshotStorageKey(userA)
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        cache.putString(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY, "{not-json")
+
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+
+        assertTrue(cache.getString(storageKey, null)?.isNotEmpty() == true)
+        assertEquals("a", store().loadState(userA)?.candidate?.releaseUid)
+    }
+
+    @Test
+    fun `missing index is rebuilt from an exact valid envelope without losing state`() {
+        val store = store()
+        assertTrue(store.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "private-a"))))
+        cache.remove(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY)
+
+        assertEquals("a", store.loadState(userA)?.candidate?.releaseUid)
+
+        assertEquals("a", store().loadState(userA)?.candidate?.releaseUid)
+    }
+
+    @Test
+    fun `corrupt candidate is discarded without erasing valid active and previous`() {
+        val store = store()
+        val storageKey = remoteConfigSnapshotStorageKey(userA)
+        val state = RemoteConfigSnapshotState(
+            candidate = release("three", 3, "candidate"),
+            active = release("two", 2, "active"),
+            previous = release("one", 1, "previous"),
+            didActivate = true,
+        )
+        assertTrue(store.save(userA, state))
+        cache.strings[storageKey] = requireNotNull(cache.strings[storageKey]).replace(
+            "\"releaseUid\":\"three\"",
+            "\"releaseUid\":\"${"x".repeat(37)}\"",
+        )
+
+        val salvaged = store.loadState(userA)
+
+        assertNull(salvaged?.candidate)
+        assertEquals("two", salvaged?.active?.releaseUid)
+        assertEquals("one", salvaged?.previous?.releaseUid)
+        val restarted = store().loadState(userA)
+        assertNull(restarted?.candidate)
+        assertEquals("two", restarted?.active?.releaseUid)
+        assertEquals("one", restarted?.previous?.releaseUid)
+    }
+
+    @Test
+    fun `equal number conflicting candidate is dropped and canonical active survives`() {
+        val store = store()
+        val storageKey = remoteConfigSnapshotStorageKey(userA)
+        val active = release("two", 2, "active")
+        assertTrue(
+            store.save(
+                userA,
+                RemoteConfigSnapshotState(
+                    candidate = active,
+                    active = active,
+                    previous = release("one", 1, "previous"),
+                    didActivate = true,
+                ),
+            ),
+        )
+        cache.strings[storageKey] = requireNotNull(cache.strings[storageKey]).replaceFirst(
+            "\"variationUid\":\"variation-two\"",
+            "\"variationUid\":\"variation-conflict\"",
+        )
+
+        val salvaged = store.loadState(userA)
+
+        assertNull(salvaged?.candidate)
+        assertEquals("two", salvaged?.active?.releaseUid)
+        assertEquals("variation-two", salvaged?.active?.entry("key")?.variationUid)
+        assertNull(store().loadState(userA)?.candidate)
+    }
+
+    @Test
+    fun `global persisted byte budget evicts least recently used envelopes`() {
+        val probe = store()
+        assertTrue(probe.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "a"))))
+        val oneEnvelopeBytes = requireNotNull(cache.strings[remoteConfigSnapshotStorageKey(userA)])
+            .toByteArray(Charsets.UTF_8).size
+        cache.strings.clear()
+        cache.durableUpdates.clear()
+        val userC = RemoteConfigSnapshotScope("project", "production", "canonical-user-c")
+        val boundedStore = PersistentRemoteConfigSnapshotStore(
+            cache = cache,
+            moshi = moshi,
+            maxTotalBytes = oneEnvelopeBytes * 2,
+        )
+        assertTrue(boundedStore.save(userA, RemoteConfigSnapshotState(candidate = release("a", 1, "a"))))
+        assertTrue(boundedStore.save(userB, RemoteConfigSnapshotState(candidate = release("b", 1, "b"))))
+
+        assertTrue(boundedStore.save(userC, RemoteConfigSnapshotState(candidate = release("c", 1, "c"))))
+
+        assertNull(boundedStore.loadState(userA))
+        assertEquals("b", boundedStore.loadState(userB)?.candidate?.releaseUid)
+        assertEquals("c", boundedStore.loadState(userC)?.candidate?.releaseUid)
+        val persistedBytes = listOf(userA, userB, userC).sumOf { scope ->
+            cache.strings[remoteConfigSnapshotStorageKey(scope)]?.toByteArray(Charsets.UTF_8)?.size ?: 0
+        }
+        assertTrue(persistedBytes <= oneEnvelopeBytes * 2)
+    }
+
+    private fun store() = PersistentRemoteConfigSnapshotStore(cache, moshi)
+
+    private fun PersistentRemoteConfigSnapshotStore.loadState(
+        scope: RemoteConfigSnapshotScope,
+    ): RemoteConfigSnapshotState? = load(scope).state
+
+    private fun release(uid: String, number: Long, value: String) = RemoteConfigSnapshotRelease(
+        releaseUid = uid,
+        releaseNumber = number,
+        manifestContentHash = "a".repeat(64),
+        entries = listOf(
+            RemoteConfigSnapshotEntry.value(
+                key = "key",
+                rawValue = "\"$value\"".encodeToByteArray(),
+                variationUid = "variation-$uid",
+                applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+                metadata = null,
+            ),
+        ),
+    )
+
+    private class SnapshotInMemoryCache : Cache {
+        data class DurableUpdate(val values: Map<String, String?>, val removedKeys: Set<String>)
+
+        val strings = mutableMapOf<String, String?>()
+        val durableUpdates = mutableListOf<DurableUpdate>()
+        var nextDurableUpdateResult = true
+        val throwOnNextGet = mutableSetOf<String>()
+        private val values = mutableMapOf<String, Any?>()
+
+        override fun putInt(key: String, value: Int) { values[key] = value }
+        override fun getInt(key: String, defValue: Int) = values[key] as? Int ?: defValue
+        override fun getBool(key: String, defValue: Boolean) = values[key] as? Boolean ?: defValue
+        override fun putBool(key: String, value: Boolean) { values[key] = value }
+        override fun putFloat(key: String, value: Float) { values[key] = value }
+        override fun getFloat(key: String, defValue: Float) = values[key] as? Float ?: defValue
+        override fun putLong(key: String, value: Long) { values[key] = value }
+        override fun getLong(key: String, defValue: Long) = values[key] as? Long ?: defValue
+        override fun putString(key: String, value: String?) { strings[key] = value }
+        override fun getString(key: String, defValue: String?): String? {
+            if (throwOnNextGet.remove(key)) error("transient read failure")
+            return strings[key] ?: defValue
+        }
+        override fun <T> putObject(key: String, value: T, adapter: JsonAdapter<T>) {
+            putString(key, adapter.toJson(value))
+        }
+        override fun <T> getObject(key: String, adapter: JsonAdapter<T>): T? =
+            getString(key, null)?.let(adapter::fromJson)
+        override fun remove(key: String) { strings.remove(key); values.remove(key) }
+        override fun updateStringsDurably(
+            values: Map<String, String?>,
+            removedKeys: Set<String>,
+        ): Boolean {
+            val result = nextDurableUpdateResult
+            nextDurableUpdateResult = true
+            if (!result) return false
+            durableUpdates += DurableUpdate(values.toMap(), removedKeys.toSet())
+            removedKeys.forEach(strings::remove)
+            strings.putAll(values)
+            return true
+        }
+    }
+
+    private companion object {
+        const val LEGACY_LKG_KEY = "qonversion_remote_config_lkg_index"
+    }
+}


### PR DESCRIPTION
## Summary
- add bounded immutable Candidate/Active/Previous snapshot state for Remote Config v2
- persist each identity scope atomically before changing memory or callbacks
- implement typed server -> previous cache -> bundled fallback resolution with tombstone safety
- fence identity changes and deliver non-empty updates in durable FIFO commit order
- salvage corrupt candidate slots while preserving admitted Active/Previous LKG

This is a dark internal foundation stacked on the bundled fallback PR. It does not expose a public fetch/activate API or change the legacy Remote Config path.

## Reliability evidence
- focused snapshot/core/store tests pass
- full debug/release test tasks pass
- detektAll passes
- sdk, nocodes, and sample debug assemblies pass
- independent adversarial review findings fixed: transient load overwrite, slot corruption, scope leakage, global storage budget, effective changed flag, scope-bound bundle, and concurrent/reentrant callback ordering

The aggregate sample release assemble still requires the repository's unavailable local release keystore; all SDK and available artifacts assemble successfully.