### PR TITLE
Remote Config v2: guard reads before activation

### DIFF
--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigReadGuard.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigReadGuard.kt
@@ -1,0 +1,396 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadResult
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadStatus
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotStore
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal const val REMOTE_CONFIG_READ_BEFORE_ACTIVATE_MESSAGE =
+    "Remote Config was read before activate(). Call activate() after SDK initialization and before reading current values."
+
+internal enum class RemoteConfigReadBuildMode {
+    Debug,
+    Release,
+}
+
+internal fun interface RemoteConfigReadAssertion {
+    fun fail(message: String)
+}
+
+internal enum class RemoteConfigReadGuardEvent {
+    ReadBeforeActivate,
+    ImplicitActivation,
+    PreloadNotReady,
+    PreloadFailed,
+    PreloadCorrupt,
+    ActivationPersistenceFailed,
+}
+
+internal fun interface RemoteConfigReadTelemetry {
+    fun report(event: RemoteConfigReadGuardEvent)
+}
+
+internal enum class RemoteConfigReadPreloadStatus {
+    Ready,
+    Failed,
+    Corrupt,
+    PersistenceFailed,
+}
+
+internal data class RemoteConfigReadPreloadResult(
+    val status: RemoteConfigReadPreloadStatus,
+    val baseState: RemoteConfigSnapshotState? = null,
+    val preparedActivationState: RemoteConfigSnapshotState? = null,
+) {
+    init {
+        when (status) {
+            RemoteConfigReadPreloadStatus.Ready -> require(baseState != null)
+            RemoteConfigReadPreloadStatus.PersistenceFailed -> {
+                require(baseState != null && preparedActivationState == null)
+            }
+            RemoteConfigReadPreloadStatus.Failed,
+            RemoteConfigReadPreloadStatus.Corrupt,
+            -> require(baseState == null && preparedActivationState == null)
+        }
+    }
+}
+
+internal interface RemoteConfigReadPreloader {
+    fun preload(
+        scope: RemoteConfigSnapshotScope,
+        prepareImplicitActivation: Boolean,
+        completion: (RemoteConfigReadPreloadResult) -> Unit,
+    )
+}
+
+internal class PersistentRemoteConfigReadPreloader(
+    private val store: RemoteConfigSnapshotStore,
+    private val executor: Executor,
+) : RemoteConfigReadPreloader {
+    override fun preload(
+        scope: RemoteConfigSnapshotScope,
+        prepareImplicitActivation: Boolean,
+        completion: (RemoteConfigReadPreloadResult) -> Unit,
+    ) {
+        val delivered = AtomicBoolean(false)
+        fun deliver(result: RemoteConfigReadPreloadResult) {
+            if (!delivered.compareAndSet(false, true)) return
+            try {
+                completion(result)
+            } catch (_: Exception) {
+                // The preload is terminal even if its internal lifecycle callback throws.
+            }
+        }
+        try {
+            executor.execute {
+                deliver(load(scope, prepareImplicitActivation))
+            }
+        } catch (_: Exception) {
+            deliver(RemoteConfigReadPreloadResult(RemoteConfigReadPreloadStatus.Failed))
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun load(
+        scope: RemoteConfigSnapshotScope,
+        prepareImplicitActivation: Boolean,
+    ): RemoteConfigReadPreloadResult {
+        val loaded = try {
+            store.load(scope)
+        } catch (_: Exception) {
+            RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Failed)
+        }
+        val baseState = when (loaded.status) {
+            RemoteConfigSnapshotLoadStatus.Found -> requireNotNull(loaded.state)
+            RemoteConfigSnapshotLoadStatus.Missing -> RemoteConfigSnapshotState()
+            RemoteConfigSnapshotLoadStatus.Failed -> {
+                return RemoteConfigReadPreloadResult(RemoteConfigReadPreloadStatus.Failed)
+            }
+            RemoteConfigSnapshotLoadStatus.Corrupt -> {
+                return RemoteConfigReadPreloadResult(RemoteConfigReadPreloadStatus.Corrupt)
+            }
+        }
+        if (!prepareImplicitActivation) {
+            return RemoteConfigReadPreloadResult(
+                status = RemoteConfigReadPreloadStatus.Ready,
+                baseState = baseState,
+            )
+        }
+        val preparedState = baseState.preparedActivationState()
+        return RemoteConfigReadPreloadResult(
+            status = RemoteConfigReadPreloadStatus.Ready,
+            baseState = baseState,
+            preparedActivationState = preparedState,
+        )
+    }
+}
+
+@Suppress("ReturnCount")
+internal fun RemoteConfigSnapshotState.preparedActivationState(): RemoteConfigSnapshotState {
+    val nextCandidate = candidate
+    if (nextCandidate == null) return if (didActivate) this else copy(didActivate = true)
+    if (didActivate && active?.admissionToken == nextCandidate.admissionToken) return this
+    return RemoteConfigSnapshotState(
+        candidate = nextCandidate,
+        active = nextCandidate,
+        previous = active,
+        didActivate = true,
+        latestAdmissionToken = latestAdmissionToken,
+    )
+}
+
+internal class RemoteConfigReadGuard(
+    private val core: RemoteConfigSnapshotCore,
+    private val preloader: RemoteConfigReadPreloader,
+    private val buildMode: RemoteConfigReadBuildMode,
+    private val assertion: RemoteConfigReadAssertion,
+    private val telemetry: RemoteConfigReadTelemetry,
+) {
+    private val lock = Any()
+    private var preloadToken: RemoteConfigScopePreloadToken? = null
+    private var preloadResult: RemoteConfigReadPreloadResult? = null
+    private var firstReadHandled = false
+    private var didConsumeImplicitActivation = false
+    private var firstReadCommitBarrier: CountDownLatch? = null
+    private var firstReadCommitOwner: Thread? = null
+    private val reportedEvents = mutableSetOf<RemoteConfigReadGuardEvent>()
+
+    fun transitionScopeBeforeSdkReady(
+        scope: RemoteConfigSnapshotScope?,
+        onReady: () -> Unit = {},
+    ) {
+        val prepareImplicitActivation = synchronized(lock) {
+            buildMode == RemoteConfigReadBuildMode.Release && !didConsumeImplicitActivation
+        }
+        val token = core.beginScopePreload(
+            scope = scope,
+            armFirstReadActivation = prepareImplicitActivation,
+        ) { boundToken ->
+            synchronized(lock) {
+                firstReadHandled = false
+                preloadResult = null
+                reportedEvents.clear()
+                preloadToken = boundToken
+            }
+        }
+        if (scope == null || token == null) {
+            safelyInvoke(onReady)
+            return
+        }
+        preloader.preload(
+            scope = scope,
+            prepareImplicitActivation = prepareImplicitActivation,
+        ) { result ->
+            completePreload(token, result, onReady)
+        }
+    }
+
+    fun currentSnapshot(): RemoteConfigSnapshot {
+        val events = mutableListOf<RemoteConfigReadGuardEvent>()
+        var decision = FirstReadDecision()
+        var waitForCommit: CountDownLatch?
+        do {
+            waitForCommit = null
+            synchronized(lock) {
+                val currentBarrier = firstReadCommitBarrier
+                if (currentBarrier != null && firstReadCommitOwner !== Thread.currentThread()) {
+                    waitForCommit = currentBarrier
+                } else {
+                    decision = claimFirstReadLocked(events)
+                }
+            }
+            waitForCommit?.awaitUninterruptibly()
+        } while (waitForCommit != null)
+        val claimedToken = decision.claimedToken
+        if (claimedToken != null) {
+            val barrier = requireNotNull(decision.claimedBarrier)
+            val transition = try {
+                core.commitPrepersistedActivationWithoutDelivery(claimedToken)
+            } finally {
+                completeFirstReadCommit(barrier)
+            }
+            core.deliverPendingUpdates()
+            if (transition.status == RemoteConfigSnapshotTransitionStatus.Activated) {
+                events += RemoteConfigReadGuardEvent.ImplicitActivation
+            }
+        }
+        val snapshot = core.currentSnapshot()
+        report(events)
+        decision.assertionMessage?.let { message -> assertion.fail(message) }
+        return snapshot
+    }
+
+    private data class FirstReadDecision(
+        val assertionMessage: String? = null,
+        val claimedToken: RemoteConfigScopePreloadToken? = null,
+        val claimedBarrier: CountDownLatch? = null,
+    )
+
+    private fun claimFirstReadLocked(
+        events: MutableList<RemoteConfigReadGuardEvent>,
+    ): FirstReadDecision = if (firstReadHandled) {
+        FirstReadDecision()
+    } else {
+        firstReadHandled = true
+        claimEvent(RemoteConfigReadGuardEvent.ReadBeforeActivate, events)
+        when {
+            buildMode == RemoteConfigReadBuildMode.Debug -> {
+                FirstReadDecision(assertionMessage = REMOTE_CONFIG_READ_BEFORE_ACTIVATE_MESSAGE)
+            }
+            didConsumeImplicitActivation -> FirstReadDecision()
+            else -> claimImplicitActivationLocked(events)
+        }
+    }
+
+    private fun claimImplicitActivationLocked(
+        events: MutableList<RemoteConfigReadGuardEvent>,
+    ): FirstReadDecision {
+        val token = preloadToken
+        return when (core.claimImplicitActivationOpportunity(token)) {
+            RemoteConfigImplicitActivationClaimStatus.Stale -> FirstReadDecision()
+            RemoteConfigImplicitActivationClaimStatus.AlreadyConsumed -> {
+                didConsumeImplicitActivation = true
+                FirstReadDecision()
+            }
+            RemoteConfigImplicitActivationClaimStatus.Claimed -> {
+                didConsumeImplicitActivation = true
+                if (preloadResult == null) {
+                    claimEvent(RemoteConfigReadGuardEvent.PreloadNotReady, events)
+                }
+                val barrier = CountDownLatch(1)
+                firstReadCommitBarrier = barrier
+                firstReadCommitOwner = Thread.currentThread()
+                FirstReadDecision(
+                    claimedToken = requireNotNull(token),
+                    claimedBarrier = barrier,
+                )
+            }
+        }
+    }
+
+    fun activate(): RemoteConfigSnapshotTransitionResult {
+        val token = synchronized(lock) {
+            firstReadHandled = true
+            preloadToken
+        }
+        when (core.claimImplicitActivationOpportunity(token)) {
+            RemoteConfigImplicitActivationClaimStatus.Stale -> Unit
+            RemoteConfigImplicitActivationClaimStatus.AlreadyConsumed,
+            RemoteConfigImplicitActivationClaimStatus.Claimed,
+            -> synchronized(lock) { didConsumeImplicitActivation = true }
+        }
+        if (token != null) {
+            val prepared = core.commitPrepersistedActivation(token)
+            if (prepared.status != RemoteConfigSnapshotTransitionStatus.Ignored) return prepared
+        }
+        return core.activateForPreloadToken(token)
+    }
+
+    private fun completePreload(
+        token: RemoteConfigScopePreloadToken,
+        result: RemoteConfigReadPreloadResult,
+        onReady: () -> Unit,
+    ) {
+        val events = mutableListOf<RemoteConfigReadGuardEvent>()
+        val isCurrent = synchronized(lock) {
+            if (preloadToken !== token) return@synchronized false
+            if (!firstReadHandled) {
+                var effectiveResult = result
+                when (result.status) {
+                    RemoteConfigReadPreloadStatus.Ready,
+                    RemoteConfigReadPreloadStatus.PersistenceFailed,
+                    -> {
+                        val baseState = requireNotNull(result.baseState)
+                        when (
+                            core.installPreloadedScope(
+                                token,
+                                baseState,
+                                result.preparedActivationState,
+                            )
+                        ) {
+                            RemoteConfigScopePreloadInstallStatus.Ignored -> return@synchronized false
+                            RemoteConfigScopePreloadInstallStatus.PersistenceFailed -> {
+                                effectiveResult = RemoteConfigReadPreloadResult(
+                                    status = RemoteConfigReadPreloadStatus.PersistenceFailed,
+                                    baseState = baseState,
+                                )
+                            }
+                            RemoteConfigScopePreloadInstallStatus.Superseded -> Unit
+                            RemoteConfigScopePreloadInstallStatus.Installed -> Unit
+                        }
+                    }
+                    RemoteConfigReadPreloadStatus.Failed,
+                    RemoteConfigReadPreloadStatus.Corrupt,
+                    -> Unit
+                }
+                preloadResult = effectiveResult
+                when (effectiveResult.status) {
+                    RemoteConfigReadPreloadStatus.Failed -> {
+                        claimEvent(RemoteConfigReadGuardEvent.PreloadFailed, events)
+                    }
+                    RemoteConfigReadPreloadStatus.Corrupt -> {
+                        claimEvent(RemoteConfigReadGuardEvent.PreloadCorrupt, events)
+                    }
+                    RemoteConfigReadPreloadStatus.PersistenceFailed -> {
+                        claimEvent(RemoteConfigReadGuardEvent.ActivationPersistenceFailed, events)
+                    }
+                    RemoteConfigReadPreloadStatus.Ready -> Unit
+                }
+            }
+            true
+        }
+        if (!isCurrent) return
+        report(events)
+        safelyInvoke(onReady)
+    }
+
+    private fun claimEvent(
+        event: RemoteConfigReadGuardEvent,
+        claimed: MutableList<RemoteConfigReadGuardEvent>,
+    ) {
+        if (reportedEvents.add(event)) claimed += event
+    }
+
+    private fun report(events: List<RemoteConfigReadGuardEvent>) {
+        events.forEach { event ->
+            try {
+                telemetry.report(event)
+            } catch (_: Exception) {
+                // Telemetry can never affect serving state.
+            }
+        }
+    }
+
+    private fun safelyInvoke(callback: () -> Unit) {
+        try {
+            callback()
+        } catch (_: Exception) {
+            // SDK readiness is terminal even if an internal lifecycle callback throws.
+        }
+    }
+
+    private fun completeFirstReadCommit(barrier: CountDownLatch) {
+        synchronized(lock) {
+            if (firstReadCommitBarrier === barrier) {
+                firstReadCommitBarrier = null
+                firstReadCommitOwner = null
+            }
+        }
+        barrier.countDown()
+    }
+
+    private fun CountDownLatch.awaitUninterruptibly() {
+        var interrupted = false
+        while (true) {
+            try {
+                await()
+                break
+            } catch (_: InterruptedException) {
+                interrupted = true
+            }
+        }
+        if (interrupted) Thread.currentThread().interrupt()
+    }
+}

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCore.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCore.kt
@@ -5,6 +5,8 @@ import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadStatu
 import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotStore
 import java.util.ArrayDeque
 import java.util.UUID
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 internal enum class RemoteConfigSnapshotTransitionStatus {
     Accepted,
@@ -47,6 +49,37 @@ internal class RemoteConfigSnapshotAdmissionToken private constructor(
     }
 }
 
+internal class RemoteConfigScopePreloadToken private constructor(
+    private val ownerNonce: UUID,
+    internal val scope: RemoteConfigSnapshotScope,
+    internal val scopeGeneration: Long,
+    internal val installEpoch: Long,
+) {
+    internal fun belongsTo(ownerNonce: UUID): Boolean = this.ownerNonce == ownerNonce
+
+    internal companion object {
+        fun issue(
+            ownerNonce: UUID,
+            scope: RemoteConfigSnapshotScope,
+            scopeGeneration: Long,
+            installEpoch: Long,
+        ) = RemoteConfigScopePreloadToken(ownerNonce, scope, scopeGeneration, installEpoch)
+    }
+}
+
+internal enum class RemoteConfigScopePreloadInstallStatus {
+    Installed,
+    PersistenceFailed,
+    Superseded,
+    Ignored,
+}
+
+internal enum class RemoteConfigImplicitActivationClaimStatus {
+    Claimed,
+    Stale,
+    AlreadyConsumed,
+}
+
 internal data class BoundRemoteConfigSnapshotAdmission(
     val ordinal: Long,
     val scope: RemoteConfigSnapshotScope,
@@ -64,35 +97,169 @@ internal class RemoteConfigSnapshotCore(
     private val store: RemoteConfigSnapshotStore,
     private val bundledRelease: RemoteConfigScopedBundledRelease?,
     private val envelopeParser: RemoteConfigSnapshotEnvelopeDecoder = RemoteConfigSnapshotEnvelopeParser(),
+    private val deliveryQueueObservedEmpty: (() -> Unit)? = null,
+    private val scopePreloadMutatedBeforeBinding: (() -> Unit)? = null,
 ) {
     private val lock = Any()
-    private val deliveryLock = Any()
+    private val deliveryLock = ReentrantLock()
+    private val deliveryBoundaryChanged = deliveryLock.newCondition()
     private val admissionOwnerNonce = UUID.randomUUID()
+    private val preloadOwnerNonce = UUID.randomUUID()
     private var currentScope: RemoteConfigSnapshotScope? = null
     private var state = RemoteConfigSnapshotState()
+    private var prepersistedFirstReadActivation: PrepersistedFirstReadActivation? = null
+    private var firstReadActivationArmed = false
+    private var implicitActivationOpportunityConsumed = false
     private var scopeLoadFailed = false
     private var scopeGeneration = 0L
+    private var stateMutationEpoch = 0L
     private var nextAdmissionToken = 0L
     private var nextObserverToken = 0L
     private val observers = linkedMapOf<Long, (RemoteConfigSnapshotUpdate) -> Unit>()
     private val pendingDeliveries = ArrayDeque<TransitionDelivery>()
     private var isDrainingDeliveries = false
+    private var deliveryOwnerThread: Thread? = null
+    private var scopeTransitionInProgress = false
 
     fun setScope(scope: RemoteConfigSnapshotScope?) {
-        synchronized(deliveryLock) {
+        withDeliveryBoundary {
             synchronized(lock) {
                 if (currentScope == scope && !(scope != null && scopeLoadFailed)) return
                 if (currentScope != scope) {
                     currentScope = scope
                     state = RemoteConfigSnapshotState()
+                    prepersistedFirstReadActivation = null
+                    firstReadActivationArmed = false
                     scopeLoadFailed = false
                     nextAdmissionToken = 0L
                     scopeGeneration++
+                    stateMutationEpoch++
                 }
                 scope?.let(::loadScopeState)
             }
         }
     }
+
+    fun beginScopePreload(
+        scope: RemoteConfigSnapshotScope?,
+        armFirstReadActivation: Boolean,
+        onBound: (RemoteConfigScopePreloadToken?) -> Unit = {},
+    ): RemoteConfigScopePreloadToken? = withDeliveryBoundary {
+        val token = synchronized(lock) {
+                currentScope = scope
+                state = RemoteConfigSnapshotState()
+                prepersistedFirstReadActivation = null
+                firstReadActivationArmed =
+                    armFirstReadActivation && !implicitActivationOpportunityConsumed
+                scopeLoadFailed = scope != null
+                nextAdmissionToken = 0L
+                scopeGeneration++
+                stateMutationEpoch++
+                scope?.let {
+                    RemoteConfigScopePreloadToken.issue(
+                        preloadOwnerNonce,
+                        it,
+                        scopeGeneration,
+                        stateMutationEpoch,
+                    )
+                }
+        }
+        scopePreloadMutatedBeforeBinding?.invoke()
+        onBound(token)
+        token
+    }
+
+    fun installPreloadedScope(
+        token: RemoteConfigScopePreloadToken,
+        preloadedState: RemoteConfigSnapshotState,
+        preparedActivationState: RemoteConfigSnapshotState?,
+    ): RemoteConfigScopePreloadInstallStatus = synchronized(lock) {
+        if (!isCurrentPreloadToken(token)) {
+            return@synchronized RemoteConfigScopePreloadInstallStatus.Ignored
+        }
+        if (token.installEpoch != stateMutationEpoch) {
+            return@synchronized RemoteConfigScopePreloadInstallStatus.Superseded
+        }
+        val preparedState = preparedActivationState.takeIf { firstReadActivationArmed }
+        val preparedStateWasPersisted = preparedState == null ||
+            preparedState === preloadedState || saveCurrentScope(preparedState)
+        state = preloadedState
+        prepersistedFirstReadActivation = if (preparedStateWasPersisted) {
+            preparedState?.let { PrepersistedFirstReadActivation(preloadedState, it) }
+        } else {
+            null
+        }
+        nextAdmissionToken = preloadedState.latestAdmissionToken
+        scopeLoadFailed = false
+        stateMutationEpoch++
+        if (preparedStateWasPersisted) {
+            RemoteConfigScopePreloadInstallStatus.Installed
+        } else {
+            RemoteConfigScopePreloadInstallStatus.PersistenceFailed
+        }
+    }
+
+    fun commitPrepersistedActivation(
+        token: RemoteConfigScopePreloadToken,
+    ): RemoteConfigSnapshotTransitionResult {
+        val result = commitPrepersistedActivationWithoutDelivery(token)
+        deliverPendingUpdates()
+        return result
+    }
+
+    fun commitPrepersistedActivationWithoutDelivery(
+        token: RemoteConfigScopePreloadToken,
+    ): RemoteConfigSnapshotTransitionResult {
+        val delivery = synchronized(lock) {
+            if (!isCurrentPreloadToken(token)) return@synchronized TransitionDelivery.ignored()
+            implicitActivationOpportunityConsumed = true
+            firstReadActivationArmed = false
+            if (scopeLoadFailed) return@synchronized TransitionDelivery.ignored()
+            val activation = prepersistedFirstReadActivation
+            prepersistedFirstReadActivation = null
+            if (activation == null || state !== activation.expectedState) {
+                return@synchronized TransitionDelivery.ignored()
+            }
+            val preparedState = activation.preparedState
+            val expectedState = activation.expectedState
+            if (preparedState === expectedState) return@synchronized TransitionDelivery.unchanged()
+            val oldSnapshot = snapshotFor(state.active, state.previous)
+            state = preparedState
+            stateMutationEpoch++
+            nextAdmissionToken = maxOf(nextAdmissionToken, preparedState.latestAdmissionToken)
+            val update = buildUpdate(oldSnapshot, snapshotFor(preparedState.active, preparedState.previous))
+            TransitionDelivery
+                .activated(update, observers.values.toList(), scopeGeneration)
+                .also(::enqueueDeliveryLocked)
+        }
+        return delivery.result
+    }
+
+    fun deliverPendingUpdates() {
+        drainDeliveries()
+    }
+
+    private data class PrepersistedFirstReadActivation(
+        val expectedState: RemoteConfigSnapshotState,
+        val preparedState: RemoteConfigSnapshotState,
+    )
+
+    fun claimImplicitActivationOpportunity(
+        token: RemoteConfigScopePreloadToken?,
+    ): RemoteConfigImplicitActivationClaimStatus = synchronized(lock) {
+        if (token == null || !isCurrentPreloadToken(token)) {
+            return@synchronized RemoteConfigImplicitActivationClaimStatus.Stale
+        }
+        if (implicitActivationOpportunityConsumed) {
+            return@synchronized RemoteConfigImplicitActivationClaimStatus.AlreadyConsumed
+        }
+        implicitActivationOpportunityConsumed = true
+        RemoteConfigImplicitActivationClaimStatus.Claimed
+    }
+
+    private fun isCurrentPreloadToken(token: RemoteConfigScopePreloadToken): Boolean =
+        token.belongsTo(preloadOwnerNonce) && token.scope == currentScope &&
+            token.scopeGeneration == scopeGeneration
 
     fun currentSnapshot(): RemoteConfigSnapshot = synchronized(lock) {
         snapshotFor(state.active, state.previous)
@@ -276,8 +443,21 @@ internal class RemoteConfigSnapshotCore(
             } else {
                 state.copy(candidate = admittedRelease, latestAdmissionToken = admissionOrdinal)
             }
-            if (!saveCurrentScope(nextState)) return@synchronized TransitionDelivery.persistenceFailed()
+            val preparedFirstReadState = if (firstReadActivationArmed) {
+                nextState.preparedActivationState()
+            } else {
+                null
+            }
+            val persistedState = preparedFirstReadState ?: nextState
+            if (!saveCurrentScope(persistedState)) return@synchronized TransitionDelivery.persistenceFailed()
             state = nextState
+            stateMutationEpoch++
+            if (firstReadActivationArmed && preparedFirstReadState != null) {
+                prepersistedFirstReadActivation = PrepersistedFirstReadActivation(
+                    expectedState = nextState,
+                    preparedState = preparedFirstReadState,
+                )
+            }
             if (admittedRelease.containsImmediateEntry) {
                 val update = buildUpdate(oldSnapshot, snapshotFor(nextState.active, nextState.previous))
                 TransitionDelivery(
@@ -301,8 +481,16 @@ internal class RemoteConfigSnapshotCore(
         return delivery.result
     }
 
-    fun activate(): RemoteConfigSnapshotTransitionResult {
+    fun activate(): RemoteConfigSnapshotTransitionResult = activateForPreloadToken(null)
+
+    fun activateForPreloadToken(
+        expectedToken: RemoteConfigScopePreloadToken?,
+    ): RemoteConfigSnapshotTransitionResult {
         val delivery = synchronized(lock) {
+            if (expectedToken != null && !isCurrentPreloadToken(expectedToken)) {
+                return@synchronized TransitionDelivery.ignored()
+            }
+            implicitActivationOpportunityConsumed = true
             if (currentScope == null) return@synchronized TransitionDelivery.ignored()
             if (!ensureCurrentScopeLoaded()) return@synchronized TransitionDelivery.persistenceFailed()
             val candidate = state.candidate
@@ -312,6 +500,7 @@ internal class RemoteConfigSnapshotCore(
                 if (!saveCurrentScope(nextState)) return@synchronized TransitionDelivery.persistenceFailed()
                 val oldSnapshot = snapshotFor(state.active, state.previous)
                 state = nextState
+                stateMutationEpoch++
                 val update = buildUpdate(oldSnapshot = null, newSnapshot = oldSnapshot)
                 return@synchronized TransitionDelivery
                     .activated(update, observers.values.toList(), scopeGeneration)
@@ -331,6 +520,7 @@ internal class RemoteConfigSnapshotCore(
             )
             if (!saveCurrentScope(nextState)) return@synchronized TransitionDelivery.persistenceFailed()
             state = nextState
+            stateMutationEpoch++
             val update = buildUpdate(oldSnapshot, snapshotFor(nextState.active, nextState.previous))
             TransitionDelivery
                 .activated(update, observers.values.toList(), scopeGeneration)
@@ -355,15 +545,20 @@ internal class RemoteConfigSnapshotCore(
         when (result.status) {
             RemoteConfigSnapshotLoadStatus.Found -> {
                 state = requireNotNull(result.state)
+                stateMutationEpoch++
                 nextAdmissionToken = state.latestAdmissionToken
                 scopeLoadFailed = false
             }
             RemoteConfigSnapshotLoadStatus.Missing -> {
                 state = RemoteConfigSnapshotState()
+                stateMutationEpoch++
                 nextAdmissionToken = 0L
                 scopeLoadFailed = false
             }
             RemoteConfigSnapshotLoadStatus.Failed -> {
+                scopeLoadFailed = true
+            }
+            RemoteConfigSnapshotLoadStatus.Corrupt -> {
                 scopeLoadFailed = true
             }
         }
@@ -406,17 +601,63 @@ internal class RemoteConfigSnapshotCore(
         if (delivery.update?.changedKeys?.isNotEmpty() == true) pendingDeliveries.addLast(delivery)
     }
 
+    private inline fun <T> withDeliveryBoundary(block: () -> T): T {
+        deliveryLock.withLock {
+            val currentThread = Thread.currentThread()
+            while (scopeTransitionInProgress ||
+                (isDrainingDeliveries && deliveryOwnerThread !== currentThread)
+            ) {
+                deliveryBoundaryChanged.awaitUninterruptibly()
+            }
+            scopeTransitionInProgress = true
+        }
+        return try {
+            block()
+        } finally {
+            deliveryLock.withLock {
+                scopeTransitionInProgress = false
+                deliveryBoundaryChanged.signalAll()
+            }
+        }
+    }
+
+    @Suppress("NestedBlockDepth")
     private fun drainDeliveries() {
-        synchronized(deliveryLock) {
+        deliveryLock.withLock {
+            while (scopeTransitionInProgress) deliveryBoundaryChanged.awaitUninterruptibly()
             if (isDrainingDeliveries) return
             isDrainingDeliveries = true
-            try {
-                while (true) {
-                    val delivery = synchronized(lock) { pollCurrentDeliveryLocked() } ?: break
+            deliveryOwnerThread = Thread.currentThread()
+        }
+        try {
+            while (true) {
+                val delivery = synchronized(lock) { pollCurrentDeliveryLocked() }
+                if (delivery == null) {
+                    deliveryQueueObservedEmpty?.invoke()
+                    val racedDelivery = takeRacedDeliveryOrReleaseOwnership()
+                    if (racedDelivery == null) return
+                    deliverIfCurrent(racedDelivery)
+                } else {
                     deliverIfCurrent(delivery)
                 }
-            } finally {
+            }
+        } finally {
+            deliveryLock.withLock {
+                if (isDrainingDeliveries && deliveryOwnerThread === Thread.currentThread()) {
+                    isDrainingDeliveries = false
+                    deliveryOwnerThread = null
+                    deliveryBoundaryChanged.signalAll()
+                }
+            }
+        }
+    }
+
+    private fun takeRacedDeliveryOrReleaseOwnership(): TransitionDelivery? = deliveryLock.withLock {
+        synchronized(lock) { pollCurrentDeliveryLocked() }.also { nextDelivery ->
+            if (nextDelivery == null) {
                 isDrainingDeliveries = false
+                deliveryOwnerThread = null
+                deliveryBoundaryChanged.signalAll()
             }
         }
     }

--- a/sdk/src/main/java/com/qonversion/android/sdk/internal/storage/PersistentRemoteConfigSnapshotStore.kt
+++ b/sdk/src/main/java/com/qonversion/android/sdk/internal/storage/PersistentRemoteConfigSnapshotStore.kt
@@ -33,6 +33,7 @@ internal enum class RemoteConfigSnapshotLoadStatus {
     Found,
     Missing,
     Failed,
+    Corrupt,
 }
 
 internal data class RemoteConfigSnapshotLoadResult(
@@ -57,6 +58,8 @@ internal class PersistentRemoteConfigSnapshotStore(
     private val maxTotalBytes: Int = DEFAULT_REMOTE_CONFIG_SNAPSHOT_MAX_TOTAL_BYTES,
 ) : RemoteConfigSnapshotStore {
     private val envelopeAdapter = moshi.adapter(PersistedRemoteConfigSnapshotEnvelope::class.java).failOnUnknown()
+    private val legacyEnvelopeAdapter =
+        moshi.adapter(PersistedRemoteConfigSnapshotEnvelopeV1::class.java).failOnUnknown()
     private val indexAdapter = moshi.adapter(PersistedRemoteConfigSnapshotIndex::class.java).failOnUnknown()
 
     init {
@@ -68,22 +71,30 @@ internal class PersistentRemoteConfigSnapshotStore(
     @Synchronized
     @Suppress("ReturnCount")
     override fun load(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotLoadResult = try {
-        loadTrusted(scope)?.let { state ->
-            RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Found, state)
-        } ?: RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Missing)
+        when (val result = loadTrusted(scope)) {
+            is TrustedSnapshotLoad.Found -> {
+                RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Found, result.state)
+            }
+            TrustedSnapshotLoad.Missing -> {
+                RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Missing)
+            }
+            TrustedSnapshotLoad.Corrupt -> {
+                RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Corrupt)
+            }
+        }
     } catch (_: Exception) {
         RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Failed)
     }
 
     @Suppress("ReturnCount")
-    private fun loadTrusted(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotState? {
+    private fun loadTrusted(scope: RemoteConfigSnapshotScope): TrustedSnapshotLoad {
         val storageKey = remoteConfigSnapshotStorageKey(scope)
         val index = loadIndex(clearInvalid = true)
-        val rawEnvelope = cache.getString(storageKey, null)
-        val envelopeBytes = rawEnvelope?.toByteArray(Charsets.UTF_8)?.size
+        val rawEnvelope = cache.getString(storageKey, null) ?: return TrustedSnapshotLoad.Missing
+        val envelopeBytes = rawEnvelope.toByteArray(Charsets.UTF_8).size
         val envelope = rawEnvelope
-            ?.takeIf {
-                requireNotNull(envelopeBytes) <= maxStateBytes && envelopeBytes <= maxTotalBytes
+            .takeIf {
+                envelopeBytes <= maxStateBytes && envelopeBytes <= maxTotalBytes
             }
             ?.let(::decodeEnvelope)
         val decoded = envelope
@@ -96,13 +107,32 @@ internal class PersistentRemoteConfigSnapshotStore(
                 if (storageKey in index.storageKeys) {
                     promoteAfterRead(storageKey, index)
                 } else {
-                    admitRecoveredAfterRead(storageKey, requireNotNull(envelopeBytes), index)
+                    admitRecoveredAfterRead(storageKey, envelopeBytes, index)
                 }
             }
-            return decoded.state
+            return TrustedSnapshotLoad.Found(decoded.state)
         }
         removeInvalidEnvelope(storageKey, index)
-        return null
+        return if (
+            envelopeBytes <= maxStateBytes && envelopeBytes <= maxTotalBytes &&
+            isLegacyEnvelopeV1(rawEnvelope, scope)
+        ) {
+            TrustedSnapshotLoad.Missing
+        } else {
+            TrustedSnapshotLoad.Corrupt
+        }
+    }
+
+    private fun isLegacyEnvelopeV1(raw: String, scope: RemoteConfigSnapshotScope): Boolean {
+        return try {
+            val envelope = legacyEnvelopeAdapter.fromJson(raw) ?: return false
+            envelope.version == 1 && envelope.projectKey == scope.projectKey &&
+                envelope.environment == scope.environment &&
+                envelope.canonicalUserId == scope.canonicalUserId &&
+                envelope.state.isValid(scope.environment)
+        } catch (_: Exception) {
+            false
+        }
     }
 
     @Synchronized
@@ -334,6 +364,12 @@ internal class PersistentRemoteConfigSnapshotStore(
         val storageKey: String,
         val bytes: Int,
     )
+
+    private sealed class TrustedSnapshotLoad {
+        data class Found(val state: RemoteConfigSnapshotState) : TrustedSnapshotLoad()
+        data object Missing : TrustedSnapshotLoad()
+        data object Corrupt : TrustedSnapshotLoad()
+    }
 }
 
 @JsonClass(generateAdapter = true)
@@ -349,6 +385,33 @@ internal data class PersistedRemoteConfigSnapshotEnvelope(
     val environment: String,
     val canonicalUserId: String,
     val state: PersistedRemoteConfigSnapshotState,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigSnapshotEnvelopeV1(
+    val version: Int,
+    val projectKey: String,
+    val environment: String,
+    val canonicalUserId: String,
+    val state: PersistedRemoteConfigSnapshotStateV1,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigSnapshotStateV1(
+    val candidate: PersistedRemoteConfigSnapshotReleaseV1?,
+    val active: PersistedRemoteConfigSnapshotReleaseV1?,
+    val previous: PersistedRemoteConfigSnapshotReleaseV1?,
+    val didActivate: Boolean,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class PersistedRemoteConfigSnapshotReleaseV1(
+    val releaseUid: String,
+    val releaseNumber: Long,
+    val manifestContentHash: String,
+    val entries: List<PersistedRemoteConfigSnapshotEntry>,
+    val canonicalBodyBase64: String?,
+    val strongETag: String?,
 )
 
 @JsonClass(generateAdapter = true)
@@ -387,6 +450,69 @@ private data class DecodedRemoteConfigSnapshotState(
     val state: RemoteConfigSnapshotState,
     val requiresRewrite: Boolean,
 )
+
+@Suppress("ComplexCondition", "ReturnCount")
+private fun PersistedRemoteConfigSnapshotStateV1.isValid(expectedEnvironment: String): Boolean {
+    val candidateModel = candidate?.toLegacyModel(expectedEnvironment)
+    val activeModel = active?.toLegacyModel(expectedEnvironment)
+    val previousModel = previous?.toLegacyModel(expectedEnvironment)
+    if (candidate != null && candidateModel == null ||
+        active != null && activeModel == null ||
+        previous != null && previousModel == null
+    ) {
+        return false
+    }
+    if (!didActivate && (activeModel != null || previousModel != null)) return false
+    if (activeModel == null && previousModel != null) return false
+    return true
+}
+
+@Suppress("ComplexCondition", "ReturnCount")
+private fun PersistedRemoteConfigSnapshotReleaseV1.toLegacyModel(
+    expectedEnvironment: String,
+): RemoteConfigSnapshotRelease? {
+    return try {
+        val canonicalBody = canonicalBodyBase64.decodeCanonicalBase64()
+        if ((canonicalBodyBase64 == null) != (strongETag == null) ||
+            (canonicalBodyBase64 != null && canonicalBody == null)
+        ) {
+            return null
+        }
+        val decodedEntries = entries.map { it.toModel() ?: return null }
+        var contextFingerprint: String? = null
+        if (canonicalBody != null) {
+            val envelope = RemoteConfigSnapshotEnvelopeParser().parseBoundBody(
+                canonicalBody,
+                requireNotNull(strongETag),
+            ) ?: return null
+            if (envelope.environmentUid != expectedEnvironment ||
+                envelope.release.releaseUid != releaseUid ||
+                envelope.release.releaseNumber != releaseNumber ||
+                envelope.release.manifestContentHash != manifestContentHash
+            ) {
+                return null
+            }
+            val persistedValues = decodedEntries.filterNot(RemoteConfigSnapshotEntry::isTombstone)
+            if (persistedValues.size != envelope.release.entries.size ||
+                persistedValues.any { entry -> !entry.contentEquals(envelope.release.entry(entry.key)) }
+            ) {
+                return null
+            }
+            contextFingerprint = envelope.contextFingerprint
+        }
+        RemoteConfigSnapshotRelease(
+            releaseUid = releaseUid,
+            releaseNumber = releaseNumber,
+            manifestContentHash = manifestContentHash,
+            entries = decodedEntries,
+            canonicalBody = canonicalBody,
+            strongETag = strongETag,
+            contextFingerprint = contextFingerprint,
+        )
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}
 
 @Suppress("ComplexMethod", "LongMethod")
 private fun PersistedRemoteConfigSnapshotState.toDecodedModel(

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigReadGuardTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigReadGuardTest.kt
@@ -1,0 +1,767 @@
+package com.qonversion.android.sdk.internal.remoteconfig
+
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadResult
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotLoadStatus
+import com.qonversion.android.sdk.internal.storage.RemoteConfigSnapshotStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class RemoteConfigReadGuardTest {
+    private val scopeA = RemoteConfigSnapshotScope("project", "production", "user-a")
+    private val scopeB = RemoteConfigSnapshotScope("project", "production", "user-b")
+    private val bundle = RemoteConfigScopedBundledRelease(
+        projectKey = "project",
+        environment = "production",
+        release = release("bundle", 1, "0"),
+    )
+
+    @Test
+    fun `release first read commits one pre-persisted activation without read-path IO`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate", 2, "2"))
+        }
+        val executor = ManualExecutor()
+        val telemetry = RecordingTelemetry()
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        val guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor), telemetry = telemetry)
+        var ready = 0
+
+        guard.transitionScopeBeforeSdkReady(scopeA) { ready++ }
+        assertEquals(0, store.loads)
+        executor.runAll()
+        assertEquals(1, ready)
+        assertEquals(1, store.loads)
+        assertEquals(1, store.saves)
+        val ioBeforeRead = store.loads to store.saves
+
+        val held = guard.currentSnapshot()
+        assertEquals("candidate", held.releaseUid)
+        assertEquals("2", held.rawValue("key")?.value?.decodeToString())
+        assertEquals(ioBeforeRead, store.loads to store.saves)
+        assertEquals("candidate", guard.currentSnapshot().releaseUid)
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ReadBeforeActivate })
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+
+        core.acceptCandidate(scopeA, release("next", 3, "3"))
+        assertEquals("2", held.rawValue("key")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `candidate fetched after preload is durably prepared and active on first read`() {
+        val active = release("active", 1, "1").withAdmissionToken(1)
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(
+                candidate = active,
+                active = active,
+                didActivate = true,
+                latestAdmissionToken = 1,
+            )
+        }
+        val executor = ManualExecutor()
+        val telemetry = RecordingTelemetry()
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        val guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor), telemetry = telemetry)
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+
+        assertEquals(
+            RemoteConfigSnapshotTransitionStatus.Accepted,
+            core.acceptCandidate(scopeA, release("fetched", 2, "2")).status,
+        )
+        assertEquals("fetched", store.states.getValue(scopeA).active?.releaseUid)
+        val ioBeforeRead = store.loads to store.saves
+
+        assertEquals("fetched", guard.currentSnapshot().releaseUid)
+        assertEquals(ioBeforeRead, store.loads to store.saves)
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+        assertEquals("fetched", guard.currentSnapshot().releaseUid)
+    }
+
+    @Test
+    fun `debug first read reports the exact actionable assertion once and never activates`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate", 2, "2"))
+        }
+        val executor = ManualExecutor()
+        val assertions = mutableListOf<String>()
+        val telemetry = RecordingTelemetry()
+        val guard = guard(
+            core = RemoteConfigSnapshotCore(store, bundle),
+            preloader = PersistentRemoteConfigReadPreloader(store, executor),
+            mode = RemoteConfigReadBuildMode.Debug,
+            assertion = RemoteConfigReadAssertion(assertions::add),
+            telemetry = telemetry,
+        )
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+        val ioBeforeRead = store.loads to store.saves
+
+        assertEquals("0", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+        assertEquals(
+            RemoteConfigSnapshotValueSource.Fallback,
+            guard.currentSnapshot().rawValue("key")?.source,
+        )
+        assertEquals(listOf(REMOTE_CONFIG_READ_BEFORE_ACTIVATE_MESSAGE), assertions)
+        assertEquals(ioBeforeRead, store.loads to store.saves)
+        assertEquals(0, store.saves)
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ReadBeforeActivate })
+    }
+
+    @Test
+    fun `read before preload readiness pins bundle and late preload cannot change current`() {
+        val preloader = ControlledPreloader()
+        val telemetry = RecordingTelemetry()
+        val core = RemoteConfigSnapshotCore(RecordingStore(), bundle)
+        val guard = guard(core, preloader, telemetry = telemetry)
+        guard.transitionScopeBeforeSdkReady(scopeA)
+
+        assertEquals("0", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+        preloader.complete(
+            0,
+            readyPreload(
+                base = RemoteConfigSnapshotState(candidate = release("private", 2, "\"private\"")),
+            ),
+        )
+        assertEquals("0", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.PreloadNotReady })
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ReadBeforeActivate })
+    }
+
+    @Test
+    fun `concurrent first reads perform one implicit attempt and see one committed generation`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate", 2, "2"))
+        }
+        val executor = ManualExecutor()
+        val telemetry = RecordingTelemetry()
+        val guard = guard(
+            RemoteConfigSnapshotCore(store, bundle),
+            PersistentRemoteConfigReadPreloader(store, executor),
+            telemetry = telemetry,
+        )
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(32)
+        val releases = Collections.synchronizedList(mutableListOf<String>())
+        repeat(32) {
+            Thread {
+                start.await()
+                releases += guard.currentSnapshot().releaseUid
+                done.countDown()
+            }.start()
+        }
+
+        start.countDown()
+        assertTrue(done.await(5, TimeUnit.SECONDS))
+        assertEquals(setOf("candidate"), releases.toSet())
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ReadBeforeActivate })
+        assertEquals(1, store.saves)
+    }
+
+    @Test
+    fun `activation preparation failure preserves old active and is observable`() {
+        val old = release("active", 1, "1").withAdmissionToken(1)
+        val next = release("candidate", 2, "2").withAdmissionToken(2)
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(
+                candidate = next,
+                active = old,
+                didActivate = true,
+                latestAdmissionToken = 2,
+            )
+            failSaves = true
+        }
+        val executor = ManualExecutor()
+        val telemetry = RecordingTelemetry()
+        val guard = guard(
+            RemoteConfigSnapshotCore(store, bundle),
+            PersistentRemoteConfigReadPreloader(store, executor),
+            telemetry = telemetry,
+        )
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+        val ioBeforeRead = store.loads to store.saves
+
+        assertEquals("active", guard.currentSnapshot().releaseUid)
+        assertEquals(ioBeforeRead, store.loads to store.saves)
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ActivationPersistenceFailed })
+        assertEquals(0, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+    }
+
+    @Test
+    fun `successful fetch rearms first read after initial preparation persistence failure`() {
+        val old = release("active", 1, "1").withAdmissionToken(1)
+        val pending = release("pending", 2, "2").withAdmissionToken(2)
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(
+                candidate = pending,
+                active = old,
+                didActivate = true,
+                latestAdmissionToken = 2,
+            )
+            failSaves = true
+        }
+        val executor = ManualExecutor()
+        val telemetry = RecordingTelemetry()
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        val guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor), telemetry = telemetry)
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+        store.failSaves = false
+
+        assertEquals(
+            RemoteConfigSnapshotTransitionStatus.Accepted,
+            core.acceptCandidate(scopeA, release("recovered", 3, "3")).status,
+        )
+        assertEquals("recovered", store.states.getValue(scopeA).active?.releaseUid)
+        val ioBeforeRead = store.loads to store.saves
+
+        assertEquals("recovered", guard.currentSnapshot().releaseUid)
+        assertEquals(ioBeforeRead, store.loads to store.saves)
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+    }
+
+    @Test
+    fun `implicit activation delivers one observer update outside guard locks`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate", 2, "2"))
+        }
+        val executor = ManualExecutor()
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        lateinit var guard: RemoteConfigReadGuard
+        val observed = mutableListOf<String>()
+        guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor))
+        core.addUpdateObserver { update ->
+            observed += update.snapshot.releaseUid
+            assertEquals("candidate", guard.currentSnapshot().releaseUid)
+        }
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+
+        assertEquals("candidate", guard.currentSnapshot().releaseUid)
+        assertEquals(listOf("candidate"), observed)
+        assertEquals("candidate", guard.currentSnapshot().releaseUid)
+        assertEquals(listOf("candidate"), observed)
+    }
+
+    @Test
+    fun `implicit activation observer can coordinate a concurrent snapshot read`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate", 2, "2"))
+        }
+        val executor = ManualExecutor()
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        lateinit var guard: RemoteConfigReadGuard
+        var callbackCouldCoordinate = false
+        guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor))
+        core.addUpdateObserver {
+            val coordinated = CountDownLatch(1)
+            Thread {
+                if (guard.currentSnapshot().releaseUid == "candidate") coordinated.countDown()
+            }.start()
+            callbackCouldCoordinate = coordinated.await(1, TimeUnit.SECONDS)
+        }
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+
+        assertEquals("candidate", guard.currentSnapshot().releaseUid)
+        assertTrue(callbackCouldCoordinate)
+    }
+
+    @Test
+    fun `readiness callback can synchronously coordinate another scope transition`() {
+        val executor = ManualExecutor()
+        val guard = guard(
+            RemoteConfigSnapshotCore(RecordingStore(), bundle),
+            PersistentRemoteConfigReadPreloader(RecordingStore(), executor),
+        )
+        val transitionFinished = CountDownLatch(1)
+        var callbackCouldCoordinate = false
+        guard.transitionScopeBeforeSdkReady(scopeA) {
+            Thread {
+                guard.transitionScopeBeforeSdkReady(scopeB)
+                transitionFinished.countDown()
+            }.start()
+            callbackCouldCoordinate = transitionFinished.await(1, TimeUnit.SECONDS)
+        }
+
+        executor.runAll()
+
+        assertTrue(callbackCouldCoordinate)
+    }
+
+    @Test
+    fun `already active restart and immediate fetch never report implicit activation`() {
+        val active = release("active", 1, "1").withAdmissionToken(1)
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(
+                candidate = active,
+                active = active,
+                didActivate = true,
+                latestAdmissionToken = 1,
+            )
+        }
+        val executor = ManualExecutor()
+        val telemetry = RecordingTelemetry()
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        val guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor), telemetry = telemetry)
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+        core.acceptCandidate(scopeA, release("immediate", 2, "2", immediate = true))
+
+        assertEquals("immediate", guard.currentSnapshot().releaseUid)
+        assertEquals(0, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+    }
+
+    @Test
+    fun `implicit activation opportunity is consumed once for the SDK lifetime across scopes`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate-a", 1, "1"))
+            states[scopeB] = RemoteConfigSnapshotState(candidate = release("candidate-b", 2, "2"))
+        }
+        val executor = ManualExecutor()
+        val telemetry = RecordingTelemetry()
+        val guard = guard(
+            RemoteConfigSnapshotCore(store, bundle),
+            PersistentRemoteConfigReadPreloader(store, executor),
+            telemetry = telemetry,
+        )
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+        assertEquals("candidate-a", guard.currentSnapshot().releaseUid)
+
+        guard.transitionScopeBeforeSdkReady(scopeB)
+        executor.runAll()
+
+        assertEquals("0", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+        assertEquals(1, store.saves)
+    }
+
+    @Test
+    fun `read between scope mutation and token binding cannot consume implicit activation`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate-a", 1, "1"))
+            states[scopeB] = RemoteConfigSnapshotState(candidate = release("candidate-b", 2, "2"))
+        }
+        val executor = ManualExecutor()
+        val scopeMutated = CountDownLatch(1)
+        val releaseBinding = CountDownLatch(1)
+        val transitionFinished = CountDownLatch(1)
+        val scopeMutationCalls = AtomicInteger()
+        val telemetry = RecordingTelemetry()
+        val core = RemoteConfigSnapshotCore(
+            store = store,
+            bundledRelease = bundle,
+            scopePreloadMutatedBeforeBinding = {
+                if (scopeMutationCalls.incrementAndGet() == 2) {
+                    scopeMutated.countDown()
+                    check(releaseBinding.await(5, TimeUnit.SECONDS))
+                }
+            },
+        )
+        val guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor), telemetry = telemetry)
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+
+        Thread {
+            guard.transitionScopeBeforeSdkReady(scopeB)
+            transitionFinished.countDown()
+        }.start()
+        assertTrue(scopeMutated.await(5, TimeUnit.SECONDS))
+
+        assertEquals("0", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+        releaseBinding.countDown()
+        assertTrue(transitionFinished.await(5, TimeUnit.SECONDS))
+        executor.runAll()
+        val ioBeforeRead = store.loads to store.saves
+
+        assertEquals("candidate-b", guard.currentSnapshot().releaseUid)
+        assertEquals(ioBeforeRead, store.loads to store.saves)
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+    }
+
+    @Test
+    fun `read with null token during initial binding cannot consume implicit activation`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate", 1, "1"))
+        }
+        val executor = ManualExecutor()
+        val scopeMutated = CountDownLatch(1)
+        val releaseBinding = CountDownLatch(1)
+        val transitionFinished = CountDownLatch(1)
+        val telemetry = RecordingTelemetry()
+        val core = RemoteConfigSnapshotCore(
+            store = store,
+            bundledRelease = bundle,
+            scopePreloadMutatedBeforeBinding = {
+                scopeMutated.countDown()
+                check(releaseBinding.await(5, TimeUnit.SECONDS))
+            },
+        )
+        val guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor), telemetry = telemetry)
+
+        Thread {
+            guard.transitionScopeBeforeSdkReady(scopeA)
+            transitionFinished.countDown()
+        }.start()
+        assertTrue(scopeMutated.await(5, TimeUnit.SECONDS))
+
+        assertEquals("0", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+        releaseBinding.countDown()
+        assertTrue(transitionFinished.await(5, TimeUnit.SECONDS))
+        executor.runAll()
+
+        assertEquals("candidate", guard.currentSnapshot().releaseUid)
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+    }
+
+    @Test
+    fun `explicit activation consumes the lifetime implicit activation opportunity`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate-a", 1, "1"))
+            states[scopeB] = RemoteConfigSnapshotState(candidate = release("candidate-b", 2, "2"))
+        }
+        val executor = ManualExecutor()
+        val telemetry = RecordingTelemetry()
+        val guard = guard(
+            RemoteConfigSnapshotCore(store, bundle),
+            PersistentRemoteConfigReadPreloader(store, executor),
+            telemetry = telemetry,
+        )
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Activated, guard.activate().status)
+
+        guard.transitionScopeBeforeSdkReady(scopeB)
+        executor.runAll()
+
+        assertEquals("0", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+        assertEquals(0, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+        assertEquals(1, store.saves)
+    }
+
+    @Test
+    fun `prepared activation survives restart without another persistence write`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("candidate", 2, "2"))
+        }
+        val firstExecutor = ManualExecutor()
+        val first = guard(
+            RemoteConfigSnapshotCore(store, bundle),
+            PersistentRemoteConfigReadPreloader(store, firstExecutor),
+        )
+        first.transitionScopeBeforeSdkReady(scopeA)
+        firstExecutor.runAll()
+        assertEquals("candidate", first.currentSnapshot().releaseUid)
+        assertEquals(1, store.saves)
+
+        val restartedExecutor = ManualExecutor()
+        val restartedTelemetry = RecordingTelemetry()
+        val restarted = guard(
+            RemoteConfigSnapshotCore(store, bundle),
+            PersistentRemoteConfigReadPreloader(store, restartedExecutor),
+            telemetry = restartedTelemetry,
+        )
+        restarted.transitionScopeBeforeSdkReady(scopeA)
+        restartedExecutor.runAll()
+        val ioBeforeRead = store.loads to store.saves
+
+        assertEquals("candidate", restarted.currentSnapshot().releaseUid)
+        assertEquals(ioBeforeRead, store.loads to store.saves)
+        assertEquals(1, store.saves)
+        assertEquals(0, restartedTelemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+    }
+
+    @Test
+    fun `late old-scope preload is fenced and can never expose another identity`() {
+        val preloader = ControlledPreloader()
+        val guard = guard(RemoteConfigSnapshotCore(RecordingStore(), bundle), preloader)
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        guard.transitionScopeBeforeSdkReady(scopeB)
+        val baseB = RemoteConfigSnapshotState(candidate = release("private-b", 2, "\"b\""))
+        preloader.complete(1, readyPreload(baseB))
+
+        assertEquals("private-b", guard.currentSnapshot().releaseUid)
+        val baseA = RemoteConfigSnapshotState(candidate = release("private-a", 3, "\"a\""))
+        preloader.complete(0, readyPreload(baseA))
+        assertEquals("private-b", guard.currentSnapshot().releaseUid)
+        assertEquals("\"b\"", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+    }
+
+    @Test
+    fun `stale same-scope preload cannot overwrite a newer durable admission`() {
+        val initial = RemoteConfigSnapshotState(candidate = release("old", 1, "1"))
+        val store = InterleavingPreloadStore(scopeA, initial)
+        val executor = TrackingExecutor(expectedTasks = 3)
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        val guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor))
+        val currentPreloadReady = CountDownLatch(1)
+
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        assertTrue(store.firstLoadEntered.await(5, TimeUnit.SECONDS))
+        guard.transitionScopeBeforeSdkReady(scopeB)
+        guard.transitionScopeBeforeSdkReady(scopeA) { currentPreloadReady.countDown() }
+        assertTrue(currentPreloadReady.await(5, TimeUnit.SECONDS))
+        assertEquals(
+            RemoteConfigSnapshotTransitionStatus.Accepted,
+            core.acceptCandidate(scopeA, release("new", 2, "2")).status,
+        )
+        assertEquals("new", store.currentState().active?.releaseUid)
+
+        store.releaseFirstLoad.countDown()
+        assertTrue(executor.finished.await(5, TimeUnit.SECONDS))
+
+        assertEquals("new", store.currentState().active?.releaseUid)
+        assertEquals(2, store.saves.get())
+        executor.shutdown()
+    }
+
+    @Test
+    fun `same-generation preload cannot replace a newer durable admission`() {
+        val initial = RemoteConfigSnapshotState(candidate = release("old", 1, "1"))
+        val store = InterleavingPreloadStore(scopeA, initial)
+        val executor = TrackingExecutor(expectedTasks = 1)
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        val telemetry = RecordingTelemetry()
+        val guard = guard(
+            core,
+            PersistentRemoteConfigReadPreloader(store, executor),
+            telemetry = telemetry,
+        )
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        assertTrue(store.firstLoadEntered.await(5, TimeUnit.SECONDS))
+
+        assertEquals(
+            RemoteConfigSnapshotTransitionStatus.Accepted,
+            core.acceptCandidate(scopeA, release("new", 2, "2")).status,
+        )
+        assertEquals("new", core.lastFetchedSnapshot()?.releaseUid)
+        store.releaseFirstLoad.countDown()
+        assertTrue(executor.finished.await(5, TimeUnit.SECONDS))
+
+        assertEquals("new", core.lastFetchedSnapshot()?.releaseUid)
+        assertEquals("new", store.currentState().candidate?.releaseUid)
+        assertEquals(1, store.saves.get())
+        val ioBeforeRead = store.loads.get() to store.saves.get()
+
+        assertEquals("new", guard.currentSnapshot().releaseUid)
+        assertEquals(ioBeforeRead, store.loads.get() to store.saves.get())
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ImplicitActivation })
+        executor.shutdown()
+    }
+
+    @Test
+    fun `stale preload failure cannot advance readiness for the current scope`() {
+        val preloader = ControlledPreloader()
+        val readiness = mutableListOf<String>()
+        val guard = guard(RemoteConfigSnapshotCore(RecordingStore(), bundle), preloader)
+        guard.transitionScopeBeforeSdkReady(scopeA) { readiness += "a" }
+        guard.transitionScopeBeforeSdkReady(scopeB) { readiness += "b" }
+
+        preloader.complete(
+            0,
+            RemoteConfigReadPreloadResult(RemoteConfigReadPreloadStatus.Failed),
+        )
+        assertTrue(readiness.isEmpty())
+        val baseB = RemoteConfigSnapshotState(candidate = release("private-b", 2, "\"b\""))
+        preloader.complete(1, readyPreload(baseB))
+
+        assertEquals(listOf("b"), readiness)
+        assertEquals("private-b", guard.currentSnapshot().releaseUid)
+    }
+
+    @Test
+    fun `after first read only explicit activation or immediate whole release changes current`() {
+        val store = RecordingStore().apply {
+            states[scopeA] = RemoteConfigSnapshotState(candidate = release("one", 1, "1"))
+        }
+        val executor = ManualExecutor()
+        val core = RemoteConfigSnapshotCore(store, bundle)
+        val guard = guard(core, PersistentRemoteConfigReadPreloader(store, executor))
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        executor.runAll()
+        assertEquals("one", guard.currentSnapshot().releaseUid)
+
+        core.acceptCandidate(scopeA, release("two", 2, "2"))
+        assertEquals("one", guard.currentSnapshot().releaseUid)
+        assertEquals(RemoteConfigSnapshotTransitionStatus.Activated, guard.activate().status)
+        assertEquals("two", guard.currentSnapshot().releaseUid)
+
+        core.acceptCandidate(scopeA, release("three", 3, "3", immediate = true))
+        assertEquals("three", guard.currentSnapshot().releaseUid)
+    }
+
+    @Test
+    fun `corrupt preload is observable and serves only matching pinned bundle`() {
+        val preloader = ControlledPreloader()
+        val telemetry = RecordingTelemetry()
+        val guard = guard(
+            RemoteConfigSnapshotCore(RecordingStore(), bundle),
+            preloader,
+            telemetry = telemetry,
+        )
+        guard.transitionScopeBeforeSdkReady(scopeA)
+        preloader.complete(
+            0,
+            RemoteConfigReadPreloadResult(RemoteConfigReadPreloadStatus.Corrupt),
+        )
+
+        assertEquals("0", guard.currentSnapshot().rawValue("key")?.value?.decodeToString())
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.PreloadCorrupt })
+        assertEquals(1, telemetry.events.count { it == RemoteConfigReadGuardEvent.ReadBeforeActivate })
+    }
+
+    private fun guard(
+        core: RemoteConfigSnapshotCore,
+        preloader: RemoteConfigReadPreloader,
+        mode: RemoteConfigReadBuildMode = RemoteConfigReadBuildMode.Release,
+        assertion: RemoteConfigReadAssertion = RemoteConfigReadAssertion { throw AssertionError(it) },
+        telemetry: RemoteConfigReadTelemetry = RemoteConfigReadTelemetry { },
+    ) = RemoteConfigReadGuard(core, preloader, mode, assertion, telemetry)
+
+    private fun readyPreload(base: RemoteConfigSnapshotState): RemoteConfigReadPreloadResult =
+        RemoteConfigReadPreloadResult(
+            status = RemoteConfigReadPreloadStatus.Ready,
+            baseState = base,
+            preparedActivationState = base.preparedActivationState(),
+        )
+
+    private fun release(uid: String, number: Long, raw: String, immediate: Boolean = false) =
+        RemoteConfigSnapshotRelease(
+            releaseUid = uid,
+            releaseNumber = number,
+            manifestContentHash = number.toString(16).padStart(64, '0'),
+            entries = listOf(
+                RemoteConfigSnapshotEntry.value(
+                    key = "key",
+                    rawValue = raw.encodeToByteArray(),
+                    variationUid = "$uid-key",
+                    applyPolicy = if (immediate) {
+                        RemoteConfigSnapshotApplyPolicy.Immediate
+                    } else {
+                        RemoteConfigSnapshotApplyPolicy.OnNextActivate
+                    },
+                    metadata = null,
+                ),
+            ),
+        )
+
+    private class RecordingStore : RemoteConfigSnapshotStore {
+        val states = mutableMapOf<RemoteConfigSnapshotScope, RemoteConfigSnapshotState>()
+        var loads = 0
+        var saves = 0
+        var failSaves = false
+        var loadStatus: RemoteConfigSnapshotLoadStatus? = null
+
+        override fun load(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotLoadResult {
+            loads++
+            loadStatus?.let { return RemoteConfigSnapshotLoadResult(it) }
+            return states[scope]?.let {
+                RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Found, it)
+            } ?: RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Missing)
+        }
+
+        override fun save(scope: RemoteConfigSnapshotScope, state: RemoteConfigSnapshotState): Boolean {
+            saves++
+            if (failSaves) return false
+            states[scope] = state
+            return true
+        }
+    }
+
+    private class ManualExecutor : Executor {
+        private val tasks = mutableListOf<Runnable>()
+        override fun execute(command: Runnable) {
+            tasks += command
+        }
+
+        fun runAll() {
+            while (tasks.isNotEmpty()) tasks.removeAt(0).run()
+        }
+    }
+
+    private class TrackingExecutor(expectedTasks: Int) : Executor {
+        private val delegate = Executors.newCachedThreadPool()
+        val finished = CountDownLatch(expectedTasks)
+
+        override fun execute(command: Runnable) {
+            delegate.execute {
+                try {
+                    command.run()
+                } finally {
+                    finished.countDown()
+                }
+            }
+        }
+
+        fun shutdown() {
+            delegate.shutdownNow()
+        }
+    }
+
+    private class InterleavingPreloadStore(
+        private val scope: RemoteConfigSnapshotScope,
+        initial: RemoteConfigSnapshotState,
+    ) : RemoteConfigSnapshotStore {
+        val firstLoadEntered = CountDownLatch(1)
+        val releaseFirstLoad = CountDownLatch(1)
+        val saves = AtomicInteger()
+        val loads = AtomicInteger()
+        private val stateLock = Any()
+        private var state = initial
+
+        override fun load(scope: RemoteConfigSnapshotScope): RemoteConfigSnapshotLoadResult {
+            val captured = synchronized(stateLock) { state }
+            if (scope == this.scope && loads.incrementAndGet() == 1) {
+                firstLoadEntered.countDown()
+                check(releaseFirstLoad.await(5, TimeUnit.SECONDS))
+            }
+            return if (scope == this.scope) {
+                RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Found, captured)
+            } else {
+                RemoteConfigSnapshotLoadResult(RemoteConfigSnapshotLoadStatus.Missing)
+            }
+        }
+
+        override fun save(scope: RemoteConfigSnapshotScope, state: RemoteConfigSnapshotState): Boolean {
+            check(scope == this.scope)
+            saves.incrementAndGet()
+            synchronized(stateLock) { this.state = state }
+            return true
+        }
+
+        fun currentState(): RemoteConfigSnapshotState = synchronized(stateLock) { state }
+    }
+
+    private class ControlledPreloader : RemoteConfigReadPreloader {
+        private val completions = mutableListOf<(RemoteConfigReadPreloadResult) -> Unit>()
+        override fun preload(
+            scope: RemoteConfigSnapshotScope,
+            prepareImplicitActivation: Boolean,
+            completion: (RemoteConfigReadPreloadResult) -> Unit,
+        ) {
+            completions += completion
+        }
+
+        fun complete(index: Int, result: RemoteConfigReadPreloadResult) {
+            completions[index](result)
+        }
+    }
+
+    private class RecordingTelemetry : RemoteConfigReadTelemetry {
+        val events = Collections.synchronizedList(mutableListOf<RemoteConfigReadGuardEvent>())
+        override fun report(event: RemoteConfigReadGuardEvent) {
+            events += event
+        }
+    }
+}

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCoreTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/remoteconfig/RemoteConfigSnapshotCoreTest.kt
@@ -381,6 +381,36 @@ internal class RemoteConfigSnapshotCoreTest {
     }
 
     @Test
