### PR TITLE
feat(remote-config): add resilient fetch policy

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/PersistentRemoteConfigFetchPolicyStore.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/PersistentRemoteConfigFetchPolicyStore.kt
@@ -1,0 +1,110 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.storage.Cache
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+
+private const val REMOTE_CONFIG_FETCH_POLICY_PREFIX = "qonversion_remote_config_v2_fetch_policy_"
+private const val REMOTE_CONFIG_FETCH_POLICY_VERSION = 1
+private const val REMOTE_CONFIG_FETCH_POLICY_MAX_BYTES = 1_024
+private const val REMOTE_CONFIG_FETCH_POLICY_MAX_FAILURES = 63
+
+internal class PersistentRemoteConfigFetchPolicyStore(
+    private val cache: Cache,
+    moshi: Moshi,
+) : RemoteConfigFetchPolicyStore {
+    private val adapter = moshi.adapter(PersistedRemoteConfigFetchPolicyState::class.java).failOnUnknown()
+
+    @Synchronized
+    @Suppress("ReturnCount")
+    override fun load(scope: RemoteConfigFetchPolicyScope): RemoteConfigFetchPolicyState? {
+        val key = remoteConfigFetchPolicyStorageKey(scope)
+        val raw = try {
+            cache.getString(key, null)
+        } catch (_: Exception) {
+            null
+        } ?: return null
+        val persisted = try {
+            raw.takeIf { it.toByteArray(Charsets.UTF_8).size <= REMOTE_CONFIG_FETCH_POLICY_MAX_BYTES }
+                ?.let(adapter::fromJson)
+        } catch (_: Exception) {
+            null
+        }
+        if (persisted == null || !persisted.isValid()) {
+            removeInvalid(key)
+            return null
+        }
+        return RemoteConfigFetchPolicyState(
+            lastSuccessfulFetchAtMillis = persisted.lastSuccessfulFetchAtMillis,
+            consecutiveRetryableFailures = persisted.consecutiveRetryableFailures,
+            nextAllowedFetchAtMillis = persisted.nextAllowedFetchAtMillis,
+        )
+    }
+
+    @Synchronized
+    @Suppress("ReturnCount")
+    override fun save(scope: RemoteConfigFetchPolicyScope, state: RemoteConfigFetchPolicyState): Boolean {
+        val persisted = PersistedRemoteConfigFetchPolicyState(
+            version = REMOTE_CONFIG_FETCH_POLICY_VERSION,
+            lastSuccessfulFetchAtMillis = state.lastSuccessfulFetchAtMillis,
+            consecutiveRetryableFailures = state.consecutiveRetryableFailures,
+            nextAllowedFetchAtMillis = state.nextAllowedFetchAtMillis,
+        )
+        if (!persisted.isValid()) return false
+        val raw = try {
+            adapter.toJson(persisted)
+        } catch (_: Exception) {
+            return false
+        }
+        if (raw.toByteArray(Charsets.UTF_8).size > REMOTE_CONFIG_FETCH_POLICY_MAX_BYTES) return false
+        return try {
+            cache.updateStringsDurably(
+                values = mapOf(remoteConfigFetchPolicyStorageKey(scope) to raw),
+                removedKeys = emptySet(),
+            )
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun PersistedRemoteConfigFetchPolicyState.isValid(): Boolean =
+        version == REMOTE_CONFIG_FETCH_POLICY_VERSION &&
+            lastSuccessfulFetchAtMillis >= 0 &&
+            consecutiveRetryableFailures in 0..REMOTE_CONFIG_FETCH_POLICY_MAX_FAILURES &&
+            nextAllowedFetchAtMillis >= 0
+
+    private fun removeInvalid(key: String) {
+        try {
+            cache.updateStringsDurably(emptyMap(), setOf(key))
+        } catch (_: Exception) {
+            // The malformed state remains untrusted even when best-effort cleanup fails.
+        }
+    }
+}
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigFetchPolicyState(
+    val version: Int,
+    @Json(name = "last_successful_fetch_at_millis")
+    val lastSuccessfulFetchAtMillis: Long,
+    @Json(name = "consecutive_retryable_failures")
+    val consecutiveRetryableFailures: Int,
+    @Json(name = "next_allowed_fetch_at_millis")
+    val nextAllowedFetchAtMillis: Long,
+)
+
+private fun remoteConfigFetchPolicyStorageKey(scope: RemoteConfigFetchPolicyScope): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.updateLengthPrefixed("remote-config-fetch-policy-v1".encodeToByteArray())
+    digest.updateLengthPrefixed(scope.projectKey.encodeToByteArray())
+    digest.updateLengthPrefixed(scope.environment.encodeToByteArray())
+    return REMOTE_CONFIG_FETCH_POLICY_PREFIX + digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+}
+
+private fun MessageDigest.updateLengthPrefixed(value: ByteArray) {
+    update(ByteBuffer.allocate(Int.SIZE_BYTES).putInt(value.size).array())
+    update(value)
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigFetchCoordinator.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigFetchCoordinator.kt
@@ -1,0 +1,623 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import java.util.ArrayDeque
+
+internal data class RemoteConfigFetchBinding(
+    val scope: RemoteConfigSnapshotScope,
+    val expectation: RemoteConfigSnapshotEnvelopeExpectation,
+) {
+    init {
+        require(scope.environment == expectation.environmentUid)
+    }
+}
+
+internal enum class RemoteConfigFetchForceReason {
+    Build,
+    Identify,
+    Logout,
+}
+
+internal data class RemoteConfigFetchPolicy(
+    val minimumFetchIntervalMillis: Long,
+    val timeoutMillis: Long? = null,
+    val initialBackoffMillis: Long = 1_000,
+    val maximumBackoffMillis: Long = 60_000,
+) {
+    init {
+        require(minimumFetchIntervalMillis >= 0)
+        require(timeoutMillis == null || timeoutMillis > 0)
+        require(initialBackoffMillis > 0)
+        require(maximumBackoffMillis >= initialBackoffMillis)
+    }
+}
+
+internal data class RemoteConfigFetchPolicyState(
+    val lastSuccessfulFetchAtMillis: Long = 0,
+    val consecutiveRetryableFailures: Int = 0,
+    val nextAllowedFetchAtMillis: Long = 0,
+)
+
+internal data class RemoteConfigFetchPolicyScope(
+    val projectKey: String,
+    val environment: String,
+) {
+    init {
+        require(projectKey.isNotEmpty())
+        require(environment.isNotEmpty())
+    }
+
+    companion object {
+        fun from(scope: RemoteConfigSnapshotScope) = RemoteConfigFetchPolicyScope(
+            projectKey = scope.projectKey,
+            environment = scope.environment,
+        )
+    }
+}
+
+internal interface RemoteConfigFetchPolicyStore {
+    fun load(scope: RemoteConfigFetchPolicyScope): RemoteConfigFetchPolicyState?
+    fun save(scope: RemoteConfigFetchPolicyScope, state: RemoteConfigFetchPolicyState): Boolean
+}
+
+internal fun interface RemoteConfigFetchClock {
+    fun nowMillis(): Long
+}
+
+internal fun interface RemoteConfigFetchRandom {
+    fun nextDouble(): Double
+}
+
+internal fun interface RemoteConfigFetchScheduledTask {
+    fun cancel()
+}
+
+internal fun interface RemoteConfigFetchScheduler {
+    fun schedule(delayMillis: Long, action: () -> Unit): RemoteConfigFetchScheduledTask
+}
+
+internal data class RemoteConfigFetchRequest(
+    val ifNoneMatch: String? = null,
+)
+
+internal sealed class RemoteConfigFetchResponse {
+    data class Success(val body: ByteArray, val etag: String) : RemoteConfigFetchResponse()
+    data class NotModified(val etag: String? = null) : RemoteConfigFetchResponse()
+    data class Failure(
+        val statusCode: Int? = null,
+        val retryAfterMillis: Long? = null,
+    ) : RemoteConfigFetchResponse()
+}
+
+internal fun interface RemoteConfigFetchTransport {
+    fun fetch(request: RemoteConfigFetchRequest, completion: (RemoteConfigFetchResponse) -> Unit)
+}
+
+internal sealed class RemoteConfigFetchResult {
+    data class Fetched(val transition: RemoteConfigSnapshotTransitionResult) : RemoteConfigFetchResult()
+    data object NotModified : RemoteConfigFetchResult()
+    data class Failed(val statusCode: Int?) : RemoteConfigFetchResult()
+    data class MinimumInterval(val nextAllowedAtMillis: Long) : RemoteConfigFetchResult()
+    data class Backoff(val nextAllowedAtMillis: Long) : RemoteConfigFetchResult()
+    data class TimedOut(val snapshot: RemoteConfigSnapshot) : RemoteConfigFetchResult()
+    data class PolicyPersistenceFailed(val result: RemoteConfigFetchResult) : RemoteConfigFetchResult()
+    data object InvalidNotModified : RemoteConfigFetchResult()
+    data object Superseded : RemoteConfigFetchResult()
+}
+
+internal class RemoteConfigFetchCoordinator(
+    private val core: RemoteConfigSnapshotCore,
+    private val transport: RemoteConfigFetchTransport,
+    private val policyStore: RemoteConfigFetchPolicyStore,
+    private val clock: RemoteConfigFetchClock,
+    private val random: RemoteConfigFetchRandom,
+    private val scheduler: RemoteConfigFetchScheduler,
+    private val policy: RemoteConfigFetchPolicy,
+    private val policyPersistenceFailureObserver: (RemoteConfigFetchPolicyScope) -> Unit = {},
+) {
+    private val lock = Any()
+    private val operationLock = Any()
+    private val deliveryLock = Any()
+    private val pendingDeliveries = ArrayDeque<PendingDelivery>()
+    private var isDrainingDeliveries = false
+    private var binding: RemoteConfigFetchBinding? = null
+    private var operationGeneration = 0L
+    private var inFlight: InFlight? = null
+    private var policyState = RemoteConfigFetchPolicyState()
+
+    fun transitionTo(nextBinding: RemoteConfigFetchBinding?) {
+        val persistenceFailure = synchronized(operationLock) {
+            synchronized(lock) {
+                operationGeneration = nextGeneration(operationGeneration)
+                binding = nextBinding
+                core.setScope(nextBinding?.scope)
+                val loaded = nextBinding?.let {
+                    loadPolicyState(RemoteConfigFetchPolicyScope.from(it.scope))
+                } ?: LoadedPolicyState(RemoteConfigFetchPolicyState())
+                policyState = loaded.state
+                val superseded = inFlight?.let { operation ->
+                    claimWaitersLocked(
+                        operation = operation,
+                        result = RemoteConfigFetchResult.Superseded,
+                    )
+                }.orEmpty()
+                inFlight = null
+                enqueueDeliveriesLocked(superseded)
+                convertQueuedDeliveriesToSupersededLocked(operationGeneration)
+                loaded.persistenceFailure
+            }
+        }
+        persistenceFailure?.let(::observePolicyPersistenceFailure)
+        drainDeliveries()
+    }
+
+    fun fetch(
+        forceReason: RemoteConfigFetchForceReason? = null,
+        callback: (RemoteConfigFetchResult) -> Unit,
+    ) {
+        val decision = synchronized(lock) { decideFetchLocked(forceReason, callback) }
+        decision.immediateResult?.let { result ->
+            enqueueImmediateResult(decision.generation, callback, result)
+            return
+        }
+        val operation = requireNotNull(decision.operation)
+        scheduleTimeout(operation, requireNotNull(decision.waiter))
+        if (decision.shouldStart) startAttempt(operation)
+    }
+
+    @Suppress("ReturnCount")
+    private fun decideFetchLocked(
+        forceReason: RemoteConfigFetchForceReason?,
+        callback: (RemoteConfigFetchResult) -> Unit,
+    ): FetchDecision {
+        inFlight?.takeIf { it.waiters.any { waiter -> !waiter.terminalClaimed } }?.let { current ->
+            return FetchDecision.joined(
+                generation = operationGeneration,
+                operation = current,
+                waiter = FetchWaiter(callback).also(current.waiters::add),
+            )
+        }
+        // A request with no live waiters continues in the transport, but a new caller owns a new
+        // admission token. This fences the zombie response without relying on HTTP cancellation.
+        inFlight = null
+        val currentBinding = binding
+            ?: return FetchDecision.immediate(operationGeneration, RemoteConfigFetchResult.Superseded)
+        fetchGateLocked(forceReason, nowMillis())?.let { gate ->
+            return FetchDecision.immediate(operationGeneration, gate)
+        }
+        val admission = core.beginAdmission(currentBinding.scope, currentBinding.expectation)
+            ?: return FetchDecision.immediate(
+                operationGeneration,
+                RemoteConfigFetchResult.Failed(statusCode = null),
+            )
+        val operation = InFlight(
+            generation = operationGeneration,
+            binding = currentBinding,
+            admission = admission,
+            waiters = mutableListOf(),
+            conditionalValidator = core.conditionalRequestValidator(),
+        )
+        val waiter = FetchWaiter(callback).also(operation.waiters::add)
+        inFlight = operation
+        return FetchDecision.started(operationGeneration, operation, waiter)
+    }
+
+    private fun fetchGateLocked(
+        forceReason: RemoteConfigFetchForceReason?,
+        now: Long,
+    ): RemoteConfigFetchResult? = when {
+        now < policyState.nextAllowedFetchAtMillis ->
+            RemoteConfigFetchResult.Backoff(policyState.nextAllowedFetchAtMillis)
+        shouldApplyMinimumInterval(forceReason, now) -> RemoteConfigFetchResult.MinimumInterval(
+            saturatingAdd(
+                policyState.lastSuccessfulFetchAtMillis,
+                policy.minimumFetchIntervalMillis,
+            ),
+        )
+        else -> null
+    }
+
+    private fun enqueueImmediateResult(
+        generation: Long,
+        callback: (RemoteConfigFetchResult) -> Unit,
+        result: RemoteConfigFetchResult,
+    ) {
+        synchronized(operationLock) {
+            synchronized(lock) {
+                val terminal = result.takeIf { generation == operationGeneration }
+                    ?: RemoteConfigFetchResult.Superseded
+                val waiter = FetchWaiter(callback).also { it.terminalClaimed = true }
+                enqueueDeliveriesLocked(listOf(PendingDelivery(generation, waiter, terminal)))
+            }
+        }
+        drainDeliveries()
+    }
+
+    private fun startAttempt(operation: InFlight) {
+        val attemptAndRequest = synchronized(lock) {
+            if (inFlight !== operation || operation.generation != operationGeneration) return
+            ++operation.attemptOrdinal to RemoteConfigFetchRequest(
+                ifNoneMatch = operation.conditionalValidator?.etag,
+            )
+        }
+        val (attempt, request) = attemptAndRequest
+        try {
+            transport.fetch(request) { response -> complete(operation, attempt, response) }
+        } catch (_: Throwable) {
+            complete(operation, attempt, RemoteConfigFetchResponse.Failure())
+        }
+    }
+
+    @Suppress("ComplexMethod", "ReturnCount")
+    private fun complete(
+        operation: InFlight,
+        attemptOrdinal: Long,
+        response: RemoteConfigFetchResponse,
+    ) {
+        var retry = false
+        var persistenceFailure: RemoteConfigFetchPolicyScope? = null
+        synchronized(operationLock) {
+            val notModifiedDisposition = if (response is RemoteConfigFetchResponse.NotModified) {
+                notModifiedDisposition(operation, attemptOrdinal, response)
+            } else {
+                NotModifiedDisposition.NotApplicable
+            }
+            if (notModifiedDisposition == NotModifiedDisposition.Ignore) return
+            if (notModifiedDisposition == NotModifiedDisposition.Retry) {
+                retry = true
+                return@synchronized
+            }
+            val isCurrent = synchronized(lock) { operation.isCurrentLocked(attemptOrdinal) }
+            if (!isCurrent) return
+
+            val outcome = responseOutcome(operation, response, notModifiedDisposition)
+            synchronized(lock) {
+                if (!operation.isCurrentLocked(attemptOrdinal)) return
+                outcome.nextPolicyState?.let { policyState = it }
+                val persisted = outcome.nextPolicyState?.let { state ->
+                    savePolicyState(operation.policyScope, state)
+                } ?: true
+                val terminalResult = if (persisted) {
+                    outcome.result
+                } else {
+                    persistenceFailure = operation.policyScope
+                    RemoteConfigFetchResult.PolicyPersistenceFailed(outcome.result)
+                }
+                inFlight = null
+                enqueueDeliveriesLocked(claimWaitersLocked(operation, terminalResult))
+            }
+        }
+        persistenceFailure?.let(::observePolicyPersistenceFailure)
+        if (retry) startAttempt(operation) else drainDeliveries()
+    }
+
+    private fun notModifiedDisposition(
+        operation: InFlight,
+        attemptOrdinal: Long,
+        response: RemoteConfigFetchResponse.NotModified,
+    ): NotModifiedDisposition = synchronized(lock) {
+        if (!operation.isCurrentLocked(attemptOrdinal)) {
+            return@synchronized NotModifiedDisposition.Ignore
+        }
+        val validator = operation.conditionalValidator
+        val responseMatchesRequest = response.etag == null || response.etag == validator?.etag
+        if (validator != null && responseMatchesRequest &&
+            core.isConditionalRequestValidatorCurrent(validator)
+        ) {
+            return@synchronized NotModifiedDisposition.Accept
+        }
+        if (operation.didRetryWithoutETag) return@synchronized NotModifiedDisposition.Reject
+        val refreshedAdmission = core.beginAdmission(operation.binding.scope, operation.binding.expectation)
+            ?: return@synchronized NotModifiedDisposition.Reject
+        operation.didRetryWithoutETag = true
+        operation.conditionalValidator = null
+        operation.admission = refreshedAdmission
+        NotModifiedDisposition.Retry
+    }
+
+    private fun responseOutcome(
+        operation: InFlight,
+        response: RemoteConfigFetchResponse,
+        notModifiedDisposition: NotModifiedDisposition,
+    ): ResponseOutcome = when (response) {
+        is RemoteConfigFetchResponse.Success -> {
+            val transition = core.admitCandidate(operation.admission, response.body, response.etag)
+            val succeeded = transition.status == RemoteConfigSnapshotTransitionStatus.Accepted ||
+                transition.status == RemoteConfigSnapshotTransitionStatus.Activated
+            ResponseOutcome(
+                result = RemoteConfigFetchResult.Fetched(transition),
+                nextPolicyState = RemoteConfigFetchPolicyState(lastSuccessfulFetchAtMillis = nowMillis())
+                    .takeIf { succeeded },
+            )
+        }
+        is RemoteConfigFetchResponse.NotModified -> if (notModifiedDisposition == NotModifiedDisposition.Accept) {
+            ResponseOutcome(
+                result = RemoteConfigFetchResult.NotModified,
+                nextPolicyState = RemoteConfigFetchPolicyState(lastSuccessfulFetchAtMillis = nowMillis()),
+            )
+        } else {
+            ResponseOutcome(RemoteConfigFetchResult.InvalidNotModified)
+        }
+        is RemoteConfigFetchResponse.Failure -> ResponseOutcome(
+            result = RemoteConfigFetchResult.Failed(response.statusCode),
+            nextPolicyState = retryableFailureState(response).takeIf { response.isRetryable() },
+        )
+    }
+
+    private fun scheduleTimeout(operation: InFlight, waiter: FetchWaiter) {
+        val timeoutMillis = policy.timeoutMillis ?: return
+        val task = try {
+            scheduler.schedule(timeoutMillis) { timeout(operation, waiter) }
+        } catch (_: Throwable) {
+            return
+        }
+        val retained = synchronized(lock) {
+            if (isLiveWaiterLocked(operation, waiter)) {
+                waiter.timeoutTask = task
+                true
+            } else {
+                false
+            }
+        }
+        if (!retained) task.cancelSafely()
+    }
+
+    private fun timeout(operation: InFlight, waiter: FetchWaiter) {
+        synchronized(operationLock) {
+            synchronized(lock) {
+                if (!isLiveWaiterLocked(operation, waiter) || !operation.waiters.remove(waiter)) {
+                    return
+                }
+                val snapshot = core.currentSnapshot()
+                waiter.terminalClaimed = true
+                enqueueDeliveriesLocked(
+                    listOf(
+                        PendingDelivery(
+                            generation = operation.generation,
+                            waiter = waiter,
+                            result = RemoteConfigFetchResult.TimedOut(snapshot),
+                        ),
+                    ),
+                )
+            }
+        }
+        drainDeliveries()
+    }
+
+    private fun claimWaitersLocked(
+        operation: InFlight,
+        result: RemoteConfigFetchResult,
+    ): List<PendingDelivery> = operation.waiters.mapNotNull { waiter ->
+        if (waiter.terminalClaimed) {
+            null
+        } else {
+            waiter.terminalClaimed = true
+            PendingDelivery(operation.generation, waiter, result)
+        }
+    }.also { operation.waiters.clear() }
+
+    private fun enqueueDeliveriesLocked(deliveries: Collection<PendingDelivery>) {
+        if (deliveries.isEmpty()) return
+        synchronized(deliveryLock) { pendingDeliveries.addAll(deliveries) }
+    }
+
+    private fun convertQueuedDeliveriesToSupersededLocked(currentGeneration: Long) {
+        synchronized(deliveryLock) {
+            pendingDeliveries.forEach { delivery ->
+                if (delivery.generation != currentGeneration) {
+                    delivery.result = RemoteConfigFetchResult.Superseded
+                }
+            }
+        }
+    }
+
+    private fun drainDeliveries() {
+        val ownsDrain = synchronized(deliveryLock) {
+            if (isDrainingDeliveries) {
+                false
+            } else {
+                isDrainingDeliveries = true
+                true
+            }
+        }
+        if (!ownsDrain) return
+        while (true) {
+            val delivery = synchronized(deliveryLock) {
+                pendingDeliveries.pollFirst() ?: run {
+                    isDrainingDeliveries = false
+                    return
+                }
+            }
+            delivery.waiter.timeoutTask?.cancelSafely()
+            try {
+                delivery.waiter.callback(delivery.result)
+            } catch (_: Throwable) {
+                // One consumer cannot undo a committed transition or starve claimed waiters.
+            }
+        }
+    }
+
+    private fun retryableFailureState(response: RemoteConfigFetchResponse.Failure): RemoteConfigFetchPolicyState {
+        val now = nowMillis()
+        val failureCount = (policyState.consecutiveRetryableFailures + 1).coerceAtMost(MAX_FAILURE_COUNT)
+        val jitterCap = exponentialBackoffCap(failureCount)
+        val randomValue = try {
+            random.nextDouble()
+        } catch (_: Throwable) {
+            SAFE_FALLBACK_JITTER
+        }
+        val jitter = randomValue.takeIf { it.isFinite() && it >= 0.0 && it < 1.0 }
+            ?: SAFE_FALLBACK_JITTER
+        val delay = response.retryAfterMillis
+            ?.takeIf { it >= 0 }
+            ?.coerceAtMost(policy.maximumBackoffMillis)
+            ?: (jitterCap.toDouble() * jitter).toLong().coerceAtLeast(MINIMUM_NONZERO_JITTER_MILLIS)
+        return policyState.copy(
+            consecutiveRetryableFailures = failureCount,
+            nextAllowedFetchAtMillis = saturatingAdd(now, delay),
+        )
+    }
+
+    private fun exponentialBackoffCap(failureCount: Int): Long {
+        var result = policy.initialBackoffMillis
+        repeat((failureCount - 1).coerceAtLeast(0)) {
+            result = if (result >= policy.maximumBackoffMillis / 2) {
+                policy.maximumBackoffMillis
+            } else {
+                (result * 2).coerceAtMost(policy.maximumBackoffMillis)
+            }
+        }
+        return result
+    }
+
+    private fun shouldApplyMinimumInterval(forceReason: RemoteConfigFetchForceReason?, now: Long): Boolean {
+        if (forceReason != null || policyState.lastSuccessfulFetchAtMillis <= 0 ||
+            now < policyState.lastSuccessfulFetchAtMillis
+        ) {
+            return false
+        }
+        return now < saturatingAdd(
+            policyState.lastSuccessfulFetchAtMillis,
+            policy.minimumFetchIntervalMillis,
+        )
+    }
+
+    @Suppress("ReturnCount")
+    private fun loadPolicyState(scope: RemoteConfigFetchPolicyScope): LoadedPolicyState {
+        val loaded = try {
+            policyStore.load(scope)
+        } catch (_: Throwable) {
+            null
+        } ?: return LoadedPolicyState(RemoteConfigFetchPolicyState())
+        val latestBoundedDeadline = saturatingAdd(nowMillis(), policy.maximumBackoffMillis)
+        if (loaded.nextAllowedFetchAtMillis <= latestBoundedDeadline) return LoadedPolicyState(loaded)
+        val sanitized = loaded.copy(nextAllowedFetchAtMillis = latestBoundedDeadline)
+        return LoadedPolicyState(
+            state = sanitized,
+            persistenceFailure = scope.takeUnless { savePolicyState(scope, sanitized) },
+        )
+    }
+
+    private fun savePolicyState(
+        scope: RemoteConfigFetchPolicyScope,
+        state: RemoteConfigFetchPolicyState,
+    ): Boolean = try {
+        policyStore.save(scope, state)
+    } catch (_: Throwable) {
+        false
+    }
+
+    private fun observePolicyPersistenceFailure(scope: RemoteConfigFetchPolicyScope) {
+        try {
+            policyPersistenceFailureObserver(scope)
+        } catch (_: Throwable) {
+            // Telemetry cannot alter the conservative in-process guard.
+        }
+    }
+
+    private fun nowMillis(): Long = try {
+        clock.nowMillis().coerceAtLeast(0)
+    } catch (_: Throwable) {
+        0
+    }
+
+    private fun RemoteConfigFetchScheduledTask.cancelSafely() {
+        try {
+            cancel()
+        } catch (_: Throwable) {
+            // Terminal claiming is independent of best-effort timer cancellation.
+        }
+    }
+
+    private fun RemoteConfigFetchResponse.Failure.isRetryable(): Boolean =
+        statusCode == HTTP_TOO_MANY_REQUESTS || statusCode in HTTP_SERVER_ERROR_MIN..HTTP_SERVER_ERROR_MAX
+
+    private fun InFlight.isCurrentLocked(attemptOrdinal: Long): Boolean =
+        inFlight === this && generation == operationGeneration && this.attemptOrdinal == attemptOrdinal
+
+    private fun isLiveWaiterLocked(operation: InFlight, waiter: FetchWaiter): Boolean {
+        val operationIsCurrent = inFlight === operation && operation.generation == operationGeneration
+        return operationIsCurrent && !waiter.terminalClaimed && operation.waiters.contains(waiter)
+    }
+
+    private data class ResponseOutcome(
+        val result: RemoteConfigFetchResult,
+        val nextPolicyState: RemoteConfigFetchPolicyState? = null,
+    )
+
+    private data class LoadedPolicyState(
+        val state: RemoteConfigFetchPolicyState,
+        val persistenceFailure: RemoteConfigFetchPolicyScope? = null,
+    )
+
+    private data class FetchDecision(
+        val generation: Long,
+        val immediateResult: RemoteConfigFetchResult? = null,
+        val operation: InFlight? = null,
+        val waiter: FetchWaiter? = null,
+        val shouldStart: Boolean = false,
+    ) {
+        companion object {
+            fun immediate(generation: Long, result: RemoteConfigFetchResult) =
+                FetchDecision(generation = generation, immediateResult = result)
+
+            fun joined(generation: Long, operation: InFlight, waiter: FetchWaiter) = FetchDecision(
+                generation = generation,
+                operation = operation,
+                waiter = waiter,
+            )
+
+            fun started(generation: Long, operation: InFlight, waiter: FetchWaiter) = FetchDecision(
+                generation = generation,
+                operation = operation,
+                waiter = waiter,
+                shouldStart = true,
+            )
+        }
+    }
+
+    private enum class NotModifiedDisposition {
+        NotApplicable,
+        Accept,
+        Retry,
+        Reject,
+        Ignore,
+    }
+
+    private data class InFlight(
+        val generation: Long,
+        val binding: RemoteConfigFetchBinding,
+        var admission: RemoteConfigSnapshotAdmissionToken,
+        val waiters: MutableList<FetchWaiter>,
+        var conditionalValidator: RemoteConfigConditionalRequestValidator?,
+        var attemptOrdinal: Long = 0,
+        var didRetryWithoutETag: Boolean = false,
+    ) {
+        val policyScope: RemoteConfigFetchPolicyScope = RemoteConfigFetchPolicyScope.from(binding.scope)
+    }
+
+    private class FetchWaiter(
+        val callback: (RemoteConfigFetchResult) -> Unit,
+        var timeoutTask: RemoteConfigFetchScheduledTask? = null,
+        var terminalClaimed: Boolean = false,
+    )
+
+    private data class PendingDelivery(
+        val generation: Long,
+        val waiter: FetchWaiter,
+        var result: RemoteConfigFetchResult,
+    )
+
+    private companion object {
+        const val MAX_FAILURE_COUNT = 63
+        const val HTTP_TOO_MANY_REQUESTS = 429
+        const val HTTP_SERVER_ERROR_MIN = 500
+        const val HTTP_SERVER_ERROR_MAX = 599
+        const val SAFE_FALLBACK_JITTER = 0.5
+        const val MINIMUM_NONZERO_JITTER_MILLIS = 1L
+
+        fun saturatingAdd(left: Long, right: Long): Long =
+            if (right > 0 && left > Long.MAX_VALUE - right) Long.MAX_VALUE else left + right
+
+        fun nextGeneration(current: Long): Long = if (current == Long.MAX_VALUE) 0 else current + 1
+    }
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshot.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshot.kt
@@ -132,6 +132,7 @@ internal class RemoteConfigSnapshotRelease(
 
     val entries: Map<String, RemoteConfigSnapshotEntry> get() = entriesByKey
     val canonicalBodyBytes: ByteArray? get() = storedCanonicalBody?.clone()
+    internal val hasCanonicalBody: Boolean get() = storedCanonicalBody != null
     val bodyDigest: String? get() = strongETag?.removeSurrounding("\"")
     internal val contentDigest: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
         calculateContentDigest()

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCore.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCore.kt
@@ -54,6 +54,12 @@ internal data class BoundRemoteConfigSnapshotAdmission(
     val expectation: RemoteConfigSnapshotEnvelopeExpectation,
 )
 
+internal data class RemoteConfigConditionalRequestValidator(
+    val etag: String,
+    val headAdmissionToken: Long,
+    val headContentDigest: String,
+)
+
 internal class RemoteConfigSnapshotCore(
     private val store: RemoteConfigSnapshotStore,
     private val bundledRelease: RemoteConfigScopedBundledRelease?,
@@ -98,6 +104,25 @@ internal class RemoteConfigSnapshotCore(
             snapshotFor(candidate, previous)
         }
     }
+
+    fun conditionalRequestValidator(): RemoteConfigConditionalRequestValidator? = synchronized(lock) {
+        conditionalHeadLocked()?.toConditionalRequestValidator()
+    }
+
+    fun isConditionalRequestValidatorCurrent(validator: RemoteConfigConditionalRequestValidator): Boolean =
+        synchronized(lock) {
+            conditionalHeadLocked()?.toConditionalRequestValidator() == validator
+        }
+
+    private fun conditionalHeadLocked(): RemoteConfigSnapshotRelease? = (state.candidate ?: state.active)
+        ?.takeIf { it.strongETag != null && it.hasCanonicalBody }
+
+    private fun RemoteConfigSnapshotRelease.toConditionalRequestValidator() =
+        RemoteConfigConditionalRequestValidator(
+            etag = requireNotNull(strongETag),
+            headAdmissionToken = admissionToken,
+            headContentDigest = contentDigest,
+        )
 
     fun addUpdateObserver(observer: (RemoteConfigSnapshotUpdate) -> Unit): Long = synchronized(lock) {
         val token = ++nextObserverToken

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/PersistentRemoteConfigFetchPolicyStoreTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/PersistentRemoteConfigFetchPolicyStoreTest.kt
@@ -1,0 +1,82 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.storage.Cache
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class PersistentRemoteConfigFetchPolicyStoreTest {
+    private val scope = RemoteConfigSnapshotScope("project-secret", "production", "customer-secret")
+    private val policyScope = RemoteConfigFetchPolicyScope.from(scope)
+
+    @Test
+    fun `policy state is durably scoped and survives a new store instance`() {
+        val cache = MapCache()
+        val first = store(cache)
+        val state = RemoteConfigFetchPolicyState(
+            lastSuccessfulFetchAtMillis = 12,
+            consecutiveRetryableFailures = 3,
+            nextAllowedFetchAtMillis = 34,
+        )
+
+        assertTrue(first.save(policyScope, state))
+        val persistedKey = cache.strings.keys.single()
+        assertFalse(persistedKey.contains("project-secret"))
+        assertFalse(persistedKey.contains("customer-secret"))
+
+        assertEquals(state, store(cache).load(policyScope))
+    }
+
+    @Test
+    fun `malformed or unbounded persisted policy is removed fail closed`() {
+        val cache = MapCache()
+        val policyStore = store(cache)
+        assertTrue(policyStore.save(policyScope, RemoteConfigFetchPolicyState()))
+        val persistedKey = cache.strings.keys.single()
+        cache.strings[persistedKey] =
+            "{\"version\":1,\"last_successful_fetch_at_millis\":0," +
+            "\"consecutive_retryable_failures\":999,\"next_allowed_fetch_at_millis\":0}"
+
+        assertNull(policyStore.load(policyScope))
+        assertFalse(cache.strings.containsKey(persistedKey))
+    }
+
+    private fun store(cache: Cache) = PersistentRemoteConfigFetchPolicyStore(
+        cache = cache,
+        moshi = Moshi.Builder().build(),
+    )
+
+    private class MapCache : Cache {
+        val strings = mutableMapOf<String, String?>()
+        private val longs = mutableMapOf<String, Long>()
+        private val ints = mutableMapOf<String, Int>()
+        private val bools = mutableMapOf<String, Boolean>()
+        private val floats = mutableMapOf<String, Float>()
+
+        override fun putInt(key: String, value: Int) { ints[key] = value }
+        override fun getInt(key: String, defValue: Int): Int = ints[key] ?: defValue
+        override fun getBool(key: String, defValue: Boolean): Boolean = bools[key] ?: defValue
+        override fun putBool(key: String, value: Boolean) { bools[key] = value }
+        override fun putFloat(key: String, value: Float) { floats[key] = value }
+        override fun getFloat(key: String, defValue: Float): Float = floats[key] ?: defValue
+        override fun putLong(key: String, value: Long) { longs[key] = value }
+        override fun getLong(key: String, defValue: Long): Long = longs[key] ?: defValue
+        override fun putString(key: String, value: String?) { strings[key] = value }
+        override fun getString(key: String, defValue: String?): String? = strings[key] ?: defValue
+        override fun <T> putObject(key: String, value: T, adapter: JsonAdapter<T>) {
+            strings[key] = adapter.toJson(value)
+        }
+        override fun <T> getObject(key: String, adapter: JsonAdapter<T>): T? =
+            strings[key]?.let(adapter::fromJson)
+        override fun remove(key: String) { strings.remove(key) }
+        override fun updateStringsDurably(values: Map<String, String?>, removedKeys: Set<String>): Boolean {
+            removedKeys.forEach(strings::remove)
+            strings.putAll(values)
+            return true
+        }
+    }
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigFetchCoordinatorTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigFetchCoordinatorTest.kt
@@ -1,0 +1,703 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadResult
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadStatus
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.MessageDigest
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class RemoteConfigFetchCoordinatorTest {
+    private val scope = RemoteConfigSnapshotScope("project", "production", "canonical-user")
+    private val binding = RemoteConfigFetchBinding(
+        scope = scope,
+        expectation = RemoteConfigSnapshotEnvelopeExpectation(
+            projectId = 42,
+            environmentUid = "production",
+            contextFingerprint = "a".repeat(64),
+        ),
+    )
+
+    @Test
+    fun `concurrent fetches coalesce into one transport request`() {
+        val transport = RecordingTransport()
+        val coordinator = coordinator(transport)
+        coordinator.transitionTo(binding)
+        val results = mutableListOf<RemoteConfigFetchResult>()
+
+        coordinator.fetch(callback = results::add)
+        coordinator.fetch(forceReason = RemoteConfigFetchForceReason.Identify, callback = results::add)
+
+        assertEquals(1, transport.requests.size)
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 400))
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun `minimum interval is persisted while an explicit lifecycle fetch bypasses it`() {
+        val transport = RecordingTransport()
+        val clock = MutableClock(1_000)
+        val policyStore = InMemoryFetchPolicyStore()
+        val coordinator = coordinator(
+            transport = transport,
+            clock = clock,
+            policyStore = policyStore,
+            policy = RemoteConfigFetchPolicy(minimumFetchIntervalMillis = 60_000),
+        )
+        coordinator.transitionTo(binding)
+        coordinator.fetch(callback = {})
+        transport.complete(success("first", 1))
+
+        val gated = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(callback = gated::add)
+        assertEquals(1, transport.requests.size)
+        assertTrue(gated.single() is RemoteConfigFetchResult.MinimumInterval)
+
+        coordinator.fetch(forceReason = RemoteConfigFetchForceReason.Build, callback = {})
+        assertEquals(2, transport.requests.size)
+    }
+
+    @Test
+    fun `retry after persists across restart and lifecycle force does not bypass backoff`() {
+        val transport = RecordingTransport()
+        val clock = MutableClock(1_000)
+        val policyStore = InMemoryFetchPolicyStore()
+        val policy = RemoteConfigFetchPolicy(
+            minimumFetchIntervalMillis = 0,
+            initialBackoffMillis = 1_000,
+            maximumBackoffMillis = 10_000,
+        )
+        val first = coordinator(transport, clock, policyStore, policy)
+        first.transitionTo(binding)
+        first.fetch(callback = {})
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 429, retryAfterMillis = 4_000))
+
+        val forced = mutableListOf<RemoteConfigFetchResult>()
+        first.fetch(forceReason = RemoteConfigFetchForceReason.Identify, callback = forced::add)
+        assertEquals(1, transport.requests.size)
+        assertEquals(5_000L, (forced.single() as RemoteConfigFetchResult.Backoff).nextAllowedAtMillis)
+
+        val restartedTransport = RecordingTransport()
+        val restarted = coordinator(restartedTransport, clock, policyStore, policy)
+        restarted.transitionTo(binding)
+        val beforeDeadline = mutableListOf<RemoteConfigFetchResult>()
+        restarted.fetch(callback = beforeDeadline::add)
+        assertTrue(beforeDeadline.single() is RemoteConfigFetchResult.Backoff)
+        assertEquals(0, restartedTransport.requests.size)
+
+        clock.now = 5_000
+        restarted.fetch(callback = {})
+        assertEquals(1, restartedTransport.requests.size)
+    }
+
+    @Test
+    fun `identify cannot evade project environment backoff by changing canonical identity`() {
+        val transport = RecordingTransport()
+        val clock = MutableClock(1_000)
+        val coordinator = coordinator(
+            transport = transport,
+            clock = clock,
+            policy = RemoteConfigFetchPolicy(
+                minimumFetchIntervalMillis = 0,
+                initialBackoffMillis = 1_000,
+                maximumBackoffMillis = 10_000,
+            ),
+        )
+        coordinator.transitionTo(binding)
+        coordinator.fetch(callback = {})
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 429, retryAfterMillis = 4_000))
+
+        coordinator.transitionTo(
+            binding.copy(
+                scope = RemoteConfigSnapshotScope("project", "production", "identified-user"),
+                expectation = binding.expectation.copy(contextFingerprint = "b".repeat(64)),
+            ),
+        )
+        val result = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(forceReason = RemoteConfigFetchForceReason.Identify, callback = result::add)
+
+        assertEquals(1, transport.requests.size)
+        assertEquals(5_000L, (result.single() as RemoteConfigFetchResult.Backoff).nextAllowedAtMillis)
+    }
+
+    @Test
+    fun `retryable failures use capped exponential full jitter and success resets it`() {
+        val transport = RecordingTransport()
+        val clock = MutableClock(1_000)
+        val random = MutableRandom(0.5)
+        val policyStore = InMemoryFetchPolicyStore()
+        val coordinator = coordinator(
+            transport = transport,
+            clock = clock,
+            random = random,
+            policyStore = policyStore,
+            policy = RemoteConfigFetchPolicy(
+                minimumFetchIntervalMillis = 0,
+                initialBackoffMillis = 1_000,
+                maximumBackoffMillis = 1_500,
+            ),
+        )
+        coordinator.transitionTo(binding)
+        coordinator.fetch(callback = {})
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 500))
+        assertEquals(
+            RemoteConfigFetchPolicyState(
+                consecutiveRetryableFailures = 1,
+                nextAllowedFetchAtMillis = 1_500,
+            ),
+            policyStore.load(RemoteConfigFetchPolicyScope.from(scope)),
+        )
+
+        clock.now = 1_500
+        random.value = Math.nextDown(1.0)
+        coordinator.fetch(callback = {})
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 503))
+        assertEquals(
+            2_999L,
+            policyStore.load(RemoteConfigFetchPolicyScope.from(scope))?.nextAllowedFetchAtMillis,
+        )
+
+        clock.now = 2_999
+        coordinator.fetch(callback = {})
+        transport.complete(success("recovered", 2))
+        assertEquals(
+            RemoteConfigFetchPolicyState(lastSuccessfulFetchAtMillis = 2_999),
+            policyStore.load(RemoteConfigFetchPolicyScope.from(scope)),
+        )
+    }
+
+    @Test
+    fun `timeout serves Active without cancelling request and late response persists Candidate`() {
+        val transport = RecordingTransport()
+        val scheduler = ManualScheduler()
+        val snapshotStore = InMemorySnapshotStore()
+        val bundle = RemoteConfigScopedBundledRelease(
+            projectKey = "project",
+            environment = "production",
+            release = release("bundle", 1, "0"),
+        )
+        val core = RemoteConfigSnapshotCore(snapshotStore, bundle)
+        val coordinator = coordinator(
+            transport = transport,
+            core = core,
+            scheduler = scheduler,
+            policy = RemoteConfigFetchPolicy(minimumFetchIntervalMillis = 0, timeoutMillis = 100),
+        )
+        coordinator.transitionTo(binding)
+        core.acceptCandidate(scope, release("active", 1, "1"))
+        core.activate()
+        val results = mutableListOf<RemoteConfigFetchResult>()
+
+        coordinator.fetch(callback = results::add)
+        scheduler.runNext()
+
+        val timedOut = results.single() as RemoteConfigFetchResult.TimedOut
+        assertEquals("1", timedOut.snapshot.rawValue("a")?.value?.decodeToString())
+        transport.complete(success("candidate", 2))
+        assertEquals(1, results.size)
+        assertEquals("1", core.currentSnapshot().rawValue("a")?.value?.decodeToString())
+        assertEquals("candidate", core.lastFetchedSnapshot()?.releaseUid)
+    }
+
+    @Test
+    fun `first fetch after every waiter timed out fences zombie operation without cancelling HTTP`() {
+        val transport = RecordingTransport()
+        val scheduler = ManualScheduler()
+        val core = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundledRelease = null)
+        val coordinator = coordinator(
+            transport = transport,
+            core = core,
+            scheduler = scheduler,
+            policy = RemoteConfigFetchPolicy(minimumFetchIntervalMillis = 0, timeoutMillis = 100),
+        )
+        coordinator.transitionTo(binding)
+        val first = mutableListOf<RemoteConfigFetchResult>()
+        val second = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(callback = first::add)
+        scheduler.runNext()
+
+        coordinator.fetch(forceReason = RemoteConfigFetchForceReason.Build, callback = second::add)
+
+        assertEquals(2, transport.requests.size)
+        transport.complete(success("late-zombie", 1))
+        assertEquals(null, core.lastFetchedSnapshot())
+        transport.complete(success("current", 2))
+        assertEquals("current", core.lastFetchedSnapshot()?.releaseUid)
+        assertTrue(second.single() is RemoteConfigFetchResult.Fetched)
+    }
+
+    @Test
+    fun `timeout falls through to matching bundled defaults when no Active exists`() {
+        val transport = RecordingTransport()
+        val scheduler = ManualScheduler()
+        val bundle = RemoteConfigScopedBundledRelease(
+            projectKey = "project",
+            environment = "production",
+            release = release("bundle", 1, "0"),
+        )
+        val core = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundle)
+        val coordinator = coordinator(
+            transport = transport,
+            core = core,
+            scheduler = scheduler,
+            policy = RemoteConfigFetchPolicy(minimumFetchIntervalMillis = 0, timeoutMillis = 100),
+        )
+        coordinator.transitionTo(binding)
+        val results = mutableListOf<RemoteConfigFetchResult>()
+
+        coordinator.fetch(callback = results::add)
+        scheduler.runNext()
+
+        val timedOut = results.single() as RemoteConfigFetchResult.TimedOut
+        assertEquals("0", timedOut.snapshot.rawValue("a")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `conditional fetch sends strong ETag only for an exact local canonical body`() {
+        val transport = RecordingTransport()
+        val core = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundledRelease = null)
+        val coordinator = coordinator(transport = transport, core = core)
+        coordinator.transitionTo(binding)
+        val first = success("first", 1)
+        coordinator.fetch(callback = {})
+        transport.complete(first)
+
+        val results = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(callback = results::add)
+
+        assertEquals(first.etag, transport.requests.last().ifNoneMatch)
+        transport.complete(RemoteConfigFetchResponse.NotModified(etag = first.etag))
+        assertTrue(results.single() is RemoteConfigFetchResult.NotModified)
+        assertEquals("first", core.lastFetchedSnapshot()?.releaseUid)
+    }
+
+    @Test
+    fun `conditional validator never falls through a noncanonical Candidate to canonical Active`() {
+        val transport = RecordingTransport()
+        val core = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundledRelease = null)
+        val coordinator = coordinator(transport = transport, core = core)
+        coordinator.transitionTo(binding)
+        coordinator.fetch(callback = {})
+        transport.complete(success("active", 1))
+        core.activate()
+        core.acceptCandidate(scope, release("local-candidate", 2, "2"))
+
+        coordinator.fetch(callback = {})
+
+        assertEquals(null, transport.requests.last().ifNoneMatch)
+    }
+
+    @Test
+    fun `304 validator invalidated by an intervening head retries once without ETag`() {
+        val transport = RecordingTransport()
+        val core = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundledRelease = null)
+        val coordinator = coordinator(transport = transport, core = core)
+        coordinator.transitionTo(binding)
+        val canonical = success("canonical", 1)
+        coordinator.fetch(callback = {})
+        transport.complete(canonical)
+        coordinator.fetch(callback = {})
+        assertEquals(canonical.etag, transport.requests.last().ifNoneMatch)
+
+        core.acceptCandidate(scope, release("intervening", 2, "2"))
+        transport.complete(RemoteConfigFetchResponse.NotModified(etag = canonical.etag))
+
+        assertEquals(3, transport.requests.size)
+        assertEquals(null, transport.requests.last().ifNoneMatch)
+        transport.complete(success("after-intervening", 3))
+        assertEquals("after-intervening", core.lastFetchedSnapshot()?.releaseUid)
+    }
+
+    @Test
+    fun `304 without matching canonical body retries exactly once without ETag`() {
+        val transport = RecordingTransport()
+        val core = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundledRelease = null)
+        val coordinator = coordinator(transport = transport, core = core)
+        coordinator.transitionTo(binding)
+        val results = mutableListOf<RemoteConfigFetchResult>()
+
+        coordinator.fetch(callback = results::add)
+        assertEquals(null, transport.requests.single().ifNoneMatch)
+        transport.complete(RemoteConfigFetchResponse.NotModified(etag = "\"${"f".repeat(64)}\""))
+
+        assertEquals(2, transport.requests.size)
+        assertEquals(null, transport.requests.last().ifNoneMatch)
+        assertTrue(results.isEmpty())
+        transport.complete(RemoteConfigFetchResponse.NotModified())
+        assertEquals(2, transport.requests.size)
+        assertTrue(results.single() is RemoteConfigFetchResult.InvalidNotModified)
+    }
+
+    @Test
+    fun `identity transition completes old waiters and fences the late response`() {
+        val transport = RecordingTransport()
+        val core = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundledRelease = null)
+        val coordinator = coordinator(transport = transport, core = core)
+        coordinator.transitionTo(binding)
+        val oldResults = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(callback = oldResults::add)
+
+        val nextBinding = binding.copy(
+            scope = RemoteConfigSnapshotScope("project", "production", "canonical-user-next"),
+            expectation = binding.expectation.copy(contextFingerprint = "b".repeat(64)),
+        )
+        coordinator.transitionTo(nextBinding)
+        assertEquals(listOf(RemoteConfigFetchResult.Superseded), oldResults)
+        transport.complete(success("late-private", 1))
+        assertEquals(null, core.lastFetchedSnapshot())
+
+        val nextResults = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(forceReason = RemoteConfigFetchForceReason.Identify, callback = nextResults::add)
+        transport.complete(success("wrong-context", 1))
+        val transition = (nextResults.single() as RemoteConfigFetchResult.Fetched).transition
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Rejected, transition.status)
+        assertEquals(null, core.lastFetchedSnapshot())
+    }
+
+    @Test
+    fun `same visible binding can be explicitly generation fenced on identify`() {
+        val transport = RecordingTransport()
+        val core = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundledRelease = null)
+        val coordinator = coordinator(transport = transport, core = core)
+        coordinator.transitionTo(binding)
+        val results = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(callback = results::add)
+
+        coordinator.transitionTo(binding)
+        transport.complete(success("stale", 1))
+
+        assertEquals(listOf(RemoteConfigFetchResult.Superseded), results)
+        assertEquals(null, core.lastFetchedSnapshot())
+    }
+
+    @Test
+    fun `identity transition waits for admitted response and its callback delivery boundary`() {
+        val parserStarted = CountDownLatch(1)
+        val releaseParser = CountDownLatch(1)
+        val parser = RemoteConfigSnapshotEnvelopeDecoder { body, etag, expectation ->
+            parserStarted.countDown()
+            assertTrue(releaseParser.await(2, TimeUnit.SECONDS))
+            RemoteConfigSnapshotEnvelopeParser().parse(body, etag, expectation)
+        }
+        val transport = RecordingTransport()
+        val core = RemoteConfigSnapshotCore(
+            store = InMemorySnapshotStore(),
+            bundledRelease = null,
+            envelopeParser = parser,
+        )
+        val coordinator = coordinator(transport = transport, core = core)
+        coordinator.transitionTo(binding)
+        val events = Collections.synchronizedList(mutableListOf<String>())
+        coordinator.fetch { events += "callback" }
+
+        val responseThread = Thread { transport.complete(success("admitted", 1)) }
+        responseThread.start()
+        assertTrue(parserStarted.await(2, TimeUnit.SECONDS))
+        val transitionFinished = CountDownLatch(1)
+        val transitionThread = Thread {
+            coordinator.transitionTo(null)
+            events += "transition"
+            transitionFinished.countDown()
+        }
+        transitionThread.start()
+
+        assertFalse(transitionFinished.await(100, TimeUnit.MILLISECONDS))
+        releaseParser.countDown()
+        responseThread.join(2_000)
+        transitionThread.join(2_000)
+        assertEquals(listOf("callback", "transition"), events)
+    }
+
+    @Test
+    fun `one throwing coalesced callback cannot starve the remaining waiters`() {
+        val transport = RecordingTransport()
+        val coordinator = coordinator(transport)
+        coordinator.transitionTo(binding)
+        val delivered = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch { throw AssertionError("consumer failure") }
+        coordinator.fetch(callback = delivered::add)
+
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 400))
+
+        assertTrue(delivered.single() is RemoteConfigFetchResult.Failed)
+    }
+
+    @Test
+    fun `reentrant identity transition converts every remaining claimed callback to Superseded`() {
+        val transport = RecordingTransport()
+        val coordinator = coordinator(transport)
+        coordinator.transitionTo(binding)
+        val first = mutableListOf<RemoteConfigFetchResult>()
+        val second = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch { result ->
+            first += result
+            coordinator.transitionTo(null)
+        }
+        coordinator.fetch(callback = second::add)
+
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 400))
+
+        assertTrue(first.single() is RemoteConfigFetchResult.Failed)
+        assertEquals(listOf(RemoteConfigFetchResult.Superseded), second)
+    }
+
+    @Test
+    fun `callback delivery holds no coordinator monitor needed by a concurrent transition`() {
+        val transport = RecordingTransport()
+        val coordinator = coordinator(transport)
+        coordinator.transitionTo(binding)
+        val transitionCompletedInsideCallback = AtomicBoolean(false)
+        coordinator.fetch {
+            val completed = CountDownLatch(1)
+            Thread {
+                coordinator.transitionTo(null)
+                completed.countDown()
+            }.start()
+            transitionCompletedInsideCallback.set(completed.await(2, TimeUnit.SECONDS))
+        }
+
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 400))
+
+        assertTrue(transitionCompletedInsideCallback.get())
+    }
+
+    @Test
+    fun `failed durable backoff is observable conservative in process and explicit after restart`() {
+        val transport = RecordingTransport()
+        val clock = MutableClock(1_000)
+        val policyStore = InMemoryFetchPolicyStore(saveSucceeds = false)
+        val policy = RemoteConfigFetchPolicy(
+            minimumFetchIntervalMillis = 0,
+            initialBackoffMillis = 1_000,
+            maximumBackoffMillis = 10_000,
+        )
+        val coordinator = coordinator(transport, clock, policyStore, policy)
+        coordinator.transitionTo(binding)
+        val failed = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(callback = failed::add)
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 500))
+
+        assertTrue(failed.single() is RemoteConfigFetchResult.PolicyPersistenceFailed)
+        val guarded = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(forceReason = RemoteConfigFetchForceReason.Build, callback = guarded::add)
+        assertTrue(guarded.single() is RemoteConfigFetchResult.Backoff)
+
+        val restartedTransport = RecordingTransport()
+        val restarted = coordinator(restartedTransport, clock, policyStore, policy)
+        restarted.transitionTo(binding)
+        restarted.fetch(callback = {})
+        assertEquals(1, restartedTransport.requests.size)
+    }
+
+    @Test
+    fun `transport and timeout scheduler failures still complete or continue the operation`() {
+        val transportFailure = coordinator(RemoteConfigFetchTransport { _, _ -> error("transport") })
+        transportFailure.transitionTo(binding)
+        val failed = mutableListOf<RemoteConfigFetchResult>()
+        transportFailure.fetch(callback = failed::add)
+        assertTrue(failed.single() is RemoteConfigFetchResult.Failed)
+
+        val transport = RecordingTransport()
+        val schedulerFailure = coordinator(
+            transport = transport,
+            scheduler = RemoteConfigFetchScheduler { _, _ -> error("scheduler") },
+            policy = RemoteConfigFetchPolicy(minimumFetchIntervalMillis = 0, timeoutMillis = 100),
+        )
+        schedulerFailure.transitionTo(binding)
+        val recovered = mutableListOf<RemoteConfigFetchResult>()
+        schedulerFailure.fetch(callback = recovered::add)
+        transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 400))
+        assertTrue(recovered.single() is RemoteConfigFetchResult.Failed)
+    }
+
+    @Test
+    fun `unbounded restored deadline is clamped to max and sanitized durably`() {
+        val transport = RecordingTransport()
+        val policyStore = InMemoryFetchPolicyStore().apply {
+            save(
+                RemoteConfigFetchPolicyScope.from(scope),
+                RemoteConfigFetchPolicyState(
+                    consecutiveRetryableFailures = 63,
+                    nextAllowedFetchAtMillis = Long.MAX_VALUE,
+                ),
+            )
+        }
+        val coordinator = coordinator(
+            transport = transport,
+            policyStore = policyStore,
+            policy = RemoteConfigFetchPolicy(
+                minimumFetchIntervalMillis = 0,
+                initialBackoffMillis = 1_000,
+                maximumBackoffMillis = 10_000,
+            ),
+        )
+        coordinator.transitionTo(binding)
+        val result = mutableListOf<RemoteConfigFetchResult>()
+        coordinator.fetch(callback = result::add)
+
+        assertEquals(0, transport.requests.size)
+        assertEquals(11_000L, (result.single() as RemoteConfigFetchResult.Backoff).nextAllowedAtMillis)
+        assertEquals(
+            11_000L,
+            policyStore.load(RemoteConfigFetchPolicyScope.from(scope))?.nextAllowedFetchAtMillis,
+        )
+    }
+
+    @Test
+    fun `invalid random sources always produce conservative nonzero jitter`() {
+        val randoms = listOf(
+            RemoteConfigFetchRandom { throw IllegalStateException("rng") },
+            RemoteConfigFetchRandom { Double.NaN },
+            RemoteConfigFetchRandom { -1.0 },
+            RemoteConfigFetchRandom { 1.0 },
+        )
+        randoms.forEach { invalidRandom ->
+            val transport = RecordingTransport()
+            val policyStore = InMemoryFetchPolicyStore()
+            val coordinator = coordinator(
+                transport = transport,
+                random = invalidRandom,
+                policyStore = policyStore,
+                policy = RemoteConfigFetchPolicy(
+                    minimumFetchIntervalMillis = 0,
+                    initialBackoffMillis = 1_000,
+                    maximumBackoffMillis = 10_000,
+                ),
+            )
+            coordinator.transitionTo(binding)
+            coordinator.fetch(callback = {})
+            transport.complete(RemoteConfigFetchResponse.Failure(statusCode = 500))
+            assertTrue(
+                requireNotNull(
+                    policyStore.load(RemoteConfigFetchPolicyScope.from(scope)),
+                ).nextAllowedFetchAtMillis > 1_000,
+            )
+        }
+    }
+
+    private fun coordinator(
+        transport: RemoteConfigFetchTransport,
+        clock: MutableClock = MutableClock(1_000),
+        policyStore: InMemoryFetchPolicyStore = InMemoryFetchPolicyStore(),
+        policy: RemoteConfigFetchPolicy = RemoteConfigFetchPolicy(minimumFetchIntervalMillis = 0),
+        random: RemoteConfigFetchRandom = MutableRandom(0.5),
+        core: RemoteConfigSnapshotCore = RemoteConfigSnapshotCore(InMemorySnapshotStore(), bundledRelease = null),
+        scheduler: RemoteConfigFetchScheduler = RemoteConfigFetchScheduler { _, _ ->
+            RemoteConfigFetchScheduledTask {}
+        },
+    ): RemoteConfigFetchCoordinator {
+        return RemoteConfigFetchCoordinator(
+            core = core,
+            transport = transport,
+            policyStore = policyStore,
+            clock = clock,
+            random = random,
+            scheduler = scheduler,
+            policy = policy,
+        )
+    }
+
+    private fun success(uid: String, number: Long): RemoteConfigFetchResponse.Success {
+        val body = wireBody(uid, number).encodeToByteArray()
+        return RemoteConfigFetchResponse.Success(body, strongETag(body))
+    }
+
+    private fun wireBody(uid: String, number: Long) =
+        "{\"schema_version\":1,\"project_id\":42,\"environment_uid\":\"production\"," +
+            "\"release_uid\":\"$uid\",\"release_number\":$number," +
+            "\"manifest_content_hash\":\"${number.toString(16).padStart(64, '0')}\"," +
+            "\"complete_key_set\":true,\"context_fingerprint\":\"${"a".repeat(64)}\"," +
+            "\"values\":{\"a\":{\"raw\":$number,\"variation_uid\":\"variation-$uid\"," +
+            "\"apply_policy\":\"on_next_activate\",\"metadata\":null}}}"
+
+    private fun strongETag(body: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(body)
+        .joinToString(prefix = "\"", postfix = "\"", separator = "") { byte -> "%02x".format(byte) }
+
+    private fun release(uid: String, number: Long, value: String) = RemoteConfigSnapshotRelease(
+        releaseUid = uid,
+        releaseNumber = number,
+        manifestContentHash = number.toString(16).padStart(64, '0'),
+        entries = listOf(
+            RemoteConfigSnapshotEntry.value(
+                key = "a",
+                rawValue = value.encodeToByteArray(),
+                variationUid = "variation-$uid",
+                applyPolicy = RemoteConfigSnapshotApplyPolicy.OnNextActivate,
+                metadata = null,
+            ),
+        ),
+    )
+
+    private class MutableClock(var now: Long) : RemoteConfigFetchClock {
+        override fun nowMillis(): Long = now
+    }
+
+    private class MutableRandom(var value: Double) : RemoteConfigFetchRandom {
+        override fun nextDouble(): Double = value
+    }
+
+    private class ManualScheduler : RemoteConfigFetchScheduler {
+        private val tasks = mutableListOf<Task>()
+
+        override fun schedule(delayMillis: Long, action: () -> Unit): RemoteConfigFetchScheduledTask {
+            val task = Task(action)
+            tasks += task
+            return RemoteConfigFetchScheduledTask { task.cancelled = true }
+        }
+
+        fun runNext() {
+            val task = tasks.removeAt(0)
+            if (!task.cancelled) task.action()
+        }
+
+        private data class Task(val action: () -> Unit, var cancelled: Boolean = false)
+    }
+
+    private class RecordingTransport : RemoteConfigFetchTransport {
+        val requests = mutableListOf<RemoteConfigFetchRequest>()
+        private val completions = mutableListOf<(RemoteConfigFetchResponse) -> Unit>()
+
+        override fun fetch(
+            request: RemoteConfigFetchRequest,
+            completion: (RemoteConfigFetchResponse) -> Unit,
+        ) {
+            requests += request
+            completions += completion
+        }
+
+        fun complete(response: RemoteConfigFetchResponse) = completions.removeAt(0)(response)
+    }
+
+    private class InMemoryFetchPolicyStore(
+        private val saveSucceeds: Boolean = true,
+    ) : RemoteConfigFetchPolicyStore {
+        private val states = mutableMapOf<RemoteConfigFetchPolicyScope, RemoteConfigFetchPolicyState>()
+
+        override fun load(scope: RemoteConfigFetchPolicyScope): RemoteConfigFetchPolicyState? = states[scope]
+
+        override fun save(scope: RemoteConfigFetchPolicyScope, state: RemoteConfigFetchPolicyState): Boolean {
+            if (saveSucceeds) states[scope] = state
+            return saveSucceeds
+        }
+    }
+
+    private class InMemorySnapshotStore : RemoteConfigSnapshotStore {
+        private val states = mutableMapOf<RemoteConfigSnapshotScope, RemoteConfigSnapshotState>()
+
+        override fun load(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotLoadResult =
+            states[scope]?.let { RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Found, it) }
+                ?: RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Missing)
+
+        override fun save(scope: RemoteConfigSnapshotScope, state: RemoteConfigSnapshotState): Boolean {
+            states[scope] = state
+            return true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the internal/dark Android Remote Config fetch coordinator on top of #861. It does not add a public endpoint, caller-supplied `user_id`, or identity-session protocol.

- concurrent request coalescing and configurable minimum interval
- optional timeout returns best Active/bundle while the network request continues
- persisted capped exponential backoff with full jitter and normalized Retry-After precedence
- build/identify/logout force triggers without bypassing incident backoff
- exact current-head ETag/304 contract and one unconditional retry when local canonical bytes are missing or stale
- identity/scope/admission fencing for late responses

## Reliability review fixes

Independent adversarial review found and this PR fixes:

- orphaned transport requests permanently absorbing future fetches
- callbacks executed under locks / lost after reentrant identity transition
- 304 validating a Previous rather than current head
- silent policy persistence failure causing restart stampedes
- fail-open jitter/deadline handling

Late orphan responses are fenced but the underlying HTTP operation is not cancelled, matching the client timeout contract. Backoff is scoped by project+environment so an identity change cannot bypass a 429/5xx incident budget.

## Verification

- independent re-review: CLEAN
- focused fetch/store/core tests: 24/24
- full debug unit tests: 342, zero failures/errors
- full author gate: `:sdk:test detektAll :sdk:assemble`, 80 tasks, debug+release, green
- detekt: zero findings
- git diff --check

## Deliberate boundaries

Transport receives an already normalized `retryAfterMillis`; raw HTTP Retry-After parsing belongs to the future HTTP adapter. Public fetch stays closed until project/environment/canonical identity are bound by the opaque identity-session foundation and signed identity assertion.