+    fun `delivery enqueued at the empty handoff is never stranded`() {
+        val raceStore = RecordingSnapshotStore()
+        val injectAtEmpty = AtomicBoolean(true)
+        lateinit var raceCore: RemoteConfigSnapshotCore
+        raceCore = RemoteConfigSnapshotCore(
+            raceStore,
+            bundled,
+            deliveryQueueObservedEmpty = {
+                if (injectAtEmpty.compareAndSet(true, false)) {
+                    raceCore.acceptCandidate(
+                        scopeA,
+                        release("two", 2, mapOf("a" to "2"), immediateKey = "a"),
+                    )
+                }
+            },
+        )
+        val observed = mutableListOf<String>()
+        raceCore.setScope(scopeA)
+        raceCore.addUpdateObserver { update -> observed += update.snapshot.releaseUid }
+
+        raceCore.acceptCandidate(
+            scopeA,
+            release("one", 1, mapOf("a" to "1"), immediateKey = "a"),
+        )
+
+        assertEquals(listOf("one", "two"), observed)
+        assertEquals("two", raceCore.currentSnapshot().releaseUid)
+    }
+
+    @Test
     fun `wire admission rejects one malformed item without any partial durable candidate`() {
         core.setScope(scopeA)
         val malformed = wireBody(

--- a/sdk/src/test/java/com/qonversion/android/sdk/internal/storage/PersistentRemoteConfigSnapshotStoreTest.kt
+++ b/sdk/src/test/java/com/qonversion/android/sdk/internal/storage/PersistentRemoteConfigSnapshotStoreTest.kt
@@ -109,7 +109,9 @@ internal class PersistentRemoteConfigSnapshotStoreTest {
                 "{\"version\":1,\"storageKeys\":[\"$storageKey\"]}",
             )
 
-            assertNull(store().loadState(userA))
+            val result = store().load(userA)
+            assertEquals(RemoteConfigSnapshotLoadStatus.Corrupt, result.status)
+            assertNull(result.state)
 
             assertNull(cache.getString(storageKey, null))
             assertEquals("legacy-must-survive", cache.getString(LEGACY_LKG_KEY, null))
@@ -587,6 +589,25 @@ internal class PersistentRemoteConfigSnapshotStoreTest {
         assertNull(cache.getString(REMOTE_CONFIG_SNAPSHOT_INDEX_KEY, null))
         assertEquals(legacyIndex, cache.getString(LEGACY_LKG_KEY, null))
         assertEquals("legacy-payload", cache.getString(legacyPayloadKey, null))
+    }
+
+    @Test
+    fun `malformed and oversized v1 lookalikes are corrupt rather than legacy missing`() {
+        val storageKey = remoteConfigSnapshotStorageKey(userA)
+        val malformedState = persistedSnapshotEnvelopeV1().replace(
+            "\"didActivate\":false",
+            "\"didActivate\":\"false\"",
+        )
+        cache.putString(storageKey, malformedState)
+        assertEquals(RemoteConfigSnapshotLoadStatus.Corrupt, store().load(userA).status)
+
+        cache.putString(storageKey, persistedSnapshotEnvelopeV1())
+        val bounded = PersistentRemoteConfigSnapshotStore(
+            cache = cache,
+            moshi = moshi,
+            maxStateBytes = 128,
+        )
+        assertEquals(RemoteConfigSnapshotLoadStatus.Corrupt, bounded.load(userA).status)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preload the exact identity-scoped snapshot off the read path and prepare a crash-safe first activation before SDK readiness
- assert actionable misuse in debug; in release, allow one SDK-lifetime implicit activation on the first read, then require explicit activation
- keep `current` synchronous and free of storage calls, preserve immutable held snapshots, and deliver updates outside SDK locks
- distinguish missing, corrupt, failed, and persistence-failed preload state and harden bounded legacy-v1 validation

## Concurrency guardrails

Tests pin stale A→B→A and same-generation preload races, token binding, concurrent first reads, persistence recovery, observer reentrancy/lost wakeups, lifetime behavior across identities, and post-preload fetch admission. Stale work cannot overwrite a newer durable candidate or consume the lifetime activation opportunity.

## Verification

- `./gradlew :sdk:test detektAll :sdk:assemble --no-daemon` — BUILD SUCCESSFUL
- 82 focused Remote Config tests, including 22 read-guard adversarial tests
- independent multi-pass review — CLEAN
- `git diff --check`

## Boundary

This is an internal lifecycle foundation stacked on #862. It does not add a public Remote Config API, URL, or production enablement